### PR TITLE
add 'jars` and `midletClassName` URL params

### DIFF
--- a/midp.js
+++ b/midp.js
@@ -10,7 +10,7 @@ var MIDP = {
     suites: [
         null,
         {
-            midletClassName: "HelloCommandMIDlet",
+            midletClassName: urlParams["midletClassName"] || "HelloCommandMIDlet",
         }
     ]
 };


### PR DESCRIPTION
This change adds a URL query parameter parser and support for two params:
- `jars`: a colon-delimited list of JARs to load (in addition to classes.jar and tests.jar);
- `midletClassName`: the name of a MIDlet class to launch (default: _HelloCommandMIDlet_).

With this change, you can start a MIDlet in j2me.js with a URL like:

```
http://localhost/path/to/j2me.js/?jars=MyMIDlet.jar&midletClassName=com.example.mymidlet
```
