### PR TITLE
add stub DisplayStateListener class

### DIFF
--- a/java/midp/com/nokia/mid/ui/lcdui/DisplayStateListener.java
+++ b/java/midp/com/nokia/mid/ui/lcdui/DisplayStateListener.java
@@ -1,0 +1,6 @@
+package com.nokia.mid.ui.lcdui;
+
+public class DisplayStateListener
+{
+
+}


### PR DESCRIPTION
This is a stub for the com.nokia.mid.ui.lcdui.DisplayStateListener class, which some MIDlets import.
