### PR TITLE
Add microedition.platform property

### DIFF
--- a/native.js
+++ b/native.js
@@ -70,6 +70,9 @@ Native["java/lang/System.getProperty0.(Ljava/lang/String;)Ljava/lang/String;"] =
     case "microedition.locale":
         value = navigator.language;
         break;
+    case "microedition.platform":
+        value = "NOKIA503/JAVA_RUNTIME_VERSION=NOKIA_ASHA_1_2";
+        break;
     default:
         console.log("UNKNOWN PROPERTY (java/lang/System): " + util.fromJavaString(key));
         value = null;


### PR DESCRIPTION
Add the microedition.platform property, using NOKIA503/JAVA_RUNTIME_VERSION=NOKIA_ASHA_1_2 because it supports some of the features we want to emulate.
