### PR TITLE
make ClassNotFoundException a subclass of Error

### DIFF
--- a/classes.js
+++ b/classes.js
@@ -16,7 +16,7 @@ var Classes = function() {
 Classes.ClassNotFoundException = function(message) {
     this.message = message;
 };
-Classes.ClassNotFoundException.prototype = new Error();
+Classes.ClassNotFoundException.prototype = Object.create(Error.prototype);
 Classes.ClassNotFoundException.prototype.name = "ClassNotFoundException";
 Classes.ClassNotFoundException.prototype.constructor = Classes.ClassNotFoundException;
 


### PR DESCRIPTION
This way Classes.prototype.loadClassFile will throw something like "Uncaught ClassNotFoundException: com/nokia/mid/ui/frameanimator/FrameAnimator.class" instead of the vague "Uncaught [object Object]".
