### PR TITLE
Kill Python SimpleHTTPServer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 test: java/tests.jar java/classes.jar
-	pkill -f SimpleHTTPServer
+	pkill -f SimpleHTTPServer || true
 	python -m SimpleHTTPServer &
 	casperjs --verbose --log-level=debug --engine=slimerjs test `pwd`/tests/automation.js
-	pkill -f SimpleHTTPServer
+	pkill -f SimpleHTTPServer || true
 
 java/tests.jar: java/classes.jar
 	cd tests && make


### PR DESCRIPTION
On Mac |killall python| doesn't work correctly because killall is case-sensitive and the process on Mac is called "Python".
