### PR TITLE
throw error if method ref to resolve not declared in class

### DIFF
--- a/vm.js
+++ b/vm.js
@@ -135,7 +135,8 @@ VM.execute = function(ctx) {
             var signature = cp[cp[constant.name_and_type_index].signature_index].bytes;
             constant = CLASSES.getMethod(classInfo, methodName, signature, op === 0xb8, op !== 0xb8);
             if (!constant) {
-                throw new Error(classInfo.className + "." + methodName + "." + signature + " not declared in class");
+                ctx.raiseException("java/lang/RuntimeException",
+                                   classInfo.className + "." + methodName + "." + signature + " not found");
             }
             break;
         default:


### PR DESCRIPTION
VM.execute currently throws the vague error:

```
TypeError: methodInfo is undefined vm.js:996
```

Or, in Chrome:

```
Uncaught TypeError: Cannot read property 'signature' of undefined vm.js:996
```

This turns out to be because the FrameAnimator.java stub doesn't declare the `register` method, which a MIDlet I'm testing is calling. Here's a change that throws this better error message, so a problem like this is easier to debug:

```
Error: com/nokia/mid/ui/frameanimator/FrameAnimator.register.(IISSLcom/nokia/mid/ui/frameanimator/FrameAnimatorListener;)Z not declared in class vm.js:138
```

Presumably this failure should actually raise some Java exception, though.
