### PR TITLE
use the 'new' operator on *Array constructor for Chrome compat

### DIFF
--- a/classes.js
+++ b/classes.js
@@ -210,7 +210,7 @@ Classes.prototype.newPrimitiveArray = function(type, size) {
 }
 
 Classes.prototype.newArray = function(typeName, size) {
-    return this.getClass(typeName).constructor.call(null, size);
+    return new (this.getClass(typeName).constructor)(size);
 }
 
 Classes.prototype.newMultiArray = function(typeName, lengths) {


### PR DESCRIPTION
Using `Function.call` in `Classes.prototype.newArray` causes Chrome to throw `TypeError: Constructor Int8Array requires 'new'` here because the function in question is the Int8Array constructor. Presumably the other *Array constructors in arrays.js will have the same problem.

It isn't clear why `Function.call` is being used here, but it shouldn't be necessary, and this change makes the call work on both Firefox and Chrome. (Note that `Classes.prototype.newPrimitiveArray`, declared right above this function, uses `new`.)
