### PR TITLE
add a test for the "method not found" exception

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,4 +1,9 @@
-SRCS=$(shell find . -name "*.java")
+SRCS=$(shell find . -not -path "./support/*" -name "*.java")
+
+BUILDTIME_SUPPORT_DIR=support/buildtime
+RUNTIME_SUPPORT_DIR=support/runtime
+BUILDTIME_SUPPORT_SRCS=$(shell find $(BUILDTIME_SUPPORT_DIR) -name "*.java")
+RUNTIME_SUPPORT_SRCS=$(shell find $(RUNTIME_SUPPORT_DIR) -name "*.java")
 
 all: tests.jar
 
@@ -15,7 +20,10 @@ Testlets.java: $(SRCS) Makefile
 tests.jar: $(SRCS) Testlets.java
 	rm -rf build
 	mkdir build
-	javac -source 1.3 -target 1.3 -encoding UTF-8 -bootclasspath ../java/classes.jar -d ./build $^
+	# Build the buildtime support classes in-place, not in ./build, so they aren't available at runtime.
+	javac -source 1.3 -target 1.3 -encoding UTF-8 -bootclasspath ../java/classes.jar $(BUILDTIME_SUPPORT_SRCS)
+	javac -source 1.3 -target 1.3 -encoding UTF-8 -bootclasspath ../java/classes.jar:$(BUILDTIME_SUPPORT_DIR) -d ./build $^
+	javac -source 1.3 -target 1.3 -encoding UTF-8 -bootclasspath ../java/classes.jar -d ./build $(RUNTIME_SUPPORT_SRCS)
 	cd build && jar cvfe ../tests.jar RunTests *
 	jar uvf tests.jar gnu/testlet/vm/test.png midlets/test.png
 	rm -rf build

--- a/tests/gnu/testlet/vm/MethodNotFoundException.java
+++ b/tests/gnu/testlet/vm/MethodNotFoundException.java
@@ -1,0 +1,23 @@
+package gnu.testlet.vm;
+
+import gnu.testlet.*;
+
+public class MethodNotFoundException implements Testlet {
+    void throw1(TestHarness th) {
+        boolean caught = false;
+        try {
+          org.mozilla.test.ClassWithMissingMethod.missingMethod();
+        } catch (Exception e) {
+            // Despite the test's name, the VM raises a generic RuntimeException
+            // because CLDC doesn't provide a MethodNotFoundException class.
+            th.check(e instanceof RuntimeException);
+            th.check(e.getMessage(), "org/mozilla/test/ClassWithMissingMethod.missingMethod.()V not found");
+            caught = true;
+        }
+        th.check(caught);
+    }
+
+    public void test(TestHarness th) {
+        throw1(th);
+    }
+}

--- a/tests/support/README.md
+++ b/tests/support/README.md
@@ -1,0 +1,11 @@
+The *buildtime/* and *runtime/* subdirectories of this directory support tests
+that need to be built with a different set of classes than the ones they access
+at runtime.
+
+For example, the `gnu.testlet.vm.MethodNotFoundException` test calls
+`org.mozilla.test.ClassWithMissingMethod.missingMethod()`, which needs to exist
+at buildtime to successfully compile the class, but which shouldn't exist
+at runtime in order to test that an exception is correctly raised.
+
+Put the buildtime implementations of any such classes into the *buildtime/*
+subdirectory and the runtime implementations into *runtime/*.

--- a/tests/support/buildtime/org/mozilla/test/ClassWithMissingMethod.java
+++ b/tests/support/buildtime/org/mozilla/test/ClassWithMissingMethod.java
@@ -1,0 +1,6 @@
+package org.mozilla.test;
+
+public class ClassWithMissingMethod {
+    // Define the method at buildtime so the test class will compile.
+    public static void missingMethod() {}
+}

--- a/tests/support/runtime/org/mozilla/test/ClassWithMissingMethod.java
+++ b/tests/support/runtime/org/mozilla/test/ClassWithMissingMethod.java
@@ -1,0 +1,4 @@
+package org.mozilla.test;
+
+public class ClassWithMissingMethod {
+}


### PR DESCRIPTION
Here's a test for the "method not found" exception. I had to add steps to build against a different set of classes than the test accesses at runtime, since the method needs to be found at buildtime in order for compilation to succeed. We should be able to reuse that to test other such VM behavior too.
