### PR TITLE
verify VM raises RuntimeException on missing field

### DIFF
--- a/tests/automation.js
+++ b/tests/automation.js
@@ -9,7 +9,7 @@ casper.test.begin("unit tests", 1, function(test) {
     casper
     .start("http://localhost:8000/index.html?main=RunTests")
     .waitForText("DONE", function then() {
-        test.assertTextExists("DONE: 705 pass, 0 fail", "run unit tests");
+        test.assertTextExists("DONE: 708 pass, 0 fail", "run unit tests");
     })
     .run(function() {
         test.done();

--- a/tests/gnu/testlet/vm/FieldNotFoundException.java
+++ b/tests/gnu/testlet/vm/FieldNotFoundException.java
@@ -1,0 +1,23 @@
+package gnu.testlet.vm;
+
+import gnu.testlet.*;
+
+public class FieldNotFoundException implements Testlet {
+    void throw1(TestHarness th) {
+        boolean caught = false;
+        try {
+          boolean missingField = org.mozilla.test.ClassWithMissingField.missingField;
+        } catch (Exception e) {
+            // Despite the test's name, the VM raises a generic RuntimeException
+            // because CLDC doesn't provide a FieldNotFoundException class.
+            th.check(e instanceof RuntimeException);
+            th.check(e.getMessage(), "org/mozilla/test/ClassWithMissingField.missingField.Z not found");
+            caught = true;
+        }
+        th.check(caught);
+    }
+
+    public void test(TestHarness th) {
+        throw1(th);
+    }
+}

--- a/tests/support/buildtime/org/mozilla/test/ClassWithMissingField.java
+++ b/tests/support/buildtime/org/mozilla/test/ClassWithMissingField.java
@@ -1,0 +1,6 @@
+package org.mozilla.test;
+
+public class ClassWithMissingField {
+    // Define the field at buildtime so the test class will compile.
+    public static boolean missingField = true;
+}

--- a/tests/support/runtime/org/mozilla/test/ClassWithMissingField.java
+++ b/tests/support/runtime/org/mozilla/test/ClassWithMissingField.java
@@ -1,0 +1,4 @@
+package org.mozilla.test;
+
+public class ClassWithMissingField {
+}


### PR DESCRIPTION
Here's a test that verifies that the VM raises a RuntimeException on a missing field.
