### PR TITLE
set status to STARTED after invoking isolate's main class

### DIFF
--- a/java/midp/com/sun/cldc/isolate/Isolate.java
+++ b/java/midp/com/sun/cldc/isolate/Isolate.java
@@ -896,7 +896,7 @@ public final class Isolate {
                 // waitStatus() performs the getStatus() <= STOPPING check in
                 // native code again, where thread switch is guaranteed to
                 // not happen. Hence we won't have a race condition.
-                waitStatus(STOPPING);
+                waitStatus(STOPPED);
             } catch (InterruptedException e) {
                 // IMPL_NOTE: this method should throw InterruptedException!
                 throw new Error();

--- a/native.js
+++ b/native.js
@@ -558,10 +558,10 @@ Native["com/sun/cldc/isolate/Isolate.nativeStart.()V"] = function(ctx, stack) {
 Native["com/sun/cldc/isolate/Isolate.waitStatus.(I)V"] = function(ctx, stack) {
     var status = stack.pop(), _this = stack.pop();
     var runtime = _this.runtime;
-    if (runtime.status > status)
+    if (runtime.status >= status)
         return;
     function waitForStatus() {
-        if (runtime.status > status) {
+        if (runtime.status >= status) {
             ctx.resume();
             return;
         }


### PR DESCRIPTION
This sets status = STARTED after nativeStart invokes the isolate's main class.

That means the status will be STARTED when the test calls waitForExit, so I had to fix a bug in waitForExit, which was relying on waitStatus to wait until the status is >= STOPPED (i.e. the behavior implemented by the native implementation, which is different from the behavior described in the Java class).

Also, calling updateStatus to update the status to STARTED may call a callback that re-calls Runtime.prototype.waitStatus, which then throws VM.Pause, which we don't want to happen in nativeStart. So I trap and discard the exception.

(Although it seems to me like it would be better to throw VM.Pause only in the initial call to the waitStatus native, which is what my earlier implementation did, rather than every time the callback is called.)
