### PR TITLE
Set the |trusted| field when loading InstallInfo. This allows MIDlets to...

### DIFF
--- a/midp/midp.js
+++ b/midp/midp.js
@@ -868,6 +868,8 @@ Native["com/sun/midp/midletsuite/SuiteSettings.save0.(IBI[B)V"] = function(ctx, 
 
 Native["com/sun/midp/midletsuite/InstallInfo.load.()V"] = function(ctx, stack) {
     var _this = stack.pop();
+    // The MIDlet has to be trusted for opening SSL connections using port 443.
+    _this.class.getField("trusted", "Z").set(_this, 1);
 }
 
 Native["com/sun/midp/midletsuite/SuiteProperties.load.()[Ljava/lang/String;"] = function(ctx, stack) {


### PR DESCRIPTION
... open SSL connections using port 443.
