### PR TITLE
set globalCompositeOperation to "copy" and ensure string fillStyle is opaque

### DIFF
--- a/midp/gfx.js
+++ b/midp/gfx.js
@@ -371,8 +371,8 @@
     function withOpaquePixel(g, c, cb) {
         var pixel = g.class.getField("pixel", "I").get(g);
         c.save();
-        var b = (pixel >>> 16) & 0xff;
-        var g = (pixel >>> 8) & 0xff;
+        var b = (pixel >> 16) & 0xff;
+        var g = (pixel >> 8) & 0xff;
         var r = pixel & 0xff;
         var style = "rgba(" + r + "," + g + "," + b + "," + 1 + ")";
         c.fillStyle = c.strokeStyle = style;


### PR DESCRIPTION
Here's a partial fix for #86. It sets globalCompositeOperation to "copy" and ensures the string fillStyle is opaque (by setting its alpha to 1). There's more to do: string backgrounds are off (they overlap other strings, they look garish, so are clearly the wrong color). And we should really figure out why some midlets pass ARGB values whose alpha values are only ever 0 or -1.

I also noticed that we're switching the R and B values in DirectGraphicsImp.setARGBColor via swapRB, which doesn't seem to cause a problem (perhaps because Graphics.pixel is private) but also isn't necessary and might theoretically cause a problem if other code tries to access that value. We're doing the same in Graphics.getPixel, which again might theoretically cause a problem, although it doesn't seem to do so currently.
