### PR TITLE
Set com.nokia.keyboard.type to None

### DIFF
--- a/native.js
+++ b/native.js
@@ -94,7 +94,7 @@ Native["java/lang/System.getProperty0.(Ljava/lang/String;)Ljava/lang/String;"] =
         value = "GMT";
         break;
     case "com.nokia.keyboard.type":
-        value = "FullKeyboard";
+        value = "None";
         break;
     case "javax.microedition.io.Connector.protocolpath":
         value = "com.sun.cldc.io";


### PR DESCRIPTION
I think values like "FullKeyboard" are for mobile phones with an external keyboard, "None" is for on-screen keyboards. I'm not entirely sure though, as the documentation is a bit lacking.
This fixes rendering with some apps.
