### PR TITLE
clean up after RecordStore tests

### DIFF
--- a/tests/com/sun/midp/rms/TestRecordStoreFileNatives.java
+++ b/tests/com/sun/midp/rms/TestRecordStoreFileNatives.java
@@ -4,6 +4,8 @@ import com.sun.j2me.security.AccessControlContext;
 import com.sun.j2me.security.AccessController;
 import gnu.testlet.TestHarness;
 import gnu.testlet.Testlet;
+import javax.microedition.io.Connector;
+import javax.microedition.io.file.FileConnection;
 import javax.microedition.rms.RecordStoreException;
 
 public class TestRecordStoreFileNatives implements Testlet, SuiteContainer, AccessControlContext {
@@ -95,6 +97,19 @@ public class TestRecordStoreFileNatives implements Testlet, SuiteContainer, Acce
                 RecordStoreUtil.deleteFile(filenameBase, name, extension);
             } catch(RecordStoreException ex) {
                 th.fail("record store file could not be deleted: " + ex);
+            }
+            try {
+                final String RECORD_STORE_BASE_URL = "file:///RecordStore";
+
+                FileConnection dir = (FileConnection)Connector.open(RECORD_STORE_BASE_URL + "/" + filenameBase);
+                dir.delete();
+                dir.close();
+
+                dir = (FileConnection)Connector.open(RECORD_STORE_BASE_URL);
+                dir.delete();
+                dir.close();
+            } catch(java.io.IOException ex) {
+                th.fail("record store dirs could not be deleted: " + ex);
             }
         } catch(java.io.IOException ex) {
             // We catch all expected exceptions, so any unexpected ones


### PR DESCRIPTION
This cleans up the directories and file created by the RecordStore tests, so subsequent test runs start from scratch, and other tests aren't affected by the changes to the filesystem state.

@marco-c can you review?
