### PR TITLE
Use com.sun.cldc.io as fallback instead of com.sun.midp.io because most ...

### DIFF
--- a/native.js
+++ b/native.js
@@ -97,10 +97,10 @@ Native["java/lang/System.getProperty0.(Ljava/lang/String;)Ljava/lang/String;"] =
         value = "None";
         break;
     case "javax.microedition.io.Connector.protocolpath":
-        value = "com.sun.cldc.io";
+        value = "com.sun.midp.io";
         break;
     case "javax.microedition.io.Connector.protocolpath.fallback":
-        value = "com.sun.midp.io";
+        value = "com.sun.cldc.io";
         break;
     case "com.nokia.multisim.slots":
         value = "1";


### PR DESCRIPTION
...of our protocols are in com.sun.midp.io

Sometimes it's useful to print all the exceptions, even caught ones, for debugging purposes. This greatly reduces the number of "useless" exceptions, making the logs more readable.
