### PR TITLE
Add com.nokia.mid.ui.customfontsize property

### DIFF
--- a/native.js
+++ b/native.js
@@ -128,6 +128,10 @@ Native["java/lang/System.getProperty0.(Ljava/lang/String;)Ljava/lang/String;"] =
         console.warn("Property 'com.nokia.mid.mnc' is a stub");
         value = mobileInfo.mnc;
         break;
+    case "com.nokia.mid.ui.customfontsize":
+        console.warn("Property 'com.nokia.mid.ui.customfontsize' is a stub");
+        value = "false";
+        break;
     case "classpathext":
         value = null;
         break;


### PR DESCRIPTION
I'm returning false so that we don't need to implement DirectUtils.getFont (see http://developer.nokia.com/resources/library/Java/developers-guides/system-properties/nokia-specific-system-properties.html)
