### PR TITLE
implement Protocol's shutdownOutput0, notifyClosedInput0, and notifyClosedOutput0 natives

### DIFF
--- a/midp/socket.js
+++ b/midp/socket.js
@@ -171,33 +171,14 @@ Native["com/sun/midp/io/j2me/socket/Protocol.notifyClosedInput0.()V"] = function
     var _this = stack.pop();
 
     if (_this.waitingData) {
-        _this.waitingData();
+        console.warn("Protocol.notifyClosedInput0.()V unimplemented while thread is blocked on read0");
     }
 }
 
 Native["com/sun/midp/io/j2me/socket/Protocol.notifyClosedOutput0.()V"] = function(ctx, stack) {
     var _this = stack.pop();
 
-    // If there's no thread to resume, then simply return early.
-    if (!_this.socket.ondrain) {
-        return;
+    if (_this.socket.ondrain) {
+        console.warn("Protocol.notifyClosedOutput0.()V unimplemented while thread is blocked on write0");
     }
-
-    // If there's buffered output, ensure it gets written to the stream first.
-    if (_this.socket.bufferedAmount > 0) {
-        // We should flush the output stream, but mozTCPSocket doesn't support
-        // that, so the best we can do is wait for the buffer to drain.
-        var originalHandler = _this.socket.ondrain;
-        _this.socket.ondrain = function() {
-            _this.socket.ondrain = originalHandler;
-            originalHandler();
-            ctx.resume();
-        };
-        throw VM.Pause;
-    }
-
-    // Resume the thread immediately.  In theory, this should never happen,
-    // as the thread should have resumed when the buffer last drained; but we
-    // call it here just in case.
-    _this.socket.ondrain();
 }


### PR DESCRIPTION
This implements the _Protocol.shutdownOutput0_, _Protocol.notifyClosedInput0_, and _Protocol.notifyClosedOutput0_ natives. But I'm not totally sure about these implementations.

For one thing, we don't actually have any control over the TCP socket's input and output streams, so we can't actually do what the original shutdownOutput0 does (flush and close the output stream). And it isn't completely clear that merely resuming the read/write threads is the right behavior.

On the other hand, based on the call sites for shutdownOutput0, I think we're ok doing nothing in that function. And my reading of the reference impls for notifyClosedInput0 and notifyClosedOutput0 suggest that they simply resume the threads. So I think these are reasonable.

But I'd love to get a second opinion, @marco-c!
