### PR TITLE
Warn instead of throwing an exception in LCDUIUtil::setObjectTrait

### DIFF
--- a/java/custom/com/nokia/mid/ui/LCDUIUtil.java
+++ b/java/custom/com/nokia/mid/ui/LCDUIUtil.java
@@ -2,7 +2,8 @@ package com.nokia.mid.ui;
 
 public class LCDUIUtil {
     public static boolean setObjectTrait(Object object1, String trait, Object object2) {
-        throw new RuntimeException("LCDUIUtil::setObjectTrait(Object,String,Object) not implemented");
+        System.out.println("LCDUIUtil::setObjectTrait(Object,String,Object) not implemented");
+        return true;
     }
 
     public static Object getObjectTrait(Object object, String trait) {


### PR DESCRIPTION
This is needed to make RLinks work.
