### PR TITLE
implement TextEditor::setFocus

### DIFF
--- a/java/custom/com/nokia/mid/ui/TextEditor.java
+++ b/java/custom/com/nokia/mid/ui/TextEditor.java
@@ -39,7 +39,6 @@ public class TextEditor extends CanvasItem {
     private boolean multiline = true;
     private boolean visible = true;
     private Object parent = null;
-    private boolean focus = false;
     private int maxSize = 0;
     private int width = 0;
     private int height = 0;
@@ -76,15 +75,10 @@ public class TextEditor extends CanvasItem {
     }
 
     // Sets this TextEditor focused or removes keyboard focus.
-    public void setFocus(boolean focused) {
-        focus = focused;
-        System.out.println("warning: TextEditor::setFocus(boolean) not implemented (" + focused + ")");
-    }
+    native public void setFocus(boolean focused);
 
     // Returns the focus state of TextEditor.
-    public boolean hasFocus() {
-        return focus;
-    }
+    native public boolean hasFocus();
 
     // Set the parent object of this TextEditor.
     public void setParent(Object theParent) {

--- a/midp/gfx.js
+++ b/midp/gfx.js
@@ -653,6 +653,7 @@
         _this.textEditorId = textEditorId;
         _this.textEditor = document.createElement("textarea");
         _this.visible = false;
+        _this.focused = false;
         _this.textEditor.style.border = "none";
         _this.textEditor.style.resize = "none";
         _this.textEditor.style.backgroundColor = "transparent";
@@ -681,11 +682,25 @@
         var visible = stack.pop(), _this = stack.pop();
         if (visible) {
             document.body.appendChild(_this.textEditor);
-            _this.textEditor.focus();
         } else if (_this.visible) {
             document.body.removeChild(_this.textEditor);
         }
         _this.visible = visible;
+    }
+
+    Native["com/nokia/mid/ui/TextEditor.setFocus.(Z)V"] = function(ctx, stack) {
+        var focused = stack.pop(), _this = stack.pop();
+        if (focused) {
+            _this.textEditor.focus();
+        } else {
+            _this.textEditor.blur();
+        }
+        _this.focused = focused;
+    }
+
+    Native["com/nokia/mid/ui/TextEditor.hasFocus.()Z"] = function(ctx, stack) {
+        var _this = stack.pop();
+        stack.push(_this.focused);
     }
 
     Native["com/nokia/mid/ui/TextEditor.getContent0.()Ljava/lang/String;"] = function(ctx, stack) {


### PR DESCRIPTION
This implements TextEditor::setFocus per [the TextEditor docs](http://developer.nokia.com/resources/library/Java/_zip/GUID-237420DE-CCBE-4A74-A129-572E0708D428/com/nokia/mid/ui/TextEditor.html).
