### PR TITLE
Don't warn in getDisplayName0

### DIFF
--- a/midp/gfx.js
+++ b/midp/gfx.js
@@ -13,7 +13,6 @@
     Native["com/sun/midp/lcdui/DisplayDevice.getDisplayName0.(I)Ljava/lang/String;"] = function(ctx, stack) {
         var id = stack.pop(), _this = stack.pop();
         stack.push(null);
-        console.warn("DisplayDevice.getDisplayName0.(I)L...String; not implemented (" + id + ")");
     }
 
     Native["com/sun/midp/lcdui/DisplayDevice.isDisplayPrimary0.(I)Z"] = function(ctx, stack) {


### PR DESCRIPTION
There's no need to warn here, because getDisplayName0 is only used in DisplayDevice to set the displayName property. The displayName property is only used in DisplayDevice::getDisplayDeviceName, that doesn't have any caller.
