### PR TITLE
Don't copy the typed array data if unnecessary

### DIFF
--- a/midp/gfx.js
+++ b/midp/gfx.js
@@ -153,7 +153,7 @@
 
     Native["javax/microedition/lcdui/ImageDataFactory.createImmutableImageDecodeImage.(Ljavax/microedition/lcdui/ImageData;[BII)V"] = function(ctx, stack) {
         var length = stack.pop(), offset = stack.pop(), bytes = stack.pop(), imageData = stack.pop(), _this = stack.pop();
-        var blob = new Blob([bytes.buffer.slice(offset, offset + length)], { type: "image/png" });
+        var blob = new Blob([bytes.subarray(offset, offset + length)], { type: "image/png" });
         var img = new Image();
         img.src = URL.createObjectURL(blob);
         img.onload = function() {

--- a/midp/midp.js
+++ b/midp/midp.js
@@ -470,14 +470,13 @@ Native["com/sun/midp/chameleon/skins/resources/LoadedSkinData.readStringArray.()
         var strEnc = MIDP.skinFileData.getUint8(MIDP.skinFilePos++);
         if ((MIDP.skinFilePos + strLen) > MIDP.skinFileData.byteLength)
             ctx.raiseExceptionAndYield("java/lang/IllegalStateException");
-        var bytes = MIDP.skinFileData.buffer.slice(MIDP.skinFilePos, MIDP.skinFilePos + strLen);
+        var bytes = new Uint8Array(MIDP.skinFileData.buffer).subarray(MIDP.skinFilePos, MIDP.skinFilePos + strLen);
         MIDP.skinFilePos += strLen;
         var str;
         if (strEnc === MIDP.STRING_ENCODING_USASCII) {
-            var data = new Uint8Array(bytes);
             str = "";
             for (var i = 0; i < strLen; ++i)
-                str += String.fromCharCode(data[i]);
+                str += String.fromCharCode(bytes[i]);
         } else if (strEnc === MIDP.STRING_ENCODING_UTF8) {
             str = util.decodeUtf8(bytes);
         } else {


### PR DESCRIPTION
The slice method copies the ArrayBuffer data in a new array.
