### PR TITLE
handle invalid image data

### DIFF
--- a/midp/gfx.js
+++ b/midp/gfx.js
@@ -161,6 +161,7 @@
             ctx.resume();
         }
         img.onerror = function(e) {
+            ctx.raiseException("java/lang/IllegalArgumentException", "error decoding image");
             ctx.resume();
         }
         throw VM.Pause;


### PR DESCRIPTION
At some point, a midlet I'm testing calls the _Image.createImage_ constructor variant that takes an _InputStream_, but it passes it a stream that returns only a single byte. That causes _ImageDataFactory.createImmutableImageDecodeImage_ to fail silently, which then causes _Graphics.render_ to throw a JavaScript exception.

_ImageDataFactory.getImageDataFromStream_ expects _createImmutableImageDecodeImage_ to raise _IllegalArgumentException_ if "data cannot be not decoded," so this branch makes it do that. It also makes _Graphics.render_ check that there's native image data before trying to access it and warn if there isn't (instead of throwing a JavaScript error, to avoid halting the VM thread just because an image couldn't render).

And it stores native image data in a JS property rather than the Java _nativeImageData_ field, which happens to work but shouldn't be counted on, given that it's supposed to be an integer!

@marco-c This unblocks me from working on other things, like TextEditor, and may unblock you and others as well.
