### PR TITLE
misc TextEditor changes

### DIFF
--- a/java/custom/com/nokia/mid/ui/TextEditor.java
+++ b/java/custom/com/nokia/mid/ui/TextEditor.java
@@ -37,7 +37,6 @@ public class TextEditor extends CanvasItem {
     private int backgroundColor = 0;
     private int foregroundColor = 0;
     private boolean multiline = true;
-    private boolean visible = true;
     private Object parent = null;
     private int maxSize = 0;
     private int width = 0;
@@ -45,17 +44,8 @@ public class TextEditor extends CanvasItem {
     private int myId;
     private static TextEditorThread textEditorThread;
 
-    native int TextEditor0();
-    native void setSize0(int width, int height);
-    native void setPosition0(int x, int y);
-    native void setVisible0(boolean visible);
-    native String getContent0();
-    native void setContent0(String str);
-    native void insert0(String str, int pos);
-    native int size0();
-
     protected TextEditor(String label, String text, int aMaxSize, int constraints, int width, int height) {
-        myId = TextEditor0();
+        myId = init();
         maxSize = aMaxSize;
         if (textEditorThread == null) {
             textEditorThread = new TextEditorThread();
@@ -63,6 +53,9 @@ public class TextEditor extends CanvasItem {
             t.start();
         }
     }
+
+    // Initialize the native representation.
+    native private int init();
 
     // Creates a new TextEditor object with the given initial contents, maximum size in characters, constraints and editor size in pixels.
     public static TextEditor createTextEditor(String text, int maxSize, int constraints, int width, int height) {
@@ -95,25 +88,16 @@ public class TextEditor extends CanvasItem {
     }
 
     // Sets the size of this TextEditor in pixels.
-    public void setSize(int width, int height) {
-        setSize0(width, height);
-    }
+    native public void setSize(int width, int height);
 
     // Sets the rendering position of this TextEditor.
-    public void setPosition(int x, int y) {
-        setPosition0(x, y);
-    }
+    native public void setPosition(int x, int y);
 
     // Sets the visibility value of TextEditor.
-    public void setVisible(boolean vis) {
-        setVisible0(vis);
-        visible = vis;
-    }
+    native public void setVisible(boolean vis);
 
     // Gets the visibility value of TextEditor.
-    public  boolean isVisible() {
-        return visible;
-    }
+    native public boolean isVisible();
 
     // Sets the Z-position, or the elevation, of the item.
     public void setZPosition(int z) {
@@ -203,19 +187,13 @@ public class TextEditor extends CanvasItem {
     }
 
     // Sets the content of the TextEditor as a string.
-    public void setContent(String content) {
-        setContent0(content);
-    }
+    native public void setContent(String content);
 
     // Gets the string content in the TextEditor.
-    public String getContent() {
-        return getContent0();
-    }
+    native public String getContent();
 
     // Inserts a string into the content of the TextEditor.
-    public void insert(String text, int position) {
-        insert0(text, position);
-    }
+    native public void insert(String text, int position);
 
     // Deletes characters from the TextEditor.
     native public void delete(int offset, int length);
@@ -234,9 +212,7 @@ public class TextEditor extends CanvasItem {
     }
 
     // Gets the number of characters that are currently stored in this TextEditor.
-    public int size() {
-        return size0();
-    }
+    native public int size();
 
     // Sets the input constraints of this TextEditor.
     public void setConstraints(int constraints) {

--- a/midp/gfx.js
+++ b/midp/gfx.js
@@ -662,7 +662,7 @@
         }
     }
 
-    Native["com/nokia/mid/ui/TextEditor.TextEditor0.()I"] = function(ctx, stack) {
+    Native["com/nokia/mid/ui/TextEditor.init.()I"] = function(ctx, stack) {
         var _this = stack.pop();
         stack.push(++textEditorId);
         _this.textEditorId = textEditorId;
@@ -678,16 +678,16 @@
         }
     }
 
-    Native["com/nokia/mid/ui/TextEditor.setSize0.(II)V"] = function(ctx, stack) {
+    Native["com/nokia/mid/ui/TextEditor.setSize.(II)V"] = function(ctx, stack) {
         var height = stack.pop(), width = stack.pop(), _this = stack.pop();
     }
 
-    Native["com/nokia/mid/ui/TextEditor.setPosition0.(II)V"] = function(ctx, stack) {
+    Native["com/nokia/mid/ui/TextEditor.setPosition.(II)V"] = function(ctx, stack) {
         var y = stack.pop(), x = stack.pop(), _this = stack.pop();
-        console.log("TextEditor::setPosition0(int, int) not implemented", _this.textEditorId, x, y);
+        console.log("TextEditor::setPosition(int, int) not implemented", _this.textEditorId, x, y);
     }
 
-    Native["com/nokia/mid/ui/TextEditor.setVisible0.(Z)V"] = function(ctx, stack) {
+    Native["com/nokia/mid/ui/TextEditor.setVisible.(Z)V"] = function(ctx, stack) {
         var visible = stack.pop(), _this = stack.pop();
         if (visible) {
             document.body.appendChild(_this.textEditor);
@@ -695,6 +695,11 @@
             document.body.removeChild(_this.textEditor);
         }
         _this.visible = visible;
+    }
+
+    Native["com/nokia/mid/ui/TextEditor.isVisible.()Z"] = function(ctx, stack) {
+        var _this = stack.pop();
+        stack.push(_this.visible ? 1 : 0);
     }
 
     Native["com/nokia/mid/ui/TextEditor.setFocus.(Z)V"] = function(ctx, stack) {
@@ -712,17 +717,17 @@
         stack.push(_this.focused);
     }
 
-    Native["com/nokia/mid/ui/TextEditor.getContent0.()Ljava/lang/String;"] = function(ctx, stack) {
+    Native["com/nokia/mid/ui/TextEditor.getContent.()Ljava/lang/String;"] = function(ctx, stack) {
         var _this = stack.pop();
         stack.push(ctx.newString(_this.textEditor.value));
     }
 
-    Native["com/nokia/mid/ui/TextEditor.setContent0.(Ljava/lang/String;)V"] = function(ctx, stack) {
+    Native["com/nokia/mid/ui/TextEditor.setContent.(Ljava/lang/String;)V"] = function(ctx, stack) {
         var str = stack.pop(), _this = stack.pop();
         _this.textEditor.value = util.fromJavaString(str);
     }
 
-    Native["com/nokia/mid/ui/TextEditor.insert0.(Ljava/lang/String;I)V"] = function(ctx, stack) {
+    Native["com/nokia/mid/ui/TextEditor.insert.(Ljava/lang/String;I)V"] = function(ctx, stack) {
         var pos = stack.pop(), str = stack.pop(), _this = stack.pop(),
             old = _this.textEditor.value;
         _this.textEditor.value = old.slice(0, pos) + util.fromJavaString(str) + old.slice(pos);
@@ -739,7 +744,7 @@
         _this.textEditor.value = old.slice(0, offset) + old.slice(offset + length);
     }
 
-    Native["com/nokia/mid/ui/TextEditor.size0.()I"] = function(ctx, stack) {
+    Native["com/nokia/mid/ui/TextEditor.size.()I"] = function(ctx, stack) {
         var _this = stack.pop();
         stack.push(_this.textEditor.value.length);
     }


### PR DESCRIPTION
This makes three changes to TextEditor:
- implements _setParent_;
- implements _delete_;
- leaves the instance invisible until _setVisible_ is called, per the [TextEditor docs](http://developer.nokia.com/resources/library/Java/_zip/GUID-237420DE-CCBE-4A74-A129-572E0708D428/com/nokia/mid/ui/TextEditor.html), which don't say anything about _setParent_ triggering a change to visibility.

There's tons more to do to TextEditor, including adding tests. But these are valuable improvements for a midlet I'm testing, especially the _delete_ implementation, which is currently blocking important functionality in the midlet.
