### PR TITLE
Don't redirect stderr to tee

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,8 @@ test: all
 	rm -f test.log
 	killall python Python || true
 	python -m SimpleHTTPServer &
-	casperjs --no-colors --engine=slimerjs test `pwd`/tests/automation.js > test.log 2>&1
+	casperjs --engine=slimerjs test `pwd`/tests/automation.js | tee test.log
 	killall python Python || true
-	cat -v test.log
 	if grep -q FAIL test.log; \
 	then false; \
 	else true; \


### PR DESCRIPTION
Sometimes tee fails on travis. Using "strings" seems to work better (it doesn't colorize the output, but it's not an important feature).
