### PR TITLE
Update the RGB color and gray color when setting ARGB.

### DIFF
--- a/midp/gfx.js
+++ b/midp/gfx.js
@@ -419,7 +419,13 @@
     Native["com/nokia/mid/ui/DirectGraphicsImp.setARGBColor.(I)V"] = function(ctx, stack) {
         var rgba = stack.pop(), _this = stack.pop();
         var g = _this.class.getField("graphics", "Ljavax/microedition/lcdui/Graphics;").get(_this);
+        var red = (rgba >> 16) & 0xff;
+        var green = (rgba >> 8) & 0xff;
+        var blue = rgba & 0xff;
         g.class.getField("pixel", "I").set(g, swapRB(rgba));
+        g.class.getField("rgbColor", "I").set(g, rgba & 0x00ffffff);
+        // Conversion matches Graphics#grayVal(int, int, int).
+        g.class.getField("gray", "I").set(g, (red * 76 + green * 150 + blue * 29) >> 8);
     }
 
     Native["com/nokia/mid/ui/DirectGraphicsImp.getAlphaComponent.()I"] = function(ctx, stack) {

--- a/tests/gfx/ARGBColorTest.java
+++ b/tests/gfx/ARGBColorTest.java
@@ -33,6 +33,17 @@ public class ARGBColorTest extends MIDlet {
             }
             g.fillRect(40, 50, 160, 40);
 
+            // setARGBColor updates rgb color and gray color
+            int grayBefore = g.getGrayScale();
+            DirectUtils.getDirectGraphics(g).setARGBColor(0x00007700);
+            if (g.getColor() != 0x00007700) {
+                System.out.println("FAIL");
+            }
+            // Gray scale is computed, so only ensure it changed.
+            if (g.getGrayScale() == grayBefore) {
+                System.out.println("FAIL");
+            }
+
             System.out.println("PAINTED");
         }
     }


### PR DESCRIPTION
Fixes colors on the first two screens of a sample app.
