### PR TITLE
use "mobilenetwork" to access privileged subset of Mobile Connection API

### DIFF
--- a/libs/mobileinfo.js
+++ b/libs/mobileinfo.js
@@ -27,13 +27,17 @@ var mobileInfo = (function() {
   // If we have access to the Mobile Connection API, then we use it to get
   // the actual values.
   if (mobileConnections) {
-    var networkInfo = mobileConnections[0].voice.network;
+    // Then the only part of the Mobile Connection API that is accessible
+    // to privileged apps is lastKnownNetwork and lastKnownHomeNetwork, which
+    // is fortunately all we need.  lastKnownNetwork is a string of format
+    // "<mcc>-<mnc>", while lastKnownHomeNetwork is "<mcc>-<mnc>[-<spn>]".
+    var lastKnownNetwork = mobileConnections[0].lastKnownNetwork.split("-");
+    mobileInfo.network.mcc = lastKnownNetwork[0];
+    mobileInfo.network.mnc = lastKnownNetwork[1];
 
-    mobileInfo.network.mcc = networkInfo.mcc.toString();
-    mobileInfo.network.mnc = networkInfo.mnc.toString();
-
-    // XXX If we're a certified app, then get the ICC (i.e. SIM) values too
-    // from mobileConnections[0].iccInfo.
+    var lastKnownHomeNetwork = mobileConnections[0].lastKnownHomeNetwork.split("-");
+    mobileInfo.icc.mcc = lastKnownHomeNetwork[0];
+    mobileInfo.icc.mnc = lastKnownHomeNetwork[1];
   }
 
   return mobileInfo;

--- a/manifest.webapp
+++ b/manifest.webapp
@@ -18,6 +18,9 @@
     "contacts": {
       "description": "Required to manage contacts",
       "access": "readonly"
+    },
+    "mobilenetwork": {
+      "description:": "Required to verify your phone number"
     }
   },
   "type": "privileged"


### PR DESCRIPTION
The Mobile Connection API is confusing: in theory, _MozMobileNetworkInfo_ is available to privileged apps, but the only way to access it is through the _voice.network_ and _data.network_ properties and the _getNetworks()_ method of a _MozMobileConnection_ object, which are only available to certified apps.

But there are two properties of _MozMobileConnection_, _lastKnownNetwork_ and _lastKnownHomeNetwork_, which are not documented on MDN but are referenced in the [MozMobileConnection WebIDL file](http://mxr.mozilla.org/mozilla-central/source/dom/webidl/MozMobileConnection.webidl?rev=b5cecf9d2750#69), that provide the information our _mobileInfo_ module needs: the MCC and MNC for the network and ICC (SIM card).

Here's an update to _mobileInfo_ that uses those properties to get that info.
