### PR TITLE
profile calls to native/override functions

### DIFF
--- a/instrument.js
+++ b/instrument.js
@@ -101,6 +101,19 @@ var Instrument = {
 
     this.profiling = false;
   },
+
+  measure: function(Alt, ctx, methodInfo) {
+    if (this.profiling) {
+      var then = performance.now();
+      Alt.invoke(ctx, methodInfo);
+      var key = this.getKey(methodInfo);
+      var methodProfileData = this.profile[key] || (this.profile[key] = { count: 0, cost: 0 });
+      methodProfileData.count++;
+      methodProfileData.cost += performance.now() - then;
+    } else {
+      Alt.invoke(ctx, methodInfo);
+    }
+  },
 };
 
 Instrument.enter["com/sun/midp/ssl/SSLStreamConnection.<init>.(Ljava/lang/String;ILjava/io/InputStream;Ljava/io/OutputStream;Lcom/sun/midp/pki/CertStore;)V"] = function(caller, callee) {

--- a/vm.js
+++ b/vm.js
@@ -1050,16 +1050,7 @@ VM.execute = function(ctx) {
             if (Alt) {
                 try {
                     Instrument.callPauseHooks(ctx.current());
-                    if (Instrument.profiling) {
-                        var then = performance.now();
-                        Alt.invoke(ctx, methodInfo);
-                        var key = Instrument.getKey(methodInfo);
-                        var methodProfileData = Instrument.profile[key] || (Instrument.profile[key] = { count: 0, cost: 0 });
-                        methodProfileData.count++;
-                        methodProfileData.cost += performance.now() - then;
-                    } else {
-                        Alt.invoke(ctx, methodInfo);
-                    }
+                    Instrument.measure(Alt, ctx, methodInfo);
                     Instrument.callResumeHooks(ctx.current());
                 } catch (e) {
                     Instrument.callResumeHooks(ctx.current());


### PR DESCRIPTION
This adds call profiling to native/override functions (although it doesn't measure those that throw _VM.Yield_).
