### PR TITLE
return -1 early when Protocol.read0 called on closed socket

### DIFF
--- a/midp/socket.js
+++ b/midp/socket.js
@@ -77,6 +77,11 @@ Native["com/sun/midp/io/j2me/socket/Protocol.available0.()I"] = function(ctx, st
 Native["com/sun/midp/io/j2me/socket/Protocol.read0.([BII)I"] = function(ctx, stack) {
     var length = stack.pop(), offset = stack.pop(), data = stack.pop(), _this = stack.pop();
 
+    if (_this.socket.readyState == "closed") {
+        stack.push(-1);
+        return;
+    }
+
     function copyData() {
         var toRead = (length < _this.data.byteLength) ? length : _this.data.byteLength;
 


### PR DESCRIPTION
I'm not sure this is quite right. In particular, I see some strange log output from the SSLStreamConnection instrumentation: on desktop, the body of the HTTP response appears twice; while on device, a bunch of null characters sometimes appears after the body.

Nevertheless, this does appear to fix a recent regression in a midlet that uses a socket connection: the midlet blocks on a call to read0 that occurs after the socket connection has been closed.

And this is at least reasonable, since the description of _read0_ says it should return "the total number of bytes read into the buffer, or `-1` if there is no more data because the end of the stream has been reached."

Perhaps the underlying bug is that we don't notify the midlet when the socket closes. Although I'm unsure why this is happening now when it didn't happen last week, as I don't think this code has changed. Maybe it's a race condition between socket closure and _read0_ which has been exposed by the recent improvements to overall perf.
