### PR TITLE
disable CGraphicsUtil.draw9pcsBackground (works around #317)

### DIFF
--- a/override.js
+++ b/override.js
@@ -176,6 +176,11 @@ Override["java/io/ByteArrayInputStream.reset.()V"] = function(ctx, stack) {
   _this.pos = _this.mark;
 }
 
+Override["com/sun/midp/chameleon/CGraphicsUtil.draw9pcsBackground.(Ljavax/microedition/lcdui/Graphics;IIII[Ljavax/microedition/lcdui/Image;)V"] = function(ctx, stack) {
+  var image = stack.pop(), h = stack.pop(), w = stack.pop(), y = stack.pop(), x = stack.pop(), g = stack.pop();
+  console.log("CGraphicsUtil.draw9pcsBackground disabled");
+}
+
 function JavaException(className, message) {
   this.javaClassName = className;
   this.message = message;


### PR DESCRIPTION
This is not yet ready to merge. But I'm requesting a pull so folks know about it.

CGraphicsUtil.draw9pcsBackground is the method that takes so long—when a midlet uses it to draw part of a modal interstitial while using a socket—that it causes the connection to close before the transaction is complete (presumably the server times out and closes the connection after not receiving any data for a while).

Currently, this branch just stubs out the method, which makes the interstitial look funny but the transaction successful. We should instead make the method fast.
