### PR TITLE
Use notifications for connection registry instead of polling.

### DIFF
--- a/main.js
+++ b/main.js
@@ -43,12 +43,11 @@ if (urlParams.jars) {
 }
 
 if (urlParams.pushConn && urlParams.pushMidlet) {
-  MIDP.pushRegistrations.push({
+  MIDP.ConnectionRegistry.addConnection({
     connection: urlParams.pushConn,
     midlet: urlParams.pushMidlet,
     filter: "*",
-    suiteId: "1",
-    id: ++MIDP.lastRegistrationId,
+    suiteId: "1"
   });
 }
 

--- a/midp/localmsg.js
+++ b/midp/localmsg.js
@@ -284,7 +284,7 @@ Native["org/mozilla/io/LocalMsgConnection.init.(Ljava/lang/String;)V"] = functio
 
     if (_this.server) {
         MIDP.LocalMsgConnections[_this.protocolName] = new LocalMsgConnection();
-        pushNotify("localmsg:" + _this.protocolName);
+        MIDP.ConnectionRegistry.pushNotify("localmsg:" + _this.protocolName);
     } else {
         // Actually, there should always be a server, but we need this check
         // for apps that use the Nokia built-in servers (because we haven't


### PR DESCRIPTION
Drops roughly 1 second off the start up time of a midlets splash screen.
