### PR TITLE
Remove callee.localsBase check

### DIFF
--- a/context.js
+++ b/context.js
@@ -30,8 +30,7 @@ Context.prototype.popFrame = function() {
   var callee = this.frames.pop();
   var caller = this.current();
   Instrument.callExitHooks(callee.methodInfo, caller, callee);
-  if (callee.localsBase)
-    caller.stack.length = callee.localsBase;
+  caller.stack.length = callee.localsBase;
   return caller;
 }
 


### PR DESCRIPTION
This is unneeded now because callee.localsBase is always defined.
Looks like this is also the right thing to do, because otherwise the stack length isn't updated when localsBase is zero.
