### PR TITLE
Cache Native/Overide alt lookups.

### DIFF
--- a/vm.js
+++ b/vm.js
@@ -1059,7 +1059,11 @@ VM.execute = function(ctx) {
                 VM.trace("invoke", ctx.thread.pid, methodInfo);
             }
 
-            var Alt = ACCESS_FLAGS.isNative(methodInfo.access_flags) ? Native : Override.hasMethod(methodInfo) ? Override : null;
+            var Alt = methodInfo.alt;
+            if (Alt === undefined) {
+                Alt = methodInfo.alt = ACCESS_FLAGS.isNative(methodInfo.access_flags) ? Native : Override.hasMethod(methodInfo) ? Override : null;
+            }
+
             if (Alt) {
                 try {
                     Instrument.callPauseHooks(ctx.current());


### PR DESCRIPTION
Looking at a startup profile, the following checks stand out within VM.execute:
- Override.hasMethod (450ms)
- ACCESS_FLAGS.isNative (400ms)

Caching the method lookup avoids these checks.
