### PR TITLE
Optimize Frame constructor.

### DIFF
--- a/frame.js
+++ b/frame.js
@@ -25,6 +25,11 @@ Array.prototype.popType = function(signature) {
     return (signature === "J" || signature === "D") ? this.pop2() : this.pop();
 }
 
+// A convenience function for retrieving values in reverse order
+// from the end of the stack.  stack.read(1) returns the topmost item
+// on the stack, while stack.read(2) returns the one underneath it.
+Array.prototype.read = function(i) { return this[this.length - i] }; 
+
 var Frame = function(methodInfo, locals, localsBase) {
     this.methodInfo = methodInfo;
     this.cp = methodInfo.classInfo.constant_pool;
@@ -36,15 +41,14 @@ var Frame = function(methodInfo, locals, localsBase) {
     this.locals = locals;
     this.localsBase = localsBase;
 
-    this.isSynchronized = ACCESS_FLAGS.isSynchronized(methodInfo.access_flags);
+    this.isSynchronized = methodInfo._isSynchronized;
+    if (this.isSynchronized === undefined) {
+        this.isSynchronized = methodInfo._isSynchronized = ACCESS_FLAGS.isSynchronized(methodInfo.access_flags);
+    }
+
     this.lockObject = null;
 
     this.profileData = null;
-
-    // A convenience function for retrieving values in reverse order
-    // from the end of the stack.  stack.read(1) returns the topmost item
-    // on the stack, while stack.read(2) returns the one underneath it.
-    this.stack.read = function(i) { return this[this.length - i] };
 }
 
 Frame.prototype.getLocal = function(idx) {


### PR DESCRIPTION
A profile shows the `Frame` constructor taking 550ms (on startup). This patch optimizes the Frame constructor by doing two things, bringing the total time down to around 230ms:
- Extracting the inline definition of `stack.read` to an Array prototype method (since we already override several properties on Array, it seems reasonable to add one more)
- Caching `isSynchronized`, which itself took 150ms.
