### PR TITLE
Remove unneeded check in invoke* bytecode instructions

### DIFF
--- a/vm.js
+++ b/vm.js
@@ -1067,10 +1067,7 @@ VM.execute = function(ctx) {
                     Instrument.callResumeHooks(ctx.current());
                 } catch (e) {
                     Instrument.callResumeHooks(ctx.current());
-                    if (!e.class) {
-                        throw e;
-                    }
-                    throw_(e, ctx);
+                    throw e;
                 }
                 break;
             }


### PR DESCRIPTION
Looks like we always throw either VM.Yield or VM.Pause
