### PR TITLE
Don't catch exceptions in invoke*

### DIFF
--- a/vm.js
+++ b/vm.js
@@ -1061,14 +1061,9 @@ VM.execute = function(ctx) {
 
             var alternateImpl = methodInfo.alternateImpl;
             if (alternateImpl) {
-                try {
-                    Instrument.callPauseHooks(ctx.current());
-                    Instrument.measure(alternateImpl, ctx, methodInfo);
-                    Instrument.callResumeHooks(ctx.current());
-                } catch (e) {
-                    Instrument.callResumeHooks(ctx.current());
-                    throw e;
-                }
+                Instrument.callPauseHooks(ctx.current());
+                Instrument.measure(alternateImpl, ctx, methodInfo);
+                Instrument.callResumeHooks(ctx.current());
                 break;
             }
             pushFrame(methodInfo, consumes);


### PR DESCRIPTION
Looks like catching exceptions is very expensive, it causes a bailout. Since we're probably throwing a lot of exceptions (because our natives often throw VM.Pause or VM.Yield), it would be better to let Context::start catch them.
The call to resume hooks should be unneeded here because it will be called by Context::start when the thread will be executed again, right?
