### PR TITLE
Add info about time spent waiting for a native

### DIFF
--- a/context.js
+++ b/context.js
@@ -172,6 +172,14 @@ Context.prototype.start = function() {
 }
 
 Context.prototype.resume = function() {
+  var frame = this.current();
+  if (Instrument.profiling && frame.profileData) {
+    var key = frame.profileData.asyncKey;
+    var asyncProfileData = Instrument.asyncProfile[key] || (Instrument.asyncProfile[key] = { count: 0, cost: 0 });
+    asyncProfileData.cost += performance.now() - frame.profileData.asyncThen;
+    asyncProfileData.count++;
+    frame.profileData.asyncThen = null;
+  }
   this.start();
 }
 

--- a/vm.js
+++ b/vm.js
@@ -1055,7 +1055,7 @@ VM.execute = function(ctx) {
 
             var alternateImpl = methodInfo.alternateImpl;
             if (alternateImpl) {
-                Instrument.callPauseHooks(ctx.current());
+                Instrument.callPauseHooks(ctx.current(), methodInfo.implKey);
                 Instrument.measure(alternateImpl, ctx, methodInfo);
                 Instrument.callResumeHooks(ctx.current());
                 break;


### PR DESCRIPTION
This is still a WIP. I'm storing the data in a separate profile because they are not comparable (this profile here shows the time elapsed between the start of an async operation and its termination, in the meantime other threads may be doing other work).

The profile generated looks like this:

```
4906ms 19 java/lang/Object.wait.(J)V
3314ms 8 com/sun/midp/events/NativeEventMonitor.waitForNativeEvent.(Lcom/sun/midp/events/NativeEvent;)I
1125ms 1 org/mozilla/io/LocalMsgConnection.waitConnection.()V
938ms 16 com/ibm/oti/connection/file/FCOutputStream.syncImpl.(I)V
565ms 26 com/ibm/oti/connection/file/Connection.isDirectoryImpl.([B)Z
475ms 19 com/ibm/oti/connection/file/Connection.fileSizeImpl.([B)J
310ms 1 com/sun/midp/io/j2me/push/ConnectionRegistry.poll0.(J)I
306ms 30 com/ibm/oti/connection/file/Connection.existsImpl.([B)Z
279ms 2 org/mozilla/io/LocalMsgConnection.receiveData.([B)I
269ms 1 com/ibm/oti/connection/file/FCOutputStream.openImpl.([B)I
169ms 7 com/ibm/oti/connection/file/FCOutputStream.openOffsetImpl.([BJ)I
162ms 6 com/ibm/oti/connection/file/FCOutputStream.closeImpl.(I)V
149ms 3 com/sun/midp/rms/RecordStoreFile.closeFile.(I)V
105ms 3 com/sun/midp/rms/RecordStoreFile.openRecordStoreFile.(Ljava/lang/String;Ljava/lang/String;I)I
93ms 1 com/ibm/oti/connection/file/Connection.truncateImpl.([BJ)V
91ms 42 javax/microedition/lcdui/ImageDataFactory.createImmutableImageDecodeImage.(Ljavax/microedition/lcdui/ImageData;[BII)V
32ms 3 com/sun/midp/rms/RecordStoreUtil.exists.(Ljava/lang/String;Ljava/lang/String;I)Z
25ms 5 com/ibm/oti/connection/file/Connection.listImpl.([B[BZ)[[B
2ms 7 OTHER
```
