### PR TITLE
API to restart thread immediately

### DIFF
--- a/context.js
+++ b/context.js
@@ -141,38 +141,36 @@ Context.prototype.execute = function() {
 Context.prototype.start = function() {
   var ctx = this;
 
-  window.setZeroTimeout(function() {
-    Instrument.callResumeHooks(ctx.current());
-    try {
-      VM.execute(ctx);
-    } catch (e) {
-      switch (e) {
-      case VM.Yield:
-        break;
-      case VM.Pause:
-        Instrument.callPauseHooks(ctx.current());
-        return;
-      default:
-        console.info(e);
-        throw e;
-      }
-    }
-    Instrument.callPauseHooks(ctx.current());
-
-    // If there's one frame left, we're back to
-    // the method that created the thread and
-    // we're done.
-    if (ctx.frames.length === 1) {
-      ctx.kill();
+  Instrument.callResumeHooks(ctx.current());
+  try {
+    VM.execute(ctx);
+  } catch (e) {
+    switch (e) {
+    case VM.Yield:
+      break;
+    case VM.Pause:
+      Instrument.callPauseHooks(ctx.current());
       return;
+    default:
+      console.info(e);
+      throw e;
     }
+  }
+  Instrument.callPauseHooks(ctx.current());
 
-    ctx.start();
-  });
+  // If there's one frame left, we're back to
+  // the method that created the thread and
+  // we're done.
+  if (ctx.frames.length === 1) {
+    ctx.kill();
+    return;
+  }
+
+  ctx.resume();
 }
 
 Context.prototype.resume = function() {
-  this.start();
+  window.setZeroTimeout(this.start.bind(this));
 }
 
 Context.prototype.block = function(obj, queue, lockLevel) {

--- a/native.js
+++ b/native.js
@@ -508,7 +508,7 @@ Native["java/lang/Thread.start0.()V"] = function(ctx, stack) {
     });
 
     ctx.frames.push(new Frame(syntheticMethod, [ thread ], 0));
-    ctx.start();
+    ctx.resume();
 }
 
 Native["java/lang/Thread.internalExit.()V"] = function(ctx, stack) {


### PR DESCRIPTION
The changes in #436 create a subtle race condition in the socket implementation (see https://github.com/andreasgal/j2me.js/pull/436#issuecomment-59095781 for the details). The most straightforward way to fix it is for Protocol.write0 to restart its thread immediately upon receiving the "send" event, but we don't yet have an API for that.

Here's one option: make Context.start restart the thread immediately, while Context.resume continues to reschedule rather than restart.
