### PR TITLE
Pass ctx as last optional parameter in natives

### DIFF
--- a/midp/codec.js
+++ b/midp/codec.js
@@ -128,27 +128,27 @@ DataDecoder.prototype.getType = function() {
   return this.data[0].type || -1;
 }
 
-Native.create("com/nokia/mid/s40/codec/DataEncoder.init.()V", function(ctx) {
+Native.create("com/nokia/mid/s40/codec/DataEncoder.init.()V", function() {
   this.encoder = new DataEncoder();
 });
 
-Native.create("com/nokia/mid/s40/codec/DataEncoder.putStart.(ILjava/lang/String;)V", function(ctx, tag, name) {
+Native.create("com/nokia/mid/s40/codec/DataEncoder.putStart.(ILjava/lang/String;)V", function(tag, name) {
   this.encoder.putStart(tag, util.fromJavaString(name));
 });
 
-Native.create("com/nokia/mid/s40/codec/DataEncoder.put.(ILjava/lang/String;Ljava/lang/String;)V", function(ctx, tag, name, value) {
+Native.create("com/nokia/mid/s40/codec/DataEncoder.put.(ILjava/lang/String;Ljava/lang/String;)V", function(tag, name, value) {
   this.encoder.put(tag, util.fromJavaString(name), util.fromJavaString(value));
 });
 
-Native.create("com/nokia/mid/s40/codec/DataEncoder.put.(ILjava/lang/String;J)V", function(ctx, tag, name, value, _) {
+Native.create("com/nokia/mid/s40/codec/DataEncoder.put.(ILjava/lang/String;J)V", function(tag, name, value, _) {
   this.encoder.put(tag, util.fromJavaString(name), value.toNumber());
 });
 
-Native.create("com/nokia/mid/s40/codec/DataEncoder.put.(ILjava/lang/String;Z)V", function(ctx, tag, name, value) {
+Native.create("com/nokia/mid/s40/codec/DataEncoder.put.(ILjava/lang/String;Z)V", function(tag, name, value) {
   this.encoder.put(tag, util.fromJavaString(name), value);
 });
 
-Native.create("com/nokia/mid/s40/codec/DataEncoder.putEnd.(ILjava/lang/String;)V", function(ctx, tag, name) {
+Native.create("com/nokia/mid/s40/codec/DataEncoder.putEnd.(ILjava/lang/String;)V", function(tag, name) {
   this.encoder.putEnd(tag, util.fromJavaString(name));
 });
 
@@ -163,23 +163,23 @@ Native.create("com/nokia/mid/s40/codec/DataEncoder.getData.()[B", function(ctx) 
   return array;
 });
 
-Native.create("com/nokia/mid/s40/codec/DataDecoder.init.([BII)V", function(ctx, data, offset, length) {
+Native.create("com/nokia/mid/s40/codec/DataDecoder.init.([BII)V", function(data, offset, length) {
   this.decoder = new DataDecoder(data, offset, length);
 });
 
-Native.create("com/nokia/mid/s40/codec/DataDecoder.getStart.(I)V", function(ctx, tag) {
+Native.create("com/nokia/mid/s40/codec/DataDecoder.getStart.(I)V", function(tag) {
   if (!this.decoder.getStart(tag)) {
     throw new JavaException("java/io/IOException", "no start found " + tag);
   }
 });
 
-Native.create("com/nokia/mid/s40/codec/DataDecoder.getEnd.(I)V", function(ctx, tag) {
+Native.create("com/nokia/mid/s40/codec/DataDecoder.getEnd.(I)V", function(tag) {
   if (!this.decoder.getEnd(tag)) {
     throw new JavaException("java/io/IOException", "no end found " + tag);
   }
 });
 
-Native.create("com/nokia/mid/s40/codec/DataDecoder.getString.(I)Ljava/lang/String;", function(ctx, tag) {
+Native.create("com/nokia/mid/s40/codec/DataDecoder.getString.(I)Ljava/lang/String;", function(tag) {
   var str = this.decoder.getValue(tag);
   if (str === undefined) {
     throw new JavaException("java/io/IOException", "tag (" + tag + ") invalid");
@@ -187,7 +187,7 @@ Native.create("com/nokia/mid/s40/codec/DataDecoder.getString.(I)Ljava/lang/Strin
   return str;
 });
 
-Native.create("com/nokia/mid/s40/codec/DataDecoder.getInteger.(I)J", function(ctx, tag) {
+Native.create("com/nokia/mid/s40/codec/DataDecoder.getInteger.(I)J", function(tag) {
   var num = this.decoder.getValue(tag);
   if (num === undefined) {
     throw new JavaException("java/io/IOException", "tag (" + tag + ") invalid");
@@ -195,7 +195,7 @@ Native.create("com/nokia/mid/s40/codec/DataDecoder.getInteger.(I)J", function(ct
   return Long.fromNumber(num);
 });
 
-Native.create("com/nokia/mid/s40/codec/DataDecoder.getBoolean.()Z", function(ctx) {
+Native.create("com/nokia/mid/s40/codec/DataDecoder.getBoolean.()Z", function() {
   var val = this.decoder.getNextValue();
   if (val === undefined) {
     throw new JavaException("java/io/IOException");
@@ -203,7 +203,7 @@ Native.create("com/nokia/mid/s40/codec/DataDecoder.getBoolean.()Z", function(ctx
   return val === 1;
 });
 
-Native.create("com/nokia/mid/s40/codec/DataDecoder.getName.()Ljava/lang/String;", function(ctx) {
+Native.create("com/nokia/mid/s40/codec/DataDecoder.getName.()Ljava/lang/String;", function() {
   var name = this.decoder.getName();
   if (name === undefined) {
     throw new JavaException("java/io/IOException");
@@ -211,7 +211,7 @@ Native.create("com/nokia/mid/s40/codec/DataDecoder.getName.()Ljava/lang/String;"
   return name;
 });
 
-Native.create("com/nokia/mid/s40/codec/DataDecoder.getType.()I", function(ctx) {
+Native.create("com/nokia/mid/s40/codec/DataDecoder.getType.()I", function() {
   var tag = this.decoder.getTag();
   if (tag === undefined) {
     throw new JavaException("java/io/IOException");
@@ -219,6 +219,6 @@ Native.create("com/nokia/mid/s40/codec/DataDecoder.getType.()I", function(ctx) {
   return tag;
 });
 
-Native.create("com/nokia/mid/s40/codec/DataDecoder.listHasMoreItems.()Z", function(ctx) {
+Native.create("com/nokia/mid/s40/codec/DataDecoder.listHasMoreItems.()Z", function() {
   return this.decoder.getType() != DataEncoder.END;
 });

--- a/midp/crypto.js
+++ b/midp/crypto.js
@@ -3,7 +3,7 @@
 
 'use strict';
 
-Native.create("com/sun/midp/crypto/PRand.getRandomBytes.([BI)Z", function(ctx, b, nbytes) {
+Native.create("com/sun/midp/crypto/PRand.getRandomBytes.([BI)Z", function(b, nbytes) {
     window.crypto.getRandomValues(b.subarray(0, nbytes));
     return true;
 });
@@ -84,11 +84,11 @@ MIDP.bin2String = function(array) {
   return result;
 };
 
-Native.create("com/sun/midp/crypto/SHA.nativeUpdate.([BII[I[I[I[I)V", function(ctx, inBuf, inOff, inLen, state, num, count, data) {
+Native.create("com/sun/midp/crypto/SHA.nativeUpdate.([BII[I[I[I[I)V", function(inBuf, inOff, inLen, state, num, count, data) {
     MIDP.getSHA1Hasher(data).update(inBuf.subarray(inOff, inOff + inLen));
 });
 
-Native.create("com/sun/midp/crypto/SHA.nativeFinal.([BII[BI[I[I[I[I)V", function(ctx, inBuf, inOff, inLen, outBuf, outOff, state, num, count, data) {
+Native.create("com/sun/midp/crypto/SHA.nativeFinal.([BII[BI[I[I[I[I)V", function(inBuf, inOff, inLen, outBuf, outOff, state, num, count, data) {
     var hasher = MIDP.getSHA1Hasher(data);
 
     if (inBuf) {
@@ -107,7 +107,7 @@ Native.create("com/sun/midp/crypto/SHA.nativeFinal.([BII[BI[I[I[I[I)V", function
     MIDP.hashers.delete(data);
 });
 
-Native.create("com/sun/midp/crypto/SHA.nativeClone.([I)V", function(ctx, data) {
+Native.create("com/sun/midp/crypto/SHA.nativeClone.([I)V", function(data) {
     for (var key of MIDP.hashers.keys()) {
         if (util.compareTypedArrays(key, data)) {
             var value = MIDP.hashers.get(key);
@@ -119,11 +119,11 @@ Native.create("com/sun/midp/crypto/SHA.nativeClone.([I)V", function(ctx, data) {
     }
 });
 
-Native.create("com/sun/midp/crypto/MD5.nativeUpdate.([BII[I[I[I[I)V", function(ctx, inBuf, inOff, inLen, state, num, count, data) {
+Native.create("com/sun/midp/crypto/MD5.nativeUpdate.([BII[I[I[I[I)V", function(inBuf, inOff, inLen, state, num, count, data) {
     MIDP.getMD5Hasher(data).update(MIDP.bin2String(new Uint8Array(inBuf.subarray(inOff, inOff + inLen))));
 });
 
-Native.create("com/sun/midp/crypto/MD5.nativeFinal.([BII[BI[I[I[I[I)V", function(ctx, inBuf, inOff, inLen, outBuf, outOff, state, num, count, data) {
+Native.create("com/sun/midp/crypto/MD5.nativeFinal.([BII[BI[I[I[I[I)V", function(inBuf, inOff, inLen, outBuf, outOff, state, num, count, data) {
     var hasher = MIDP.getMD5Hasher(data);
 
     if (inBuf) {
@@ -145,7 +145,7 @@ Native.create("com/sun/midp/crypto/MD5.nativeFinal.([BII[BI[I[I[I[I)V", function
     MIDP.hashers.delete(data);
 });
 
-Native.create("com/sun/midp/crypto/MD5.nativeClone.([I)V", function(ctx, data) {
+Native.create("com/sun/midp/crypto/MD5.nativeClone.([I)V", function(data) {
     for (var key of MIDP.hashers.keys()) {
         if (util.compareTypedArrays(key, data)) {
             var value = MIDP.hashers.get(key);
@@ -187,7 +187,7 @@ function hexStringToBytes(hex) {
     return bytes;
 }
 
-Native.create("com/sun/midp/crypto/RSA.modExp.([B[B[B[B)I", function(ctx, data, exponent, modulus, result) {
+Native.create("com/sun/midp/crypto/RSA.modExp.([B[B[B[B)I", function(data, exponent, modulus, result) {
     // The jsbn library doesn't work well with typed arrays, so we're using this
     // hack of translating the numbers to hexadecimal strings before handing
     // them to jsbn (and we're getting the result back in a hex string).
@@ -202,7 +202,7 @@ Native.create("com/sun/midp/crypto/RSA.modExp.([B[B[B[B)I", function(ctx, data, 
     return remainder.length;
 });
 
-Native.create("com/sun/midp/crypto/ARC4.nativetx.([B[I[I[BII[BI)V", function(ctx, S, X, Y, inbuf, inoff, inlen, outbuf, outoff) {
+Native.create("com/sun/midp/crypto/ARC4.nativetx.([B[I[I[BII[BI)V", function(S, X, Y, inbuf, inoff, inlen, outbuf, outoff) {
     var x = X[0];
     var y = Y[0];
 

--- a/midp/frameanimator.js
+++ b/midp/frameanimator.js
@@ -33,11 +33,11 @@ FrameAnimator.prototype.isRegistered = function() {
   return this._isRegistered;
 };
 
-Native.create("com/nokia/mid/ui/frameanimator/FrameAnimator.init.()V", function(ctx) {
+Native.create("com/nokia/mid/ui/frameanimator/FrameAnimator.init.()V", function() {
   this.nativeObject = new FrameAnimator();
 });
 
-Native.create("com/nokia/mid/ui/frameanimator/FrameAnimator.register.(IISSLcom/nokia/mid/ui/frameanimator/FrameAnimatorListener;)Z", function(ctx, x, y, maxFps, maxPps, listener) {
+Native.create("com/nokia/mid/ui/frameanimator/FrameAnimator.register.(IISSLcom/nokia/mid/ui/frameanimator/FrameAnimatorListener;)Z", function(x, y, maxFps, maxPps, listener) {
   if (this.nativeObject.isRegistered()) {
     throw new JavaException("java/lang/IllegalStateException", "FrameAnimator already registered");
   }
@@ -56,7 +56,7 @@ Native.create("com/nokia/mid/ui/frameanimator/FrameAnimator.register.(IISSLcom/n
   return true;
 });
 
-Native.create("com/nokia/mid/ui/frameanimator/FrameAnimator.unregister.()V", function(ctx) {
+Native.create("com/nokia/mid/ui/frameanimator/FrameAnimator.unregister.()V", function() {
   if (!this.nativeObject.isRegistered()) {
     throw new JavaException("java/lang/IllegalStateException", "FrameAnimator not registered");
   }
@@ -64,28 +64,28 @@ Native.create("com/nokia/mid/ui/frameanimator/FrameAnimator.unregister.()V", fun
   this.nativeObject.unregister();
 });
 
-Native.create("com/nokia/mid/ui/frameanimator/FrameAnimator.drag.(II)V", function(ctx, x, y) {
+Native.create("com/nokia/mid/ui/frameanimator/FrameAnimator.drag.(II)V", function(x, y) {
   console.warn("FrameAnimator.drag(II)V not implemented (" + x + ", " + y + ")");
 });
 
-Native.create("com/nokia/mid/ui/frameanimator/FrameAnimator.kineticScroll.(IIIF)V", function(ctx, speed, direction, friction, angle) {
+Native.create("com/nokia/mid/ui/frameanimator/FrameAnimator.kineticScroll.(IIIF)V", function(speed, direction, friction, angle) {
   console.warn("FrameAnimator.kineticScroll(IIIF)V not implemented (" +
                speed + ", " + direction + ", " + friction + ", " + angle + ")");
 });
 
-Native.create("com/nokia/mid/ui/frameanimator/FrameAnimator.limitedKineticScroll.(IIIFII)V", function(ctx, speed, direction, friction, angle, limitUp, limitDown) {
+Native.create("com/nokia/mid/ui/frameanimator/FrameAnimator.limitedKineticScroll.(IIIFII)V", function(speed, direction, friction, angle, limitUp, limitDown) {
   console.warn("FrameAnimator.limitedKineticScroll(IIIFII)V not implemented (" +
                speed + ", " + direction + ", " + friction + ", " + angle + ", " + limitUp + ", " + limitDown + ")");
 });
 
-Native.create("com/nokia/mid/ui/frameanimator/FrameAnimator.stop.()V", function(ctx) {
+Native.create("com/nokia/mid/ui/frameanimator/FrameAnimator.stop.()V", function() {
   console.warn("FrameAnimator.stop()V not implemented");
 });
 
-Native.create("com/nokia/mid/ui/frameanimator/FrameAnimator.isRegistered.()Z", function(ctx) {
+Native.create("com/nokia/mid/ui/frameanimator/FrameAnimator.isRegistered.()Z", function() {
   return this.nativeObject.isRegistered();
 });
 
-Native.create("com/nokia/mid/ui/frameanimator/FrameAnimator.getNumRegisteredFrameAnimators.()I", function(ctx) {
+Native.create("com/nokia/mid/ui/frameanimator/FrameAnimator.getNumRegisteredFrameAnimators.()I", function() {
   return FrameAnimator.numRegistered;
 });

--- a/midp/fs.js
+++ b/midp/fs.js
@@ -5,16 +5,16 @@
 
 var RECORD_STORE_BASE = "/RecordStore";
 
-Native.create("com/sun/midp/io/j2me/storage/File.initConfigRoot.(I)Ljava/lang/String;", function(ctx, storageId) {
+Native.create("com/sun/midp/io/j2me/storage/File.initConfigRoot.(I)Ljava/lang/String;", function(storageId) {
     return "assets/" + storageId + "/";
 });
 
-Native.create("com/sun/midp/midletsuite/MIDletSuiteStorage.getSecureFilenameBase.(I)Ljava/lang/String;", function(ctx, id) {
+Native.create("com/sun/midp/midletsuite/MIDletSuiteStorage.getSecureFilenameBase.(I)Ljava/lang/String;", function(id) {
     return "";
 });
 
 Native.create("com/sun/midp/rms/RecordStoreUtil.exists.(Ljava/lang/String;Ljava/lang/String;I)Z",
-function(ctx, filenameBase, name, ext) {
+function(filenameBase, name, ext) {
     return new Promise(function(resolve, reject) {
         var path = RECORD_STORE_BASE + "/" + util.fromJavaString(filenameBase) + "/" + util.fromJavaString(name) + "." + ext;
         fs.exists(path, resolve);
@@ -22,7 +22,7 @@ function(ctx, filenameBase, name, ext) {
 });
 
 Native.create("com/sun/midp/rms/RecordStoreUtil.deleteFile.(Ljava/lang/String;Ljava/lang/String;I)V",
-function(ctx, filenameBase, name, ext) {
+function(filenameBase, name, ext) {
     return new Promise(function(resolve, reject) {
         var path = RECORD_STORE_BASE + "/" + util.fromJavaString(filenameBase) + "/" + util.fromJavaString(name) + "." + ext;
 
@@ -30,7 +30,7 @@ function(ctx, filenameBase, name, ext) {
     });
 });
 
-Native.create("com/sun/midp/rms/RecordStoreFile.spaceAvailableNewRecordStore0.(Ljava/lang/String;I)I", function(ctx, filenameBase, storageId) {
+Native.create("com/sun/midp/rms/RecordStoreFile.spaceAvailableNewRecordStore0.(Ljava/lang/String;I)I", function(filenameBase, storageId) {
     // Pretend there is 50MiB available.  Our implementation is backed
     // by IndexedDB, which has no actual limit beyond space available on device,
     // which I don't think we can determine.  But this should be sufficient
@@ -38,7 +38,7 @@ Native.create("com/sun/midp/rms/RecordStoreFile.spaceAvailableNewRecordStore0.(L
     return 50 * 1024 * 1024;
 });
 
-Native.create("com/sun/midp/rms/RecordStoreFile.spaceAvailableRecordStore.(ILjava/lang/String;I)I", function(ctx, handle, filenameBase, storageId) {
+Native.create("com/sun/midp/rms/RecordStoreFile.spaceAvailableRecordStore.(ILjava/lang/String;I)I", function(handle, filenameBase, storageId) {
     // Pretend there is 50MiB available.  Our implementation is backed
     // by IndexedDB, which has no actual limit beyond space available on device,
     // which I don't think we can determine.  But this should be sufficient
@@ -47,7 +47,7 @@ Native.create("com/sun/midp/rms/RecordStoreFile.spaceAvailableRecordStore.(ILjav
 });
 
 Native.create("com/sun/midp/rms/RecordStoreFile.openRecordStoreFile.(Ljava/lang/String;Ljava/lang/String;I)I",
-function(ctx, filenameBase, name, ext) {
+function(filenameBase, name, ext) {
     return new Promise(function(resolve, reject) {
         var path = RECORD_STORE_BASE + "/" + util.fromJavaString(filenameBase) + "/" + util.fromJavaString(name) + "." + ext;
 
@@ -84,11 +84,11 @@ function(ctx, filenameBase, name, ext) {
     });
 });
 
-Native.create("com/sun/midp/rms/RecordStoreFile.setPosition.(II)V", function(ctx, handle, pos) {
+Native.create("com/sun/midp/rms/RecordStoreFile.setPosition.(II)V", function(handle, pos) {
     fs.setpos(handle, pos);
 });
 
-Native.create("com/sun/midp/rms/RecordStoreFile.readBytes.(I[BII)I", function(ctx, handle, buf, offset, numBytes) {
+Native.create("com/sun/midp/rms/RecordStoreFile.readBytes.(I[BII)I", function(handle, buf, offset, numBytes) {
     var from = fs.getpos(handle);
     var to = from + numBytes;
     var readBytes = fs.read(handle, from, to);
@@ -104,17 +104,17 @@ Native.create("com/sun/midp/rms/RecordStoreFile.readBytes.(I[BII)I", function(ct
     return readBytes.byteLength;
 });
 
-Native.create("com/sun/midp/rms/RecordStoreFile.writeBytes.(I[BII)V", function(ctx, handle, buf, offset, numBytes) {
+Native.create("com/sun/midp/rms/RecordStoreFile.writeBytes.(I[BII)V", function(handle, buf, offset, numBytes) {
     fs.write(handle, buf.subarray(offset, offset + numBytes));
 });
 
-Native.create("com/sun/midp/rms/RecordStoreFile.commitWrite.(I)V", function(ctx, handle) {
+Native.create("com/sun/midp/rms/RecordStoreFile.commitWrite.(I)V", function(handle) {
     return new Promise(function(resolve, reject) {
       fs.flush(handle, resolve);
     });
 });
 
-Native.create("com/sun/midp/rms/RecordStoreFile.closeFile.(I)V", function(ctx, handle) {
+Native.create("com/sun/midp/rms/RecordStoreFile.closeFile.(I)V", function(handle) {
     return new Promise(function(resolve, reject) {
       fs.flush(handle, function() {
           fs.close(handle);
@@ -123,7 +123,7 @@ Native.create("com/sun/midp/rms/RecordStoreFile.closeFile.(I)V", function(ctx, h
     });
 });
 
-Native.create("com/sun/midp/rms/RecordStoreFile.truncateFile.(II)V", function(ctx, handle, size) {
+Native.create("com/sun/midp/rms/RecordStoreFile.truncateFile.(II)V", function(handle, size) {
     return new Promise(function(resolve, reject) {
       fs.flush(handle, function() {
           fs.ftruncate(handle, size);
@@ -135,7 +135,7 @@ Native.create("com/sun/midp/rms/RecordStoreFile.truncateFile.(II)V", function(ct
 MIDP.RecordStoreCache = [];
 
 Native.create("com/sun/midp/rms/RecordStoreSharedDBHeader.getLookupId0.(ILjava/lang/String;I)I",
-function(ctx, suiteId, jStoreName, headerDataSize) {
+function(suiteId, jStoreName, headerDataSize) {
     var storeName = util.fromJavaString(jStoreName);
 
     var sharedHeader =
@@ -158,7 +158,7 @@ function(ctx, suiteId, jStoreName, headerDataSize) {
     return sharedHeader.lookupId;
 });
 
-Native.create("com/sun/midp/rms/RecordStoreSharedDBHeader.shareCachedData0.(I[BI)I", function(ctx, lookupId, headerData, headerDataSize) {
+Native.create("com/sun/midp/rms/RecordStoreSharedDBHeader.shareCachedData0.(I[BI)I", function(lookupId, headerData, headerDataSize) {
     var sharedHeader = MIDP.RecordStoreCache[lookupId];
     if (!sharedHeader) {
         throw new JavaException("java/lang/IllegalStateException", "invalid header lookup ID");
@@ -179,7 +179,7 @@ Native.create("com/sun/midp/rms/RecordStoreSharedDBHeader.shareCachedData0.(I[BI
 });
 
 Native.create("com/sun/midp/rms/RecordStoreSharedDBHeader.updateCachedData0.(I[BII)I",
-function(ctx, lookupId, headerData, headerDataSize, headerVersion) {
+function(lookupId, headerData, headerDataSize, headerVersion) {
     var sharedHeader = MIDP.RecordStoreCache[lookupId];
     if (!sharedHeader) {
         throw new JavaException("java/lang/IllegalStateException", "invalid header lookup ID");
@@ -203,7 +203,7 @@ function(ctx, lookupId, headerData, headerDataSize, headerVersion) {
     return headerVersion;
 });
 
-Native.create("com/sun/midp/rms/RecordStoreSharedDBHeader.getHeaderRefCount0.(I)I", function(ctx, lookupId) {
+Native.create("com/sun/midp/rms/RecordStoreSharedDBHeader.getHeaderRefCount0.(I)I", function(lookupId) {
     var sharedHeader = MIDP.RecordStoreCache[lookupId];
     if (!sharedHeader) {
         throw new JavaException("java/lang/IllegalStateException", "invalid header lookup ID");
@@ -212,7 +212,7 @@ Native.create("com/sun/midp/rms/RecordStoreSharedDBHeader.getHeaderRefCount0.(I)
     return sharedHeader.refCount;
 });
 
-Native.create("com/sun/midp/rms/RecordStoreSharedDBHeader.cleanup0.()V", function(ctx) {
+Native.create("com/sun/midp/rms/RecordStoreSharedDBHeader.cleanup0.()V", function() {
     var lookupId = this.class.getField("I.lookupId.I").get(this);
     if (MIDP.RecordStoreCache[lookupId] &&
         --MIDP.RecordStoreCache[lookupId].refCount <= 0) {
@@ -227,35 +227,35 @@ Native["com/sun/midp/rms/RecordStoreSharedDBHeader.finalize.()V"] =
     Native["com/sun/midp/rms/RecordStoreSharedDBHeader.cleanup0.()V"];
 
 Native.create("com/sun/midp/rms/RecordStoreRegistry.getRecordStoreListeners.(ILjava/lang/String;)[I",
-function(ctx, suiteId, storeName) {
+function(suiteId, storeName) {
     console.warn("RecordStoreRegistry.getRecordStoreListeners.(IL...String;)[I not implemented (" +
                  suiteId + ", " + util.fromJavaString(storeName) + ")");
     return null;
 });
 
 Native.create("com/sun/midp/rms/RecordStoreRegistry.sendRecordStoreChangeEvent.(ILjava/lang/String;II)V",
-function(ctx, suiteId, storeName, changeType, recordId) {
+function(suiteId, storeName, changeType, recordId) {
     console.warn("RecordStoreRegistry.sendRecordStoreChangeEvent.(IL...String;II)V not implemented (" +
                  suiteId + ", " + util.fromJavaString(storeName) + ", " + changeType + ", " + recordId + ")");
 });
 
 Native.create("com/sun/midp/rms/RecordStoreRegistry.startRecordStoreListening.(ILjava/lang/String;)V",
-function(ctx, suiteId, storeName) {
+function(suiteId, storeName) {
     console.warn("RecordStoreRegistry.startRecordStoreListening.(IL...String;)V not implemented (" +
                  suiteId + ", " + util.fromJavaString(storeName) + ")");
 });
 
 Native.create("com/sun/midp/rms/RecordStoreRegistry.stopRecordStoreListening.(ILjava/lang/String;)V",
-function(ctx, suiteId, storeName) {
+function(suiteId, storeName) {
     console.warn("RecordStoreRegistry.stopRecordStoreListening.(IL...String;)V not implemented (" +
                  suiteId + ", " + util.fromJavaString(storeName) + ")");
 });
 
-Native.create("com/sun/midp/rms/RecordStoreRegistry.stopAllRecordStoreListeners.(I)V", function(ctx, taskId) {
+Native.create("com/sun/midp/rms/RecordStoreRegistry.stopAllRecordStoreListeners.(I)V", function(taskId) {
     console.warn("RecordStoreRegistry.stopAllRecordStoreListeners.(I)V not implemented (" + taskId + ")");
 });
 
-Native.create("com/ibm/oti/connection/file/Connection.isValidFilenameImpl.([B)Z", function(ctx, path) {
+Native.create("com/ibm/oti/connection/file/Connection.isValidFilenameImpl.([B)Z", function(path) {
     var invalid = ['<', '>', ':', '"', '/', '\\', '|', '*', '?'].map(function(char) {
       return char.charCodeAt(0);
     });
@@ -269,22 +269,22 @@ Native.create("com/ibm/oti/connection/file/Connection.isValidFilenameImpl.([B)Z"
     return true;
 });
 
-Native.create("com/ibm/oti/connection/file/Connection.availableSizeImpl.([B)J", function(ctx, path) {
+Native.create("com/ibm/oti/connection/file/Connection.availableSizeImpl.([B)J", function(path) {
     // Pretend there is 1 GB available
     return Long.fromNumber(1024 * 1024 * 1024);
 });
 
-Native.create("com/ibm/oti/connection/file/Connection.setHiddenImpl.([BZ)V", function(ctx, path, value) {
+Native.create("com/ibm/oti/connection/file/Connection.setHiddenImpl.([BZ)V", function(path, value) {
     console.warn("Connection.setHiddenImpl.([BZ)V not implemented (" + util.decodeUtf8(path) + ")");
 });
 
-Native.create("com/ibm/oti/connection/file/Connection.existsImpl.([B)Z", function(ctx, path) {
+Native.create("com/ibm/oti/connection/file/Connection.existsImpl.([B)Z", function(path) {
     return new Promise(function(resolve, reject) {
       fs.exists(util.decodeUtf8(path), resolve);
     });
 });
 
-Native.create("com/ibm/oti/connection/file/Connection.fileSizeImpl.([B)J", function(ctx, path) {
+Native.create("com/ibm/oti/connection/file/Connection.fileSizeImpl.([B)J", function(path) {
     return new Promise(function(resolve, reject) {
         fs.size(util.decodeUtf8(path), function(size) {
             resolve(Long.fromNumber(size));
@@ -292,7 +292,7 @@ Native.create("com/ibm/oti/connection/file/Connection.fileSizeImpl.([B)J", funct
     });
 });
 
-Native.create("com/ibm/oti/connection/file/Connection.isDirectoryImpl.([B)Z", function(ctx, path) {
+Native.create("com/ibm/oti/connection/file/Connection.isDirectoryImpl.([B)Z", function(path) {
     return new Promise(function(resolve, reject) {
         fs.stat(util.decodeUtf8(path), function(stat) {
             resolve(!!stat && stat.isDir);
@@ -301,7 +301,7 @@ Native.create("com/ibm/oti/connection/file/Connection.isDirectoryImpl.([B)Z", fu
 });
 
 Native.create("com/ibm/oti/connection/file/Connection.listImpl.([B[BZ)[[B",
-function(ctx, jPath, filterArray, includeHidden) {
+function(jPath, filterArray, includeHidden, ctx) {
     var path = util.decodeUtf8(jPath);
     return new Promise(function(resolve, reject) {
         var filter = "";
@@ -367,7 +367,7 @@ function(ctx, jPath, filterArray, includeHidden) {
 });
 
 
-Native.create("com/ibm/oti/connection/file/Connection.mkdirImpl.([B)I", function(ctx, path) {
+Native.create("com/ibm/oti/connection/file/Connection.mkdirImpl.([B)I", function(path) {
     return new Promise(function(resolve, reject) {
         fs.mkdir(util.decodeUtf8(path), function(created) {
             // IBM's implementation returns different error numbers, we don't care
@@ -376,7 +376,7 @@ Native.create("com/ibm/oti/connection/file/Connection.mkdirImpl.([B)I", function
     });
 });
 
-Native.create("com/ibm/oti/connection/file/Connection.newFileImpl.([B)I", function(ctx, jPath) {
+Native.create("com/ibm/oti/connection/file/Connection.newFileImpl.([B)I", function(jPath) {
     var path = util.decodeUtf8(jPath);
 
     return new Promise(function(resolve, reject) {
@@ -396,7 +396,7 @@ Native.create("com/ibm/oti/connection/file/Connection.newFileImpl.([B)I", functi
     });
 });
 
-Native.create("com/ibm/oti/connection/file/Connection.deleteFileImpl.([B)Z", function(ctx, path) {
+Native.create("com/ibm/oti/connection/file/Connection.deleteFileImpl.([B)Z", function(path) {
     return new Promise(function(resolve, reject) {
         fs.remove(util.decodeUtf8(path), resolve);
     });
@@ -405,17 +405,17 @@ Native.create("com/ibm/oti/connection/file/Connection.deleteFileImpl.([B)Z", fun
 Native["com/ibm/oti/connection/file/Connection.deleteDirImpl.([B)Z"] =
   Native["com/ibm/oti/connection/file/Connection.deleteFileImpl.([B)Z"]
 
-Native.create("com/ibm/oti/connection/file/Connection.isReadOnlyImpl.([B)Z", function(ctx, path) {
+Native.create("com/ibm/oti/connection/file/Connection.isReadOnlyImpl.([B)Z", function(path) {
     console.warn("Connection.isReadOnlyImpl.([B)Z not implemented (" + util.decodeUtf8(path) + ")");
     return false;
 });
 
-Native.create("com/ibm/oti/connection/file/Connection.isWriteOnlyImpl.([B)Z", function(ctx, path) {
+Native.create("com/ibm/oti/connection/file/Connection.isWriteOnlyImpl.([B)Z", function(path) {
     console.warn("Connection.isWriteOnlyImpl.([B)Z not implemented (" + util.decodeUtf8(path) + ")");
     return false;
 });
 
-Native.create("com/ibm/oti/connection/file/Connection.lastModifiedImpl.([B)J", function(ctx, path) {
+Native.create("com/ibm/oti/connection/file/Connection.lastModifiedImpl.([B)J", function(path) {
     return new Promise(function(resolve, reject) {
         fs.stat(util.decodeUtf8(path), function(stat) {
             resolve(Long.fromNumber(stat != null ? stat.mtime : 0));
@@ -423,7 +423,7 @@ Native.create("com/ibm/oti/connection/file/Connection.lastModifiedImpl.([B)J", f
     });
 });
 
-Native.create("com/ibm/oti/connection/file/Connection.renameImpl.([B[B)V", function(ctx, oldPath, newPath) {
+Native.create("com/ibm/oti/connection/file/Connection.renameImpl.([B[B)V", function(oldPath, newPath) {
     return new Promise(function(resolve, reject) {
         fs.rename(util.decodeUtf8(oldPath), util.decodeUtf8(newPath), function(renamed) {
             if (!renamed) {
@@ -436,7 +436,7 @@ Native.create("com/ibm/oti/connection/file/Connection.renameImpl.([B[B)V", funct
     });
 });
 
-Native.create("com/ibm/oti/connection/file/Connection.truncateImpl.([BJ)V", function(ctx, path, newLength, _) {
+Native.create("com/ibm/oti/connection/file/Connection.truncateImpl.([BJ)V", function(path, newLength, _) {
     return new Promise(function(resolve, reject) {
         fs.open(util.decodeUtf8(path), function(fd) {
           if (fd == -1) {
@@ -453,17 +453,17 @@ Native.create("com/ibm/oti/connection/file/Connection.truncateImpl.([BJ)V", func
     });
 });
 
-Native.create("com/ibm/oti/connection/file/FCInputStream.openImpl.([B)I", function(ctx, path) {
+Native.create("com/ibm/oti/connection/file/FCInputStream.openImpl.([B)I", function(path) {
     return new Promise(function(resolve, reject) {
       fs.open(util.decodeUtf8(path), resolve);
     });
 });
 
-Native.create("com/ibm/oti/connection/file/FCInputStream.availableImpl.(I)I", function(ctx, fd) {
+Native.create("com/ibm/oti/connection/file/FCInputStream.availableImpl.(I)I", function(fd) {
     return fs.getsize(fd) - fs.getpos(fd);
 });
 
-Native.create("com/ibm/oti/connection/file/FCInputStream.skipImpl.(JI)J", function(ctx, count, _, fd) {
+Native.create("com/ibm/oti/connection/file/FCInputStream.skipImpl.(JI)J", function(count, _, fd) {
     var curpos = fs.getpos(fd);
     var size = fs.getsize(fd);
     if (curpos + count.toNumber() > size) {
@@ -475,7 +475,7 @@ Native.create("com/ibm/oti/connection/file/FCInputStream.skipImpl.(JI)J", functi
     return count;
 });
 
-Native.create("com/ibm/oti/connection/file/FCInputStream.readImpl.([BIII)I", function(ctx, buffer, offset, count, fd) {
+Native.create("com/ibm/oti/connection/file/FCInputStream.readImpl.([BIII)I", function(buffer, offset, count, fd) {
     if (offset < 0 || count < 0 || offset > buffer.byteLength || (buffer.byteLength - offset) < count) {
         throw new JavaException("java/lang/IndexOutOfBoundsException");
     }
@@ -491,7 +491,7 @@ Native.create("com/ibm/oti/connection/file/FCInputStream.readImpl.([BIII)I", fun
     return (data.byteLength > 0) ? data.byteLength : -1;
 });
 
-Native.create("com/ibm/oti/connection/file/FCInputStream.readByteImpl.(I)I", function(ctx, fd) {
+Native.create("com/ibm/oti/connection/file/FCInputStream.readByteImpl.(I)I", function(fd) {
     var curpos = fs.getpos(fd);
 
     var data = fs.read(fd, curpos, curpos+1);
@@ -499,13 +499,13 @@ Native.create("com/ibm/oti/connection/file/FCInputStream.readByteImpl.(I)I", fun
     return (data.byteLength > 0) ? data[0] : -1;
 });
 
-Native.create("com/ibm/oti/connection/file/FCInputStream.closeImpl.(I)V", function(ctx, fd) {
+Native.create("com/ibm/oti/connection/file/FCInputStream.closeImpl.(I)V", function(fd) {
     if (fd >= 0) {
       fs.close(fd);
     }
 });
 
-Native.create("com/ibm/oti/connection/file/FCOutputStream.closeImpl.(I)V", function(ctx, fd) {
+Native.create("com/ibm/oti/connection/file/FCOutputStream.closeImpl.(I)V", function(fd) {
     return new Promise(function(resolve, reject) {
         if (fd <= -1) {
             resolve();
@@ -519,7 +519,7 @@ Native.create("com/ibm/oti/connection/file/FCOutputStream.closeImpl.(I)V", funct
     });
 });
 
-Native.create("com/ibm/oti/connection/file/FCOutputStream.openImpl.([B)I", function(ctx, jPath) {
+Native.create("com/ibm/oti/connection/file/FCOutputStream.openImpl.([B)I", function(jPath) {
     var path = util.decodeUtf8(jPath);
 
     return new Promise(function(resolve, reject) {
@@ -545,7 +545,7 @@ Native.create("com/ibm/oti/connection/file/FCOutputStream.openImpl.([B)I", funct
     });
 });
 
-Native.create("com/ibm/oti/connection/file/FCOutputStream.openOffsetImpl.([BJ)I", function(ctx, jPath, offset, _) {
+Native.create("com/ibm/oti/connection/file/FCOutputStream.openOffsetImpl.([BJ)I", function(jPath, offset, _) {
     var path = util.decodeUtf8(jPath);
 
     return new Promise(function(resolve, reject) {
@@ -572,24 +572,24 @@ Native.create("com/ibm/oti/connection/file/FCOutputStream.openOffsetImpl.([BJ)I"
     });
 });
 
-Native.create("com/ibm/oti/connection/file/FCOutputStream.syncImpl.(I)V", function(ctx, fd) {
+Native.create("com/ibm/oti/connection/file/FCOutputStream.syncImpl.(I)V", function(fd) {
     return new Promise(function(resolve, reject) {
         fs.flush(fd, resolve);
     });
 });
 
-Native.create("com/ibm/oti/connection/file/FCOutputStream.writeByteImpl.(II)V", function(ctx, val, fd) {
+Native.create("com/ibm/oti/connection/file/FCOutputStream.writeByteImpl.(II)V", function(val, fd) {
     var buf = new Uint8Array(1);
     buf[0] = val;
     fs.write(fd, buf);
 });
 
 Native.create("com/ibm/oti/connection/file/FCOutputStream.writeImpl.([BIII)V",
-function(ctx, byteArray, offset, count, fd) {
+function(byteArray, offset, count, fd) {
     fs.write(fd, byteArray.subarray(offset, offset+count));
 });
 
-Native.create("com/sun/midp/io/j2me/storage/RandomAccessStream.open.(Ljava/lang/String;I)I", function(ctx, fileName, mode) {
+Native.create("com/sun/midp/io/j2me/storage/RandomAccessStream.open.(Ljava/lang/String;I)I", function(fileName, mode) {
     var path = "/" + util.fromJavaString(fileName);
 
     return new Promise(function(resolve, reject) {
@@ -622,7 +622,7 @@ Native.create("com/sun/midp/io/j2me/storage/RandomAccessStream.open.(Ljava/lang/
 });
 
 Native.create("com/sun/midp/io/j2me/storage/RandomAccessStream.read.(I[BII)I",
-function(ctx, handle, buffer, offset, length) {
+function(handle, buffer, offset, length) {
     var from = fs.getpos(handle);
     var to = from + length;
     var readBytes = fs.read(handle, from, to);
@@ -639,21 +639,21 @@ function(ctx, handle, buffer, offset, length) {
 });
 
 Native.create("com/sun/midp/io/j2me/storage/RandomAccessStream.write.(I[BII)V",
-function(ctx, handle, buffer, offset, length) {
+function(handle, buffer, offset, length) {
     fs.write(handle, buffer.subarray(offset, offset + length));
 });
 
-Native.create("com/sun/midp/io/j2me/storage/RandomAccessStream.commitWrite.(I)V", function(ctx, handle) {
+Native.create("com/sun/midp/io/j2me/storage/RandomAccessStream.commitWrite.(I)V", function(handle) {
     return new Promise(function(resolve, reject) {
         fs.flush(handle, resolve);
     });
 });
 
-Native.create("com/sun/midp/io/j2me/storage/RandomAccessStream.position.(II)V", function(ctx, handle, position) {
+Native.create("com/sun/midp/io/j2me/storage/RandomAccessStream.position.(II)V", function(handle, position) {
     fs.setpos(handle, position);
 });
 
-Native.create("com/sun/midp/io/j2me/storage/RandomAccessStream.sizeOf.(I)I", function(ctx, handle) {
+Native.create("com/sun/midp/io/j2me/storage/RandomAccessStream.sizeOf.(I)I", function(handle) {
     var size = fs.getsize(handle);
 
     if (size == -1) {
@@ -663,7 +663,7 @@ Native.create("com/sun/midp/io/j2me/storage/RandomAccessStream.sizeOf.(I)I", fun
     return size;
 });
 
-Native.create("com/sun/midp/io/j2me/storage/RandomAccessStream.close.(I)V", function(ctx, handle) {
+Native.create("com/sun/midp/io/j2me/storage/RandomAccessStream.close.(I)V", function(handle) {
     return new Promise(function(resolve, reject) {
         fs.flush(handle, function() {
             fs.close(handle);

--- a/midp/gfx.js
+++ b/midp/gfx.js
@@ -10,65 +10,65 @@
         return ids;
     });
 
-    Native.create("com/sun/midp/lcdui/DisplayDevice.getDisplayName0.(I)Ljava/lang/String;", function(ctx, id) {
+    Native.create("com/sun/midp/lcdui/DisplayDevice.getDisplayName0.(I)Ljava/lang/String;", function(id) {
         return null;
     });
 
-    Native.create("com/sun/midp/lcdui/DisplayDevice.isDisplayPrimary0.(I)Z", function(ctx, id) {
+    Native.create("com/sun/midp/lcdui/DisplayDevice.isDisplayPrimary0.(I)Z", function(id) {
         console.warn("DisplayDevice.isDisplayPrimary0.(I)Z not implemented (" + id + ")");
         return true;
     });
 
-    Native.create("com/sun/midp/lcdui/DisplayDevice.isbuildInDisplay0.(I)Z", function(ctx, id) {
+    Native.create("com/sun/midp/lcdui/DisplayDevice.isbuildInDisplay0.(I)Z", function(id) {
         return true;
     });
 
-    Native.create("com/sun/midp/lcdui/DisplayDevice.getDisplayCapabilities0.(I)I", function(ctx, id) {
+    Native.create("com/sun/midp/lcdui/DisplayDevice.getDisplayCapabilities0.(I)I", function(id) {
         return 0x3ff;
     });
 
-    Native.create("com/sun/midp/lcdui/DisplayDevice.isDisplayPenSupported0.(I)Z", function(ctx, id) {
+    Native.create("com/sun/midp/lcdui/DisplayDevice.isDisplayPenSupported0.(I)Z", function(id) {
         return true;
     });
 
-    Native.create("com/sun/midp/lcdui/DisplayDevice.isDisplayPenMotionSupported0.(I)Z", function(ctx, id) {
+    Native.create("com/sun/midp/lcdui/DisplayDevice.isDisplayPenMotionSupported0.(I)Z", function(id) {
         return true;
     });
 
-    Native.create("com/sun/midp/lcdui/DisplayDevice.getReverseOrientation0.(I)Z", function(ctx, id) {
+    Native.create("com/sun/midp/lcdui/DisplayDevice.getReverseOrientation0.(I)Z", function(id) {
         return false;
     });
 
-    Native.create("com/sun/midp/lcdui/DisplayDevice.getScreenWidth0.(I)I", function(ctx, id) {
+    Native.create("com/sun/midp/lcdui/DisplayDevice.getScreenWidth0.(I)I", function(id) {
         return MIDP.Context2D.canvas.width;
     });
 
-    Native.create("com/sun/midp/lcdui/DisplayDevice.getScreenHeight0.(I)I", function(ctx, id) {
+    Native.create("com/sun/midp/lcdui/DisplayDevice.getScreenHeight0.(I)I", function(id) {
         return MIDP.Context2D.canvas.height;
     });
 
-    Native.create("com/sun/midp/lcdui/DisplayDevice.displayStateChanged0.(II)V", function(ctx, hardwareId, state) {
+    Native.create("com/sun/midp/lcdui/DisplayDevice.displayStateChanged0.(II)V", function(hardwareId, state) {
         console.warn("DisplayDevice.displayStateChanged0.(II)V not implemented (" + hardwareId + ", " + state + ")");
     });
 
-    Native.create("com/sun/midp/lcdui/DisplayDevice.setFullScreen0.(IIZ)V", function(ctx, hardwareId, displayId, mode) {
+    Native.create("com/sun/midp/lcdui/DisplayDevice.setFullScreen0.(IIZ)V", function(hardwareId, displayId, mode) {
         console.warn("DisplayDevice.setFullScreen0.(IIZ)V not implemented (" +
                      hardwareId + ", " + displayId + ", " + mode + ")");
     });
 
-    Native.create("com/sun/midp/lcdui/DisplayDevice.gainedForeground0.(II)V", function(ctx, hardwareId, displayId) {
+    Native.create("com/sun/midp/lcdui/DisplayDevice.gainedForeground0.(II)V", function(hardwareId, displayId) {
         console.warn("DisplayDevice.gainedForeground0.(II)V not implemented (" + hardwareId + ", " + displayId + ")");
     });
 
-    Native.create("com/sun/midp/lcdui/DisplayDeviceAccess.vibrate0.(IZ)Z", function(ctx, displayId, on) {
+    Native.create("com/sun/midp/lcdui/DisplayDeviceAccess.vibrate0.(IZ)Z", function(displayId, on) {
         return true;
     });
 
-    Native.create("com/sun/midp/lcdui/DisplayDeviceAccess.isBacklightSupported0.(I)Z", function(ctx, displayId) {
+    Native.create("com/sun/midp/lcdui/DisplayDeviceAccess.isBacklightSupported0.(I)Z", function(displayId) {
         return true;
     });
 
-    Native.create("com/sun/midp/lcdui/DisplayDevice.refresh0.(IIIIII)V", function(ctx, hardwareId, displayId, x1, y1, x2, y2) {
+    Native.create("com/sun/midp/lcdui/DisplayDevice.refresh0.(IIIIII)V", function(hardwareId, displayId, x1, y1, x2, y2) {
         console.warn("DisplayDevice.refresh0.(IIIIII)V not implemented (" +
                      hardwareId + ", " + displayId + ", " + x1 + ", " + y1 + ", " + x2 + ", " + y2 + ")");
     });
@@ -149,7 +149,7 @@
     }
 
     Native.create("javax/microedition/lcdui/ImageDataFactory.createImmutableImageDecodeImage.(Ljavax/microedition/lcdui/ImageData;[BII)V",
-    function(ctx, imageData, bytes, offset, length) {
+    function(imageData, bytes, offset, length) {
         return new Promise(function(resolve, reject) {
             var blob = new Blob([bytes.subarray(offset, offset + length)], { type: "image/png" });
             var img = new Image();
@@ -165,7 +165,7 @@
     });
 
     Native.create("javax/microedition/lcdui/ImageDataFactory.createMutableImageData.(Ljavax/microedition/lcdui/ImageData;II)V",
-    function(ctx, imageData, width, height) {
+    function(imageData, width, height) {
         var context = createContext2d(width, height);
         context.fillStyle = "rgb(255,255,255)"; // white
         context.fillRect(0, 0, width, height);
@@ -173,22 +173,22 @@
     });
 
     Native.create("javax/microedition/lcdui/ImageDataFactory.createImmutableImageDecodeRGBImage.(Ljavax/microedition/lcdui/ImageData;[IIIZ)V",
-    function(ctx, imageData, rgbData, width, height, processAlpha) {
+    function(imageData, rgbData, width, height, processAlpha) {
         var context = createContext2d(width, height);
         rgbDataToContext(context, rgbData, 0, width, processAlpha ? swapRB : swapRBAndSetAlpha);
         setImageData(imageData, width, height, context);
     });
 
-    Native.create("javax/microedition/lcdui/ImageData.getRGB.([IIIIIII)V", function(ctx, rgbData, offset, scanlength, x, y, width, height) {
+    Native.create("javax/microedition/lcdui/ImageData.getRGB.([IIIIIII)V", function(rgbData, offset, scanlength, x, y, width, height) {
         contextToRgbData(convertNativeImageData(this), rgbData, offset, scanlength, x, y, width, height, swapRB);
     });
 
-    Native.create("com/nokia/mid/ui/DirectUtils.makeMutable.(Ljavax/microedition/lcdui/Image;)V", function(ctx, image) {
+    Native.create("com/nokia/mid/ui/DirectUtils.makeMutable.(Ljavax/microedition/lcdui/Image;)V", function(image) {
         var imageData = image.class.getField("I.imageData.Ljavax/microedition/lcdui/ImageData;").get(image);
         imageData.class.getField("I.isMutable.Z").set(imageData, 1);
     });
 
-    Native.create("com/nokia/mid/ui/DirectUtils.setPixels.(Ljavax/microedition/lcdui/Image;I)V", function(ctx, image, argb) {
+    Native.create("com/nokia/mid/ui/DirectUtils.setPixels.(Ljavax/microedition/lcdui/Image;I)V", function(image, argb) {
         var width = image.class.getField("I.width.I").get(image);
         var height = image.class.getField("I.height.I").get(image);
         var imageData = image.class.getField("I.imageData.Ljavax/microedition/lcdui/ImageData;").get(image);
@@ -222,7 +222,7 @@
     var SIZE_MEDIUM = 0;
     var SIZE_LARGE = 16;
 
-    Native.create("javax/microedition/lcdui/Font.init.(III)V", function(ctx, face, style, size) {
+    Native.create("javax/microedition/lcdui/Font.init.(III)V", function(face, style, size) {
         var defaultSize = Math.max(10, (MIDP.Context2D.canvas.height / 48) | 0);
         if (size & SIZE_SMALL)
             size = defaultSize / 1.25;
@@ -251,19 +251,19 @@
         this.css = style + " " + size + "pt " + face;
     });
 
-    Native.create("javax/microedition/lcdui/Font.stringWidth.(Ljava/lang/String;)I", function(ctx, str) {
+    Native.create("javax/microedition/lcdui/Font.stringWidth.(Ljava/lang/String;)I", function(str) {
         return withFont(this, MIDP.Context2D, util.fromJavaString(str));
     });
 
-    Native.create("javax/microedition/lcdui/Font.charWidth.(C)I", function(ctx, char) {
+    Native.create("javax/microedition/lcdui/Font.charWidth.(C)I", function(char) {
         return withFont(this, MIDP.Context2D, String.fromCharCode(char));
     });
 
-    Native.create("javax/microedition/lcdui/Font.charsWidth.([CII)I", function(ctx, str, offset, len) {
+    Native.create("javax/microedition/lcdui/Font.charsWidth.([CII)I", function(str, offset, len) {
         return withFont(this, MIDP.Context2D, util.fromJavaChars(str).slice(offset, offset + len));
     });
 
-    Native.create("javax/microedition/lcdui/Font.substringWidth.(Ljava/lang/String;II)I", function(ctx, str, offset, len) {
+    Native.create("javax/microedition/lcdui/Font.substringWidth.(Ljava/lang/String;II)I", function(str, offset, len) {
         return withFont(this, MIDP.Context2D, util.fromJavaString(str).slice(offset, offset + len));
     });
 
@@ -455,7 +455,7 @@
     }
 
     Override.create("com/sun/midp/chameleon/CGraphicsUtil.draw9pcsBackground.(Ljavax/microedition/lcdui/Graphics;IIII[Ljavax/microedition/lcdui/Image;)V",
-    function(ctx, g, x, y, w, h, image) {
+    function(g, x, y, w, h, image) {
         if (image == null || image.length != 9) {
             return;
         }
@@ -508,15 +508,15 @@
         transY.set(g, transY.get(g) - y);
     });
 
-    Native.create("javax/microedition/lcdui/Graphics.getDisplayColor.(I)I", function(ctx, color) {
+    Native.create("javax/microedition/lcdui/Graphics.getDisplayColor.(I)I", function(color) {
         return color;
     });
 
-    Native.create("javax/microedition/lcdui/Graphics.getPixel.(IIZ)I", function(ctx, rgb, gray, isGray) {
+    Native.create("javax/microedition/lcdui/Graphics.getPixel.(IIZ)I", function(rgb, gray, isGray) {
         return swapRB(rgb) | 0xff000000;
     });
 
-    Native.create("com/nokia/mid/ui/DirectGraphicsImp.setARGBColor.(I)V", function(ctx, rgba) {
+    Native.create("com/nokia/mid/ui/DirectGraphicsImp.setARGBColor.(I)V", function(rgba) {
         var g = this.class.getField("I.graphics.Ljavax/microedition/lcdui/Graphics;").get(this);
         var red = (rgba >> 16) & 0xff;
         var green = (rgba >> 8) & 0xff;
@@ -527,14 +527,14 @@
         g.class.getField("I.gray.I").set(g, (red * 76 + green * 150 + blue * 29) >> 8);
     });
 
-    Native.create("com/nokia/mid/ui/DirectGraphicsImp.getAlphaComponent.()I", function(ctx) {
+    Native.create("com/nokia/mid/ui/DirectGraphicsImp.getAlphaComponent.()I", function() {
         var g = this.class.getField("I.graphics.Ljavax/microedition/lcdui/Graphics;").get(this);
         var pixel = g.class.getField("I.pixel.I").get(g);
         return (pixel >> 24) & 0xff;
     });
 
     Native.create("com/nokia/mid/ui/DirectGraphicsImp.getPixels.([SIIIIIII)V",
-    function(ctx, pixels, offset, scanlength, x, y, width, height, format) {
+    function(pixels, offset, scanlength, x, y, width, height, format) {
         if (pixels == null) {
             throw new JavaException("java/lang/NullPointerException", "Pixels array is null");
         }
@@ -567,7 +567,7 @@
     });
 
     Native.create("com/nokia/mid/ui/DirectGraphicsImp.drawPixels.([SZIIIIIIII)V",
-    function(ctx, pixels, transparency, offset, scanlength, x, y, width, height, manipulation, format) {
+    function(pixels, transparency, offset, scanlength, x, y, width, height, manipulation, format) {
         if (pixels == null) {
             throw new JavaException("java/lang/NullPointerException", "Pixels array is null");
         }
@@ -596,12 +596,12 @@
         });
     });
 
-    Native.create("javax/microedition/lcdui/Graphics.render.(Ljavax/microedition/lcdui/Image;III)Z", function(ctx, image, x, y, anchor) {
+    Native.create("javax/microedition/lcdui/Graphics.render.(Ljavax/microedition/lcdui/Image;III)Z", function(image, x, y, anchor) {
         renderImage(this, image, x, y, anchor);
         return true;
     });
 
-    Native.create("javax/microedition/lcdui/Graphics.drawString.(Ljava/lang/String;III)V", function(ctx, jStr, x, y, anchor) {
+    Native.create("javax/microedition/lcdui/Graphics.drawString.(Ljava/lang/String;III)V", function(jStr, x, y, anchor) {
         var str = util.fromJavaString(jStr);
         var g = this;
         withGraphics(g, function(c) {
@@ -613,7 +613,7 @@
         });
     });
 
-    Native.create("javax/microedition/lcdui/Graphics.drawChars.([CIIIII)V", function(ctx, data, offset, len, x, y, anchor) {
+    Native.create("javax/microedition/lcdui/Graphics.drawChars.([CIIIII)V", function(data, offset, len, x, y, anchor) {
         var str = util.fromJavaChars(data, offset, len);
         var g = this;
         withGraphics(g, function(c) {
@@ -625,7 +625,7 @@
         });
     });
 
-    Native.create("javax/microedition/lcdui/Graphics.drawChar.(CIII)V", function(ctx, jChr, x, y, anchor) {
+    Native.create("javax/microedition/lcdui/Graphics.drawChar.(CIII)V", function(jChr, x, y, anchor) {
         var chr = String.fromCharCode(jChr);
         var g = this;
         withGraphics(g, function(c) {
@@ -637,7 +637,7 @@
         });
     });
 
-    Native.create("javax/microedition/lcdui/Graphics.fillTriangle.(IIIIII)V", function(ctx, x1, y1, x2, y2, x3, y3) {
+    Native.create("javax/microedition/lcdui/Graphics.fillTriangle.(IIIIII)V", function(x1, y1, x2, y2, x3, y3) {
         var g = this;
         withGraphics(g, function(c) {
             withClip(g, c, x1, y1, function(x, y) {
@@ -657,7 +657,7 @@
         });
     });
 
-    Native.create("javax/microedition/lcdui/Graphics.drawRect.(IIII)V", function(ctx, x, y, w, h) {
+    Native.create("javax/microedition/lcdui/Graphics.drawRect.(IIII)V", function(x, y, w, h) {
         if (w < 0 || h < 0) {
             return;
         }
@@ -673,7 +673,7 @@
         });
     });
 
-    Native.create("javax/microedition/lcdui/Graphics.drawRoundRect.(IIIIII)V", function(ctx, x, y, w, h, arcWidth, arcHeight) {
+    Native.create("javax/microedition/lcdui/Graphics.drawRoundRect.(IIIIII)V", function(x, y, w, h, arcWidth, arcHeight) {
         if (w < 0 || h < 0) {
             return;
         }
@@ -691,7 +691,7 @@
         });
     });
 
-    Native.create("javax/microedition/lcdui/Graphics.fillRect.(IIII)V", function(ctx, x, y, w, h) {
+    Native.create("javax/microedition/lcdui/Graphics.fillRect.(IIII)V", function(x, y, w, h) {
         if (w <= 0 || h <= 0) {
             return;
         }
@@ -707,7 +707,7 @@
         });
     });
 
-    Native.create("javax/microedition/lcdui/Graphics.fillRoundRect.(IIIIII)V", function(ctx, x, y, w, h, arcWidth, arcHeight) {
+    Native.create("javax/microedition/lcdui/Graphics.fillRoundRect.(IIIIII)V", function(x, y, w, h, arcWidth, arcHeight) {
         if (w <= 0 || h <= 0) {
             return;
         }
@@ -725,7 +725,7 @@
         });
     });
 
-    Native.create("javax/microedition/lcdui/Graphics.drawArc.(IIIIII)V", function(ctx, x, y, width, height, startAngle, arcAngle) {
+    Native.create("javax/microedition/lcdui/Graphics.drawArc.(IIIIII)V", function(x, y, width, height, startAngle, arcAngle) {
         if (width < 0 || height < 0) {
             return;
         }
@@ -741,7 +741,7 @@
         });
     });
 
-    Native.create("javax/microedition/lcdui/Graphics.fillArc.(IIIIII)V", function(ctx, x, y, width, height, startAngle, arcAngle) {
+    Native.create("javax/microedition/lcdui/Graphics.fillArc.(IIIIII)V", function(x, y, width, height, startAngle, arcAngle) {
         if (width <= 0 || height <= 0) {
             return;
         }
@@ -769,7 +769,7 @@
     var TRANS_MIRROR_ROT90 = 7;
 
     Override.create("javax/microedition/lcdui/Graphics.drawRegion.(Ljavax/microedition/lcdui/Image;IIIIIIII)V",
-    function(ctx, image, sx, sy, sw, sh, transform, x, y, anchor) {
+    function(image, sx, sy, sw, sh, transform, x, y, anchor) {
         if (!image) {
             throw new JavaException("java/lang/NullPointerException", "src image is null");
         }
@@ -801,7 +801,7 @@
         });
     });
 
-    Native.create("javax/microedition/lcdui/Graphics.drawLine.(IIII)V", function(ctx, x1, y1, x2, y2) {
+    Native.create("javax/microedition/lcdui/Graphics.drawLine.(IIII)V", function(x1, y1, x2, y2) {
         var dx = x2 - x1, dy = y2 - y1;
         var g = this;
         withGraphics(g, function(c) {
@@ -821,7 +821,7 @@
     });
 
     Native.create("javax/microedition/lcdui/Graphics.drawRGB.([IIIIIIIZ)V",
-    function(ctx, rgbData, offset, scanlength, x, y, width, height, processAlpha) {
+    function(rgbData, offset, scanlength, x, y, width, height, processAlpha) {
         var context = createContext2d(width, height);
         rgbDataToContext(context, rgbData, offset, scanlength, processAlpha ? swapRB : swapRBAndSetAlpha);
         var g = this;
@@ -845,7 +845,7 @@
     }
 
     Native.create("com/nokia/mid/ui/TextEditor.init.(Ljava/lang/String;IIII)I",
-    function(ctx, text, maxSize, constraints, width, height) {
+    function(text, maxSize, constraints, width, height) {
         if (constraints != 0) {
             console.warn("TextEditor.constraints not implemented");
         }
@@ -871,12 +871,12 @@
         return textEditorId;
     });
 
-    Native.create("com/nokia/mid/ui/CanvasItem.setSize.(II)V", function(ctx, width, height) {
+    Native.create("com/nokia/mid/ui/CanvasItem.setSize.(II)V", function(width, height) {
         this.textEditor.style.width = width + "px";
         this.textEditor.style.height = height + "px";
     });
 
-    Native.create("com/nokia/mid/ui/CanvasItem.setVisible.(Z)V", function(ctx, visible) {
+    Native.create("com/nokia/mid/ui/CanvasItem.setVisible.(Z)V", function(visible) {
         if (visible) {
             document.getElementById("display").appendChild(this.textEditor);
         } else if (this.visible) {
@@ -885,32 +885,32 @@
         this.visible = visible;
     });
 
-    Native.create("com/nokia/mid/ui/CanvasItem.getWidth.()I", function(ctx) {
+    Native.create("com/nokia/mid/ui/CanvasItem.getWidth.()I", function() {
         return parseInt(this.textEditor.style.width);
     });
 
-    Native.create("com/nokia/mid/ui/CanvasItem.getHeight.()I", function(ctx) {
+    Native.create("com/nokia/mid/ui/CanvasItem.getHeight.()I", function() {
         return parseInt(this.textEditor.style.height);
     });
 
-    Native.create("com/nokia/mid/ui/CanvasItem.setPosition.(II)V", function(ctx, x, y) {
+    Native.create("com/nokia/mid/ui/CanvasItem.setPosition.(II)V", function(x, y) {
         this.textEditor.style.left = x + "px";
         this.textEditor.style.top = y + "px";
     });
 
-    Native.create("com/nokia/mid/ui/CanvasItem.getPositionX.()I", function(ctx) {
+    Native.create("com/nokia/mid/ui/CanvasItem.getPositionX.()I", function() {
         return parseInt(this.textEditor.style.left) || 0;
     });
 
-    Native.create("com/nokia/mid/ui/CanvasItem.getPositionY.()I", function(ctx) {
+    Native.create("com/nokia/mid/ui/CanvasItem.getPositionY.()I", function() {
         return parseInt(this.textEditor.style.top) || 0;
     });
 
-    Native.create("com/nokia/mid/ui/CanvasItem.isVisible.()Z", function(ctx) {
+    Native.create("com/nokia/mid/ui/CanvasItem.isVisible.()Z", function() {
         return this.visible;
     });
 
-    Native.create("com/nokia/mid/ui/TextEditor.setFocus.(Z)V", function(ctx, focused) {
+    Native.create("com/nokia/mid/ui/TextEditor.setFocus.(Z)V", function(focused) {
         if (focused) {
             this.textEditor.focus();
         } else {
@@ -919,11 +919,11 @@
         this.focused = focused;
     });
 
-    Native.create("com/nokia/mid/ui/TextEditor.hasFocus.()Z", function(ctx) {
+    Native.create("com/nokia/mid/ui/TextEditor.hasFocus.()Z", function() {
         return this.focused;
     });
 
-    Native.create("com/nokia/mid/ui/TextEditor.setCaret.(I)V", function(ctx, index) {
+    Native.create("com/nokia/mid/ui/TextEditor.setCaret.(I)V", function(index) {
         if (!this.visible) {
             console.warn("setCaret ignored when TextEditor is invisible");
             return;
@@ -932,53 +932,53 @@
         this.textEditor.setSelectionRange(index, index);
     });
 
-    Native.create("com/nokia/mid/ui/TextEditor.getCaretPosition.()I", function(ctx) {
+    Native.create("com/nokia/mid/ui/TextEditor.getCaretPosition.()I", function() {
         return this.textEditor.selectionStart;
     });
 
-    Native.create("com/nokia/mid/ui/TextEditor.getBackgroundColor.()I", function(ctx) {
+    Native.create("com/nokia/mid/ui/TextEditor.getBackgroundColor.()I", function() {
         return this.backgroundColor;
     });
-    Native.create("com/nokia/mid/ui/TextEditor.getForegroundColor.()I", function(ctx) {
+    Native.create("com/nokia/mid/ui/TextEditor.getForegroundColor.()I", function() {
         return this.foregroundColor;
     });
-    Native.create("com/nokia/mid/ui/TextEditor.setBackgroundColor.(I)V", function(ctx, backgroundColor) {
+    Native.create("com/nokia/mid/ui/TextEditor.setBackgroundColor.(I)V", function(backgroundColor) {
         this.backgroundColor = backgroundColor;
         this.textEditor.style.backgroundColor = abgrIntToCSS(backgroundColor);
     });
-    Native.create("com/nokia/mid/ui/TextEditor.setForegroundColor.(I)V", function(ctx, foregroundColor) {
+    Native.create("com/nokia/mid/ui/TextEditor.setForegroundColor.(I)V", function(foregroundColor) {
         this.foregroundColor = foregroundColor;
         this.textEditor.style.color = abgrIntToCSS(foregroundColor);
     });
 
-    Native.create("com/nokia/mid/ui/TextEditor.getContent.()Ljava/lang/String;", function(ctx) {
+    Native.create("com/nokia/mid/ui/TextEditor.getContent.()Ljava/lang/String;", function() {
         return this.textEditor.value;
     });
 
-    Native.create("com/nokia/mid/ui/TextEditor.setContent.(Ljava/lang/String;)V", function(ctx, str) {
+    Native.create("com/nokia/mid/ui/TextEditor.setContent.(Ljava/lang/String;)V", function(str) {
         this.textEditor.value = util.fromJavaString(str);
     });
 
-    Native.create("com/nokia/mid/ui/TextEditor.insert.(Ljava/lang/String;I)V", function(ctx, str, pos) {
+    Native.create("com/nokia/mid/ui/TextEditor.insert.(Ljava/lang/String;I)V", function(str, pos) {
         var old = this.textEditor.value;
         this.textEditor.value = old.slice(0, pos) + util.fromJavaString(str) + old.slice(pos);
     });
 
-    Native.create("com/nokia/mid/ui/TextEditor.delete.(II)V", function(ctx, offset, length) {
+    Native.create("com/nokia/mid/ui/TextEditor.delete.(II)V", function(offset, length) {
         var old = _this.textEditor.value;
 
         if (offset < 0 || offset > old.length || length < 0 || offset + length > old.length) {
-            ctx.raiseExceptionAndYield("java.lang.StringIndexOutOfBoundsException", "offset/length invalid");
+            throw new JavaException("java.lang.StringIndexOutOfBoundsException", "offset/length invalid");
         }
 
         this.textEditor.value = old.slice(0, offset) + old.slice(offset + length);
     });
 
-    Native.create("com/nokia/mid/ui/TextEditor.getMaxSize.()I", function(ctx) {
+    Native.create("com/nokia/mid/ui/TextEditor.getMaxSize.()I", function() {
         return parseInt(this.textEditor.getAttribute("maxlength"));
     });
 
-    Native.create("com/nokia/mid/ui/TextEditor.setMaxSize.(I)I", function(ctx, maxSize) {
+    Native.create("com/nokia/mid/ui/TextEditor.setMaxSize.(I)I", function(maxSize) {
         this.textEditor.setAttribute("maxlength", maxSize);
         this.textEditor.value = this.textEditor.value.substring(0, maxSize);
 
@@ -988,11 +988,11 @@
         return maxSize;
     });
 
-    Native.create("com/nokia/mid/ui/TextEditor.size.()I", function(ctx) {
+    Native.create("com/nokia/mid/ui/TextEditor.size.()I", function() {
         return this.textEditor.value.length;
     });
 
-    Native.create("com/nokia/mid/ui/TextEditorThread.sleep.()V", function(ctx) {
+    Native.create("com/nokia/mid/ui/TextEditorThread.sleep.()V", function() {
         return new Promise(function(resolve, reject) {
           if (!dirtyEditors.length) {
               textEditorResolve = resolve;
@@ -1000,7 +1000,7 @@
         });
     });
 
-    Native.create("com/nokia/mid/ui/TextEditorThread.getNextDirtyEditor.()I", function(ctx) {
+    Native.create("com/nokia/mid/ui/TextEditorThread.getNextDirtyEditor.()I", function() {
         if (!dirtyEditors.length) {
             console.error("ERROR: getNextDirtyEditor called but no dirty editors");
             return 0;

--- a/midp/localmsg.js
+++ b/midp/localmsg.js
@@ -352,7 +352,7 @@ MIDP.LocalMsgConnections["nokia.contacts"] = new NokiaContactsLocalMsgConnection
 MIDP.LocalMsgConnections["nokia.messaging"] = new NokiaMessagingLocalMsgConnection();
 MIDP.LocalMsgConnections["nokia.phone-status"] = new NokiaPhoneStatusLocalMsgConnection();
 
-Native.create("org/mozilla/io/LocalMsgConnection.init.(Ljava/lang/String;)V", function(ctx, jName) {
+Native.create("org/mozilla/io/LocalMsgConnection.init.(Ljava/lang/String;)V", function(jName) {
     var name = util.fromJavaString(jName);
 
     this.server = (name[2] == ":");
@@ -384,11 +384,11 @@ Native.create("org/mozilla/io/LocalMsgConnection.init.(Ljava/lang/String;)V", fu
     }).bind(this));
 });
 
-Native.create("org/mozilla/io/LocalMsgConnection.waitConnection.()V", function(ctx) {
+Native.create("org/mozilla/io/LocalMsgConnection.waitConnection.()V", function() {
     return MIDP.LocalMsgConnections[this.protocolName].waitConnection();
 });
 
-Native.create("org/mozilla/io/LocalMsgConnection.sendData.([BII)V", function(ctx, data, offset, length) {
+Native.create("org/mozilla/io/LocalMsgConnection.sendData.([BII)V", function(data, offset, length) {
     var message = {
       data: data,
       offset: offset,
@@ -406,7 +406,7 @@ Native.create("org/mozilla/io/LocalMsgConnection.sendData.([BII)V", function(ctx
     }
 });
 
-Native.create("org/mozilla/io/LocalMsgConnection.receiveData.([B)I", function(ctx, data) {
+Native.create("org/mozilla/io/LocalMsgConnection.receiveData.([B)I", function(data) {
     if (this.server) {
         return MIDP.LocalMsgConnections[this.protocolName].serverReceiveMessage(data);
     }
@@ -418,7 +418,7 @@ Native.create("org/mozilla/io/LocalMsgConnection.receiveData.([B)I", function(ct
     return MIDP.LocalMsgConnections[this.protocolName].clientReceiveMessage(data);
 });
 
-Native.create("org/mozilla/io/LocalMsgConnection.closeConnection.()V", function(ctx) {
+Native.create("org/mozilla/io/LocalMsgConnection.closeConnection.()V", function() {
     if (this.server) {
         delete MIDP.LocalMsgConnections[this.protocolName];
     }

--- a/midp/midp.js
+++ b/midp/midp.js
@@ -8,7 +8,7 @@ var MIDP = {
 
 MIDP.manifest = {};
 
-Native.create("com/sun/midp/jarutil/JarReader.readJarEntry0.(Ljava/lang/String;Ljava/lang/String;)[B", function(ctx, jar, entryName) {
+Native.create("com/sun/midp/jarutil/JarReader.readJarEntry0.(Ljava/lang/String;Ljava/lang/String;)[B", function(jar, entryName, ctx) {
     var bytes = CLASSES.loadFileFromJar(util.fromJavaString(jar), util.fromJavaString(entryName));
     if (!bytes)
         throw new JavaException("java/io/IOException");
@@ -20,7 +20,7 @@ Native.create("com/sun/midp/jarutil/JarReader.readJarEntry0.(Ljava/lang/String;L
     return array;
 });
 
-Native.create("com/sun/midp/log/LoggingBase.report.(IILjava/lang/String;)V", function(ctx, severity, channelID, message) {
+Native.create("com/sun/midp/log/LoggingBase.report.(IILjava/lang/String;)V", function(severity, channelID, message) {
     console.info(util.fromJavaString(message));
 });
 
@@ -141,7 +141,7 @@ MIDP.messagesTBL = [
      ["satsa"]
 ];
 
-Native.create("com/sun/midp/security/Permissions.getGroupMessages.(Ljava/lang/String;)[Ljava/lang/String;", function(ctx, jName) {
+Native.create("com/sun/midp/security/Permissions.getGroupMessages.(Ljava/lang/String;)[Ljava/lang/String;", function(jName, ctx) {
     var name = util.fromJavaString(jName);
     var list = null;
     MIDP.groupTBL.forEach(function(e, n) {
@@ -209,7 +209,7 @@ MIDP.membersTBL = [
     ["javax.microedition.apdu.sat"],
 ];
 
-Native.create("com/sun/midp/security/Permissions.loadGroupPermissions.(Ljava/lang/String;)[Ljava/lang/String;", function(ctx, jName) {
+Native.create("com/sun/midp/security/Permissions.loadGroupPermissions.(Ljava/lang/String;)[Ljava/lang/String;", function(jName, ctx) {
     var name = util.fromJavaString(jName);
     var list = null;
     MIDP.groupTBL.forEach(function(e, n) {
@@ -224,7 +224,7 @@ Native.create("com/sun/midp/security/Permissions.loadGroupPermissions.(Ljava/lan
     return list;
 });
 
-Native.create("com/sun/midp/main/CldcPlatformRequest.dispatchPlatformRequest.(Ljava/lang/String;)Z", function(ctx, request) {
+Native.create("com/sun/midp/main/CldcPlatformRequest.dispatchPlatformRequest.(Ljava/lang/String;)Z", function(request) {
     request = util.fromJavaString(request);
     if (request.startsWith("http://") || request.startsWith("https://")) {
       window.open(request);
@@ -233,7 +233,7 @@ Native.create("com/sun/midp/main/CldcPlatformRequest.dispatchPlatformRequest.(Lj
     }
 });
 
-Native.create("com/sun/midp/main/CommandState.restoreCommandState.(Lcom/sun/midp/main/CommandState;)V", function(ctx, state) {
+Native.create("com/sun/midp/main/CommandState.restoreCommandState.(Lcom/sun/midp/main/CommandState;)V", function(state, ctx) {
     var suiteId = (MIDP.midletClassName === "internal") ? -1 : 1;
     state.class.getField("I.suiteId.I").set(state, suiteId);
     state.class.getField("I.midletClassName.Ljava/lang/String;").set(state, ctx.newString(MIDP.midletClassName));
@@ -304,7 +304,7 @@ MIDP.unidentifiedTBL = {
     satsa: { max: MIDP.NEVER,   default: MIDP.NEVER},
 };
 
-Native.create("com/sun/midp/security/Permissions.getDefaultValue.(Ljava/lang/String;Ljava/lang/String;)B", function(ctx, domain, group) {
+Native.create("com/sun/midp/security/Permissions.getDefaultValue.(Ljava/lang/String;Ljava/lang/String;)B", function(domain, group) {
     var allow = MIDP.NEVER;
     switch (util.fromJavaString(domain)) {
     case "manufacturer":
@@ -322,7 +322,7 @@ Native.create("com/sun/midp/security/Permissions.getDefaultValue.(Ljava/lang/Str
     return allow;
 });
 
-Native.create("com/sun/midp/security/Permissions.getMaxValue.(Ljava/lang/String;Ljava/lang/String;)B", function(ctx, domain, group) {
+Native.create("com/sun/midp/security/Permissions.getMaxValue.(Ljava/lang/String;Ljava/lang/String;)B", function(domain, group) {
     var allow = MIDP.NEVER;
     switch (util.fromJavaString(domain)) {
     case "manufacturer":
@@ -340,7 +340,7 @@ Native.create("com/sun/midp/security/Permissions.getMaxValue.(Ljava/lang/String;
     return allow;
 });
 
-Native.create("com/sun/midp/security/Permissions.loadingFinished.()V", function(ctx) {
+Native.create("com/sun/midp/security/Permissions.loadingFinished.()V", function() {
     console.warn("Permissions.loadingFinished.()V not implemented");
 });
 
@@ -352,7 +352,7 @@ Native.create("com/sun/midp/main/MIDletSuiteUtils.registerAmsIsolateId.()V", fun
     MIDP.AMSIsolateId = ctx.runtime.isolate.id;
 });
 
-Native.create("com/sun/midp/main/MIDletSuiteUtils.getAmsIsolateId.()I", function(ctx) {
+Native.create("com/sun/midp/main/MIDletSuiteUtils.getAmsIsolateId.()I", function() {
     return MIDP.AMSIsolateId;
 });
 
@@ -360,7 +360,7 @@ Native.create("com/sun/midp/main/MIDletSuiteUtils.isAmsIsolate.()Z", function(ct
     return MIDP.AMSIsolateId == ctx.runtime.isolate.id;
 });
 
-Native.create("com/sun/midp/main/MIDletSuiteUtils.vmBeginStartUp.(I)V", function(ctx, midletIsolateId) {
+Native.create("com/sun/midp/main/MIDletSuiteUtils.vmBeginStartUp.(I)V", function(midletIsolateId) {
     // See DisplayContainer::createDisplayId, called by the LCDUIEnvironment constructor,
     // called by CldcMIDletSuiteLoader::createSuiteEnvironment.
     // The formula depens on the ID of the isolate that calls createDisplayId, that is
@@ -369,14 +369,14 @@ Native.create("com/sun/midp/main/MIDletSuiteUtils.vmBeginStartUp.(I)V", function
     MIDP.displayId = ((midletIsolateId & 0xff)<<24) | (1 & 0x00ffffff);
 });
 
-Native.create("com/sun/midp/main/MIDletSuiteUtils.vmEndStartUp.(I)V", function(ctx, midletIsolateId) {
+Native.create("com/sun/midp/main/MIDletSuiteUtils.vmEndStartUp.(I)V", function(midletIsolateId) {
 });
 
-Native.create("com/sun/midp/main/AppIsolateMIDletSuiteLoader.allocateReservedResources0.()Z", function(ctx) {
+Native.create("com/sun/midp/main/AppIsolateMIDletSuiteLoader.allocateReservedResources0.()Z", function() {
   return true;
 });
 
-Native.create("com/sun/midp/main/Configuration.getProperty0.(Ljava/lang/String;)Ljava/lang/String;", function(ctx, key) {
+Native.create("com/sun/midp/main/Configuration.getProperty0.(Ljava/lang/String;)Ljava/lang/String;", function(key) {
     var value;
     switch (util.fromJavaString(key)) {
     case "com.sun.midp.publickeystore.WebPublicKeyStore":
@@ -424,7 +424,7 @@ Native.create("com/sun/midp/main/Configuration.getProperty0.(Ljava/lang/String;)
     return value ? value : null;
 });
 
-Native.create("com/sun/midp/chameleon/skins/resources/LoadedSkinData.beginReadingSkinFile.(Ljava/lang/String;)V", function(ctx, fileName) {
+Native.create("com/sun/midp/chameleon/skins/resources/LoadedSkinData.beginReadingSkinFile.(Ljava/lang/String;)V", function(fileName) {
     var data = CLASSES.loadFile(util.fromJavaString(fileName));
     if (!data)
         throw new JavaException("java/io/IOException");
@@ -432,7 +432,7 @@ Native.create("com/sun/midp/chameleon/skins/resources/LoadedSkinData.beginReadin
     MIDP.skinFilePos = 0;
 });
 
-Native.create("com/sun/midp/chameleon/skins/resources/LoadedSkinData.readByteArray.(I)[B", function(ctx, len) {
+Native.create("com/sun/midp/chameleon/skins/resources/LoadedSkinData.readByteArray.(I)[B", function(len, ctx) {
     if (!MIDP.skinFileData || (MIDP.skinFilePos + len) > MIDP.skinFileData.byteLength)
         throw new JavaException("java/lang/IllegalStateException");
     var bytes = ctx.newPrimitiveArray("B", len);
@@ -490,7 +490,7 @@ Native.create("com/sun/midp/chameleon/skins/resources/LoadedSkinData.readStringA
     return strings;
 });
 
-Native.create("com/sun/midp/chameleon/skins/resources/LoadedSkinData.finishReadingSkinFile.()I", function(ctx) {
+Native.create("com/sun/midp/chameleon/skins/resources/LoadedSkinData.finishReadingSkinFile.()I", function() {
     MIDP.skinFileData = null;
     MIDP.skinFilePos = 0;
     return 0;
@@ -499,27 +499,27 @@ Native.create("com/sun/midp/chameleon/skins/resources/LoadedSkinData.finishReadi
 MIDP.sharedPool = null;
 MIDP.sharedSkinData = null;
 
-Native.create("com/sun/midp/chameleon/skins/resources/SkinResourcesImpl.shareResourcePool.(Ljava/lang/Object;)V", function(ctx, pool) {
+Native.create("com/sun/midp/chameleon/skins/resources/SkinResourcesImpl.shareResourcePool.(Ljava/lang/Object;)V", function(pool) {
     MIDP.sharedPool = pool;
 });
 
-Native.create("com/sun/midp/chameleon/skins/resources/SkinResourcesImpl.getSharedResourcePool.()Ljava/lang/Object;", function(ctx) {
+Native.create("com/sun/midp/chameleon/skins/resources/SkinResourcesImpl.getSharedResourcePool.()Ljava/lang/Object;", function() {
     return MIDP.sharedPool;
 });
 
-Native.create("com/sun/midp/chameleon/skins/resources/SkinResourcesImpl.shareSkinData.(Ljava/lang/Object;)V", function(ctx, skinData) {
+Native.create("com/sun/midp/chameleon/skins/resources/SkinResourcesImpl.shareSkinData.(Ljava/lang/Object;)V", function(skinData) {
     MIDP.sharedSkinData = skinData;
 });
 
-Native.create("com/sun/midp/chameleon/skins/resources/SkinResourcesImpl.getSharedSkinData.()Ljava/lang/Object;", function(ctx) {
+Native.create("com/sun/midp/chameleon/skins/resources/SkinResourcesImpl.getSharedSkinData.()Ljava/lang/Object;", function() {
     return MIDP.sharedSkinData;
 });
 
-Native.create("com/sun/midp/chameleon/skins/resources/SkinResourcesImpl.ifLoadAllResources0.()Z", function(ctx) {
+Native.create("com/sun/midp/chameleon/skins/resources/SkinResourcesImpl.ifLoadAllResources0.()Z", function() {
     return false;
 });
 
-Native.create("com/sun/midp/util/ResourceHandler.loadRomizedResource0.(Ljava/lang/String;)[B", function(ctx, file) {
+Native.create("com/sun/midp/util/ResourceHandler.loadRomizedResource0.(Ljava/lang/String;)[B", function(file, ctx) {
     var fileName = "assets/0/" + util.fromJavaString(file).replace("_", ".").replace("_png", ".png");
     var data = CLASSES.loadFile(fileName);
     if (!data) {
@@ -534,7 +534,7 @@ Native.create("com/sun/midp/util/ResourceHandler.loadRomizedResource0.(Ljava/lan
     return bytes;
 });
 
-Native.create("com/sun/midp/chameleon/layers/SoftButtonLayer.isNativeSoftButtonLayerSupported0.()Z", function(ctx) {
+Native.create("com/sun/midp/chameleon/layers/SoftButtonLayer.isNativeSoftButtonLayerSupported0.()Z", function() {
     return false;
 });
 
@@ -594,46 +594,46 @@ MIDP.Context2D = (function() {
     return c.getContext("2d");
 })();
 
-Native.create("com/sun/midp/midletsuite/MIDletSuiteStorage.loadSuitesIcons0.()I", function(ctx) {
+Native.create("com/sun/midp/midletsuite/MIDletSuiteStorage.loadSuitesIcons0.()I", function() {
     return 0;
 });
 
-Native.create("com/sun/midp/midletsuite/MIDletSuiteStorage.suiteExists.(I)Z", function(ctx, id) {
+Native.create("com/sun/midp/midletsuite/MIDletSuiteStorage.suiteExists.(I)Z", function(id) {
     return id <= 1;
 });
 
-Native.create("com/sun/midp/midletsuite/MIDletSuiteStorage.suiteIdToString.(I)Ljava/lang/String;", function(ctx, id) {
+Native.create("com/sun/midp/midletsuite/MIDletSuiteStorage.suiteIdToString.(I)Ljava/lang/String;", function(id) {
     return id.toString();
 });
 
-Native.create("com/sun/midp/midletsuite/MIDletSuiteStorage.getMidletSuiteStorageId.(I)I", function(ctx, suiteId) {
+Native.create("com/sun/midp/midletsuite/MIDletSuiteStorage.getMidletSuiteStorageId.(I)I", function(suiteId) {
     // We should be able to use the same storage ID for all MIDlet suites.
     return 0; // storageId
 });
 
-Native.create("com/sun/midp/midletsuite/MIDletSuiteStorage.getMidletSuiteJarPath.(I)Ljava/lang/String;", function(ctx, id) {
+Native.create("com/sun/midp/midletsuite/MIDletSuiteStorage.getMidletSuiteJarPath.(I)Ljava/lang/String;", function(id) {
     return "";
 });
 
-Native.create("com/sun/midp/midletsuite/MIDletSuiteImpl.lockMIDletSuite.(IZ)V", function(ctx, id, lock) {
+Native.create("com/sun/midp/midletsuite/MIDletSuiteImpl.lockMIDletSuite.(IZ)V", function(id, lock) {
     console.warn("MIDletSuiteImpl.lockMIDletSuite.(IZ)V not implemented (" + id + ", " + lock + ")");
 });
 
-Native.create("com/sun/midp/midletsuite/MIDletSuiteImpl.unlockMIDletSuite.(I)V", function(ctx, suiteId) {
+Native.create("com/sun/midp/midletsuite/MIDletSuiteImpl.unlockMIDletSuite.(I)V", function(suiteId) {
     console.warn("MIDletSuiteImpl.unlockMIDletSuite.(I)V not implemented (" + suiteId + ")");
 });
 
-Native.create("com/sun/midp/midletsuite/SuiteSettings.load.()V", function(ctx) {
+Native.create("com/sun/midp/midletsuite/SuiteSettings.load.()V", function() {
     this.class.getField("I.pushInterruptSetting.B").set(this, 1);
     console.warn("com/sun/midp/midletsuite/SuiteSettings.load.()V incomplete");
 });
 
-Native.create("com/sun/midp/midletsuite/SuiteSettings.save0.(IBI[B)V", function(ctx, suiteId, pushInterruptSetting, pushOptions, permissions) {
+Native.create("com/sun/midp/midletsuite/SuiteSettings.save0.(IBI[B)V", function(suiteId, pushInterruptSetting, pushOptions, permissions) {
     console.warn("SuiteSettings.save0.(IBI[B)V not implemented (" +
                  suiteId + ", " + pushInterruptSetting + ", " + pushOptions + ", " + permissions + ")");
 });
 
-Native.create("com/sun/midp/midletsuite/InstallInfo.load.()V", function(ctx) {
+Native.create("com/sun/midp/midletsuite/InstallInfo.load.()V", function() {
     // The MIDlet has to be trusted for opening SSL connections using port 443.
     this.class.getField("I.trusted.Z").set(this, 1);
     console.warn("com/sun/midp/midletsuite/InstallInfo.load.()V incomplete");
@@ -650,7 +650,7 @@ Native.create("com/sun/midp/midletsuite/SuiteProperties.load.()[Ljava/lang/Strin
     return arr;
 });
 
-Native.create("javax/microedition/lcdui/SuiteImageCacheImpl.loadAndCreateImmutableImageDataFromCache0.(Ljavax/microedition/lcdui/ImageData;ILjava/lang/String;)Z", function(ctx, imageData, suiteId, fileName) {
+Native.create("javax/microedition/lcdui/SuiteImageCacheImpl.loadAndCreateImmutableImageDataFromCache0.(Ljavax/microedition/lcdui/ImageData;ILjava/lang/String;)Z", function(imageData, suiteId, fileName) {
     console.warn("SuiteImageCacheImpl.loadAndCreateImmutableImageDataFromCache0.(L...ImageData;IL...String;)Z " +
                  "not implemented (" + imageData + ", " + suiteId + ", " + util.fromJavaString(fileName) + ")");
     return false;
@@ -659,7 +659,7 @@ Native.create("javax/microedition/lcdui/SuiteImageCacheImpl.loadAndCreateImmutab
 MIDP.InterIsolateMutexes = [];
 MIDP.LastInterIsolateMutexID = -1;
 
-Native.create("com/sun/midp/util/isolate/InterIsolateMutex.getID0.(Ljava/lang/String;)I", function(ctx, jName) {
+Native.create("com/sun/midp/util/isolate/InterIsolateMutex.getID0.(Ljava/lang/String;)I", function(jName) {
     var name = util.fromJavaString(jName);
 
     var mutex;
@@ -682,7 +682,7 @@ Native.create("com/sun/midp/util/isolate/InterIsolateMutex.getID0.(Ljava/lang/St
     return mutex.id;
 });
 
-Native.create("com/sun/midp/util/isolate/InterIsolateMutex.lock0.(I)V", function(ctx, id) {
+Native.create("com/sun/midp/util/isolate/InterIsolateMutex.lock0.(I)V", function(id, ctx) {
     return new Promise(function(resolve, reject) {
         var mutex;
         for (var i = 0; i < MIDP.InterIsolateMutexes.length; i++) {
@@ -717,7 +717,7 @@ Native.create("com/sun/midp/util/isolate/InterIsolateMutex.lock0.(I)V", function
     });
 });
 
-Native.create("com/sun/midp/util/isolate/InterIsolateMutex.unlock0.(I)V", function(ctx, id) {
+Native.create("com/sun/midp/util/isolate/InterIsolateMutex.unlock0.(I)V", function(id, ctx) {
     var mutex;
     for (var i = 0; i < MIDP.InterIsolateMutexes.length; i++) {
         if (MIDP.InterIsolateMutexes[i].id == id) {
@@ -812,21 +812,21 @@ window.addEventListener("keypress", function(ev) {
     MIDP.keyPress(ev.which);
 });
 
-Native.create("com/sun/midp/events/EventQueue.getNativeEventQueueHandle.()I", function(ctx) {
+Native.create("com/sun/midp/events/EventQueue.getNativeEventQueueHandle.()I", function() {
     return 0;
 });
 
-Native.create("com/sun/midp/events/EventQueue.resetNativeEventQueue.()V", function(ctx) {
+Native.create("com/sun/midp/events/EventQueue.resetNativeEventQueue.()V", function() {
     console.warn("EventQueue.resetNativeEventQueue.()V not implemented");
 });
 
 Native.create("com/sun/midp/events/EventQueue.sendNativeEventToIsolate.(Lcom/sun/midp/events/NativeEvent;I)V",
-function(ctx, obj, isolateId) {
+function(obj, isolateId) {
     MIDP.sendEvent(obj, isolateId);
 });
 
 Native.create("com/sun/midp/events/NativeEventMonitor.waitForNativeEvent.(Lcom/sun/midp/events/NativeEvent;)I",
-function(ctx, nativeEvent) {
+function(nativeEvent, ctx) {
     return new Promise(function(resolve, reject) {
         var isolateId = ctx.runtime.isolate.id;
 
@@ -847,7 +847,7 @@ function(ctx, nativeEvent) {
 });
 
 Native.create("com/sun/midp/events/NativeEventMonitor.readNativeEvent.(Lcom/sun/midp/events/NativeEvent;)Z",
-function(ctx, obj) {
+function(obj, ctx) {
     if (!MIDP.nativeEventQueues[ctx.runtime.isolate.id].length) {
         return false;
     }
@@ -857,7 +857,7 @@ function(ctx, obj) {
 
 MIDP.localizedStrings = new Map();
 
-Native.create("com/sun/midp/l10n/LocalizedStringsBase.getContent.(I)Ljava/lang/String;", function(ctx, id) {
+Native.create("com/sun/midp/l10n/LocalizedStringsBase.getContent.(I)Ljava/lang/String;", function(id) {
     if (MIDP.localizedStrings.size === 0) {
         // First build up a mapping of field names to field IDs
         var classInfo = CLASSES.getClass("com/sun/midp/i18n/ResourceConstants");
@@ -891,7 +891,7 @@ Native.create("com/sun/midp/l10n/LocalizedStringsBase.getContent.(I)Ljava/lang/S
     return value;
 });
 
-Native.create("javax/microedition/lcdui/Display.drawTrustedIcon0.(IZ)V", function(ctx, displayId, drawTrusted) {
+Native.create("javax/microedition/lcdui/Display.drawTrustedIcon0.(IZ)V", function(displayId, drawTrusted) {
     console.warn("Display.drawTrustedIcon0.(IZ)V not implemented (" + displayId + ", " + drawTrusted + ")");
 });
 
@@ -901,16 +901,16 @@ Native.create("com/sun/midp/events/EventQueue.sendShutdownEvent.()V", function(c
     MIDP.sendEvent(obj, ctx.runtime.isolate.id);
 });
 
-Native.create("com/sun/midp/main/CommandState.saveCommandState.(Lcom/sun/midp/main/CommandState;)V", function(ctx, commandState) {
+Native.create("com/sun/midp/main/CommandState.saveCommandState.(Lcom/sun/midp/main/CommandState;)V", function(commandState) {
     console.warn("CommandState.saveCommandState.(L...CommandState;)V not implemented (" + commandState + ")");
 });
 
-Native.create("com/sun/midp/main/CommandState.exitInternal.(I)V", function(ctx, exit) {
+Native.create("com/sun/midp/main/CommandState.exitInternal.(I)V", function(exit) {
     console.info("Exit: " + exit);
     return new Promise(function(){});
 });
 
-Native.create("com/sun/midp/suspend/SuspendSystem$MIDPSystem.allMidletsKilled.()Z", function(ctx) {
+Native.create("com/sun/midp/suspend/SuspendSystem$MIDPSystem.allMidletsKilled.()Z", function() {
     console.warn("SuspendSystem$MIDPSystem.allMidletsKilled.()Z not implemented");
     return false;
 });
@@ -938,7 +938,7 @@ MIDP.systemKeyMap = {
   114: MIDP.SYSTEM_KEY_END, // F3
 };
 
-Native.create("javax/microedition/lcdui/KeyConverter.getSystemKey.(I)I", function(ctx, key) {
+Native.create("javax/microedition/lcdui/KeyConverter.getSystemKey.(I)I", function(key) {
     return MIDP.systemKeyMap[key] || 0;
 });
 
@@ -954,7 +954,7 @@ MIDP.keyMap = {
     12: 99, // GAME_D
 };
 
-Native.create("javax/microedition/lcdui/KeyConverter.getKeyCode.(I)I", function(ctx, key) {
+Native.create("javax/microedition/lcdui/KeyConverter.getKeyCode.(I)I", function(key) {
     return MIDP.keyMap[key] || 0;
 });
 
@@ -970,7 +970,7 @@ MIDP.keyNames = {
     99: "Mail",
 };
 
-Native.create("javax/microedition/lcdui/KeyConverter.getKeyName.(I)Ljava/lang/String;", function(ctx, keyCode) {
+Native.create("javax/microedition/lcdui/KeyConverter.getKeyName.(I)Ljava/lang/String;", function(keyCode) {
     return (keyCode in MIDP.keyNames) ? MIDP.keyNames[keyCode] : String.fromCharCode(keyCode);
 });
 
@@ -986,19 +986,19 @@ MIDP.gameKeys = {
     99: 12   // GAME_D
 };
 
-Native.create("javax/microedition/lcdui/KeyConverter.getGameAction.(I)I", function(ctx, keyCode) {
+Native.create("javax/microedition/lcdui/KeyConverter.getGameAction.(I)I", function(keyCode) {
     return MIDP.gameKeys[keyCode] || 0;
 });
 
-Native.create("javax/microedition/lcdui/game/GameCanvas.setSuppressKeyEvents.(Ljavax/microedition/lcdui/Canvas;Z)V", function(ctx, canvas, suppressKeyEvents) {
+Native.create("javax/microedition/lcdui/game/GameCanvas.setSuppressKeyEvents.(Ljavax/microedition/lcdui/Canvas;Z)V", function(canvas, suppressKeyEvents) {
     MIDP.suppressKeyEvents = suppressKeyEvents;
 });
 
-Native.create("com/sun/midp/main/MIDletProxyList.resetForegroundInNativeState.()V", function(ctx) {
+Native.create("com/sun/midp/main/MIDletProxyList.resetForegroundInNativeState.()V", function() {
     MIDP.displayId = -1;
 });
 
-Native.create("com/sun/midp/main/MIDletProxyList.setForegroundInNativeState.(II)V", function(ctx, isolateId, displayId) {
+Native.create("com/sun/midp/main/MIDletProxyList.setForegroundInNativeState.(II)V", function(isolateId, displayId) {
     MIDP.displayId = displayId;
     MIDP.foregroundIsolateId = isolateId;
 });
@@ -1047,7 +1047,7 @@ MIDP.ConnectionRegistry = {
     }
 };
 
-Native.create("com/sun/midp/io/j2me/push/ConnectionRegistry.poll0.(J)I", function(ctx, time, _) {
+Native.create("com/sun/midp/io/j2me/push/ConnectionRegistry.poll0.(J)I", function(time, _) {
     return new Promise(function(resolve, reject) {
         MIDP.ConnectionRegistry.waitForRegistration(function(id) {
             resolve(id);
@@ -1055,7 +1055,7 @@ Native.create("com/sun/midp/io/j2me/push/ConnectionRegistry.poll0.(J)I", functio
     });
 });
 
-Native.create("com/sun/midp/io/j2me/push/ConnectionRegistry.add0.(Ljava/lang/String;)I", function(ctx, connection) {
+Native.create("com/sun/midp/io/j2me/push/ConnectionRegistry.add0.(Ljava/lang/String;)I", function(connection) {
     var values = util.fromJavaString(connection).split(',');
 
     console.warn("ConnectionRegistry.add0.(IL...String;)I isn't completely implemented");
@@ -1070,7 +1070,7 @@ Native.create("com/sun/midp/io/j2me/push/ConnectionRegistry.add0.(Ljava/lang/Str
     return 0;
 });
 
-Native.create("com/sun/midp/io/j2me/push/ConnectionRegistry.addAlarm0.([BJ)J", function(ctx, jMidlet, jTime, _) {
+Native.create("com/sun/midp/io/j2me/push/ConnectionRegistry.addAlarm0.([BJ)J", function(jMidlet, jTime, _) {
     var time = jTime.toNumber(), midlet = util.decodeUtf8(jMidlet);
 
     var lastAlarm = 0;
@@ -1111,7 +1111,7 @@ Native.create("com/sun/midp/io/j2me/push/ConnectionRegistry.addAlarm0.([BJ)J", f
     return Long.fromNumber(lastAlarm);
 });
 
-Native.create("com/sun/midp/io/j2me/push/ConnectionRegistry.getMIDlet0.(I[BI)I", function(ctx, handle, regentry, entrysz) {
+Native.create("com/sun/midp/io/j2me/push/ConnectionRegistry.getMIDlet0.(I[BI)I", function(handle, regentry, entrysz) {
     var reg;
     var alarms = MIDP.ConnectionRegistry.alarms;
     for (var i = 0; i < alarms.length; i++) {
@@ -1150,49 +1150,49 @@ Native.create("com/sun/midp/io/j2me/push/ConnectionRegistry.getMIDlet0.(I[BI)I",
     return 0;
 });
 
-Native.create("com/sun/midp/io/j2me/push/ConnectionRegistry.checkInByMidlet0.(ILjava/lang/String;)V", function(ctx, suiteId, className) {
+Native.create("com/sun/midp/io/j2me/push/ConnectionRegistry.checkInByMidlet0.(ILjava/lang/String;)V", function(suiteId, className) {
     console.warn("ConnectionRegistry.checkInByMidlet0.(IL...String;)V not implemented (" +
                  suiteId + ", " + className + ")");
 });
 
-Native.create("com/sun/midp/io/j2me/push/ConnectionRegistry.checkInByName0.([B)I", function(ctx, name) {
+Native.create("com/sun/midp/io/j2me/push/ConnectionRegistry.checkInByName0.([B)I", function(name) {
     console.warn("ConnectionRegistry.checkInByName0.([B)V not implemented (" +
                  util.decodeUtf8(name) + ")");
     return 0;
 });
 
-Native.create("com/nokia/mid/ui/gestures/GestureInteractiveZone.isSupported.(I)Z", function(ctx, gestureEventIdentity) {
+Native.create("com/nokia/mid/ui/gestures/GestureInteractiveZone.isSupported.(I)Z", function(gestureEventIdentity) {
     console.warn("GestureInteractiveZone.isSupported.(I)Z not implemented (" + gestureEventIdentity + ")");
     return false;
 });
 
-Native.create("com/sun/midp/security/SecurityHandler.checkPermission0.(II)Z", function(ctx, suiteId, permission) {
+Native.create("com/sun/midp/security/SecurityHandler.checkPermission0.(II)Z", function(suiteId, permission) {
     return true;
 });
 
-Native.create("com/sun/midp/security/SecurityHandler.checkPermissionStatus0.(II)I", function(ctx, suiteId, permission) {
+Native.create("com/sun/midp/security/SecurityHandler.checkPermissionStatus0.(II)I", function(suiteId, permission) {
     return 1;
 });
 
-Native.create("com/sun/midp/io/NetworkConnectionBase.initializeInternal.()V", function(ctx) {
+Native.create("com/sun/midp/io/NetworkConnectionBase.initializeInternal.()V", function() {
     console.warn("NetworkConnectionBase.initializeInternal.()V not implemented");
 });
 
-Native.create("com/sun/j2me/content/RegistryStore.init.()Z", function(ctx) {
+Native.create("com/sun/j2me/content/RegistryStore.init.()Z", function() {
     console.warn("com/sun/j2me/content/RegistryStore.init.()Z not implemented");
     return true;
 });
 
-Native.create("com/sun/j2me/content/RegistryStore.forSuite0.(I)Ljava/lang/String;", function(ctx, suiteID) {
+Native.create("com/sun/j2me/content/RegistryStore.forSuite0.(I)Ljava/lang/String;", function(suiteID) {
     console.warn("com/sun/j2me/content/RegistryStore.forSuite0.(I)Ljava/lang/String; not implemented");
     return "";
 });
 
-Native.create("com/sun/j2me/content/AppProxy.isInSvmMode.()Z", function(ctx) {
+Native.create("com/sun/j2me/content/AppProxy.isInSvmMode.()Z", function() {
     console.warn("com/sun/j2me/content/AppProxy.isInSvmMode.()Z not implemented");
     return false;
 });
 
-Native.create("com/sun/j2me/content/InvocationStore.setCleanup0.(ILjava/lang/String;Z)V", function(ctx, suiteID, className, cleanup) {
+Native.create("com/sun/j2me/content/InvocationStore.setCleanup0.(ILjava/lang/String;Z)V", function(suiteID, className, cleanup) {
     console.warn("com/sun/j2me/content/InvocationStore.setCleanup0.(ILjava/lang/String;Z)V not implemented");
 });

--- a/midp/sms.js
+++ b/midp/sms.js
@@ -68,7 +68,7 @@ function promptForMessageText() {
     input.focus();
 }
 
-Native.create("com/sun/midp/io/j2me/sms/Protocol.open0.(Ljava/lang/String;II)I", function(ctx, host, msid, port) {
+Native.create("com/sun/midp/io/j2me/sms/Protocol.open0.(Ljava/lang/String;II)I", function(host, msid, port) {
     MIDP.smsConnections[++MIDP.lastSMSConnection] = {
       port: port,
       msid: msid,
@@ -81,7 +81,7 @@ Native.create("com/sun/midp/io/j2me/sms/Protocol.open0.(Ljava/lang/String;II)I",
 });
 
 Native.create("com/sun/midp/io/j2me/sms/Protocol.receive0.(IIILcom/sun/midp/io/j2me/sms/Protocol$SMSPacket;)I",
-function(ctx, port, msid, handle, smsPacket) {
+function(port, msid, handle, smsPacket, ctx) {
     return new Promise(function(resolve, reject) {
         function receiveSMS() {
             var sms = MIDP.j2meSMSMessages.shift();
@@ -118,7 +118,7 @@ function(ctx, port, msid, handle, smsPacket) {
     });
 });
 
-Native.create("com/sun/midp/io/j2me/sms/Protocol.close0.(III)I", function(ctx, port, handle, deRegister) {
+Native.create("com/sun/midp/io/j2me/sms/Protocol.close0.(III)I", function(port, handle, deRegister) {
     delete MIDP.smsConnections[handle];
     return 0;
 });

--- a/midp/socket.js
+++ b/midp/socket.js
@@ -11,7 +11,7 @@ var SOCKET_OPT = {
   SNDBUF: 4,
 };
 
-Native.create("com/sun/midp/io/j2me/socket/Protocol.getIpNumber0.(Ljava/lang/String;[B)I", function(ctx, host, ipBytes) {
+Native.create("com/sun/midp/io/j2me/socket/Protocol.getIpNumber0.(Ljava/lang/String;[B)I", function(host, ipBytes) {
     // We'd need to modify ipBytes, that is an array with length 0
     // But we don't really need to do that, because getIpNumber0 is called only
     // before open0. So we just need to store the host and pass it to
@@ -20,7 +20,7 @@ Native.create("com/sun/midp/io/j2me/socket/Protocol.getIpNumber0.(Ljava/lang/Str
     return 0;
 });
 
-Native.create("com/sun/midp/io/j2me/socket/Protocol.getHost0.(Z)Ljava/lang/String;", function(ctx, local) {
+Native.create("com/sun/midp/io/j2me/socket/Protocol.getHost0.(Z)Ljava/lang/String;", function(local) {
     return local ? "127.0.0.1" : this.socket.host;
 });
 
@@ -52,7 +52,7 @@ Socket.prototype.close = function() {
     this.sender({ type: "close" });
 }
 
-Native.create("com/sun/midp/io/j2me/socket/Protocol.open0.([BI)V", function(ctx, ipBytes, port) {
+Native.create("com/sun/midp/io/j2me/socket/Protocol.open0.([BI)V", function(ipBytes, port) {
     // console.log("Protocol.open0: " + this.host + ":" + port);
 
     return new Promise((function(resolve, reject) {
@@ -92,12 +92,12 @@ Native.create("com/sun/midp/io/j2me/socket/Protocol.open0.([BI)V", function(ctx,
     }).bind(this));
 });
 
-Native.create("com/sun/midp/io/j2me/socket/Protocol.available0.()I", function(ctx) {
+Native.create("com/sun/midp/io/j2me/socket/Protocol.available0.()I", function() {
     // console.log("Protocol.available0: " + this.data.byteLength);
     return this.data.byteLength;
 });
 
-Native.create("com/sun/midp/io/j2me/socket/Protocol.read0.([BII)I", function(ctx, data, offset, length) {
+Native.create("com/sun/midp/io/j2me/socket/Protocol.read0.([BII)I", function(data, offset, length) {
     // console.log("Protocol.read0: " + this.socket.isClosed);
 
     return new Promise((function(resolve, reject) {
@@ -131,7 +131,7 @@ Native.create("com/sun/midp/io/j2me/socket/Protocol.read0.([BII)I", function(ctx
     }).bind(this));
 });
 
-Native.create("com/sun/midp/io/j2me/socket/Protocol.write0.([BII)I", function(ctx, data, offset, length) {
+Native.create("com/sun/midp/io/j2me/socket/Protocol.write0.([BII)I", function(data, offset, length) {
     return new Promise(function(resolve, reject) {
         if (this.socket.isClosed) {
           reject(new JavaException("java/io/IOException", "socket is closed"));
@@ -157,7 +157,7 @@ Native.create("com/sun/midp/io/j2me/socket/Protocol.write0.([BII)I", function(ct
     }.bind(this));
 });
 
-Native.create("com/sun/midp/io/j2me/socket/Protocol.setSockOpt0.(II)V", function(ctx, option, value) {
+Native.create("com/sun/midp/io/j2me/socket/Protocol.setSockOpt0.(II)V", function(option, value) {
     if (!(option in this.options)) {
         throw new JavaException("java/lang/IllegalArgumentException", "Unsupported socket option");
     }
@@ -165,7 +165,7 @@ Native.create("com/sun/midp/io/j2me/socket/Protocol.setSockOpt0.(II)V", function
     this.options[option] = value;
 });
 
-Native.create("com/sun/midp/io/j2me/socket/Protocol.getSockOpt0.(I)I", function(ctx, option) {
+Native.create("com/sun/midp/io/j2me/socket/Protocol.getSockOpt0.(I)I", function(option) {
     if (!(option in this.options)) {
         throw new JavaException("java/lang/IllegalArgumentException", "Unsupported socket option");
     }
@@ -173,7 +173,7 @@ Native.create("com/sun/midp/io/j2me/socket/Protocol.getSockOpt0.(I)I", function(
     return this.options[option];
 });
 
-Native.create("com/sun/midp/io/j2me/socket/Protocol.close0.()V", function(ctx) {
+Native.create("com/sun/midp/io/j2me/socket/Protocol.close0.()V", function() {
     // console.log("Protocol.close0: " + this.socket.isClosed);
 
     return new Promise((function(resolve, reject) {
@@ -192,7 +192,7 @@ Native.create("com/sun/midp/io/j2me/socket/Protocol.close0.()V", function(ctx) {
     }).bind(this));
 });
 
-Native.create("com/sun/midp/io/j2me/socket/Protocol.shutdownOutput0.()V", function(ctx) {
+Native.create("com/sun/midp/io/j2me/socket/Protocol.shutdownOutput0.()V", function() {
     // We don't have the ability to close the output stream independently
     // of the connection as a whole.  But we don't seem to have to do anything
     // here, since this has just two call sites: one in Protocol.disconnect,
@@ -201,13 +201,13 @@ Native.create("com/sun/midp/io/j2me/socket/Protocol.shutdownOutput0.()V", functi
     // I can't find an actual caller.
 });
 
-Native.create("com/sun/midp/io/j2me/socket/Protocol.notifyClosedInput0.()V", function(ctx) {
+Native.create("com/sun/midp/io/j2me/socket/Protocol.notifyClosedInput0.()V", function() {
     if (this.waitingData) {
         console.warn("Protocol.notifyClosedInput0.()V unimplemented while thread is blocked on read0");
     }
 });
 
-Native.create("com/sun/midp/io/j2me/socket/Protocol.notifyClosedOutput0.()V", function(ctx) {
+Native.create("com/sun/midp/io/j2me/socket/Protocol.notifyClosedOutput0.()V", function() {
     if (this.socket.ondrain) {
         console.warn("Protocol.notifyClosedOutput0.()V unimplemented while thread is blocked on write0");
     }

--- a/native.js
+++ b/native.js
@@ -7,7 +7,7 @@ var Native = {};
 
 Native.create = createAlternateImpl.bind(null, Native);
 
-Native.create("java/lang/System.arraycopy.(Ljava/lang/Object;ILjava/lang/Object;II)V", function(ctx, src, srcOffset, dst, dstOffset, length) {
+Native.create("java/lang/System.arraycopy.(Ljava/lang/Object;ILjava/lang/Object;II)V", function(src, srcOffset, dst, dstOffset, length) {
     if (!src || !dst)
         throw new JavaException("java/lang/NullPointerException", "Cannot copy to/from a null array.");
     var srcClass = src.class;
@@ -52,7 +52,7 @@ Native.create("java/lang/System.arraycopy.(Ljava/lang/Object;ILjava/lang/Object;
     }
 });
 
-Native.create("java/lang/System.getProperty0.(Ljava/lang/String;)Ljava/lang/String;", function(ctx, key) {
+Native.create("java/lang/System.getProperty0.(Ljava/lang/String;)Ljava/lang/String;", function(key) {
     var value;
     switch (util.fromJavaString(key)) {
     case "microedition.encoding":
@@ -161,19 +161,19 @@ Native.create("java/lang/System.getProperty0.(Ljava/lang/String;)Ljava/lang/Stri
     return value ? value : null;
 });
 
-Native.create("java/lang/System.currentTimeMillis.()J", function(ctx) {
+Native.create("java/lang/System.currentTimeMillis.()J", function() {
     return Long.fromNumber(Date.now());
 });
 
-Native.create("com/sun/cldchi/jvm/JVM.unchecked_char_arraycopy.([CI[CII)V", function(ctx, src, srcOffset, dst, dstOffset, length) {
+Native.create("com/sun/cldchi/jvm/JVM.unchecked_char_arraycopy.([CI[CII)V", function(src, srcOffset, dst, dstOffset, length) {
   dst.set(src.subarray(srcOffset, srcOffset + length), dstOffset);
 });
 
-Native.create("com/sun/cldchi/jvm/JVM.unchecked_int_arraycopy.([II[III)V", function(ctx, src, srcOffset, dst, dstOffset, length) {
+Native.create("com/sun/cldchi/jvm/JVM.unchecked_int_arraycopy.([II[III)V", function(src, srcOffset, dst, dstOffset, length) {
   dst.set(src.subarray(srcOffset, srcOffset + length), dstOffset);
 });
 
-Native.create("com/sun/cldchi/jvm/JVM.unchecked_obj_arraycopy.([Ljava/lang/Object;I[Ljava/lang/Object;II)V", function(ctx, src, srcOffset, dst, dstOffset, length) {
+Native.create("com/sun/cldchi/jvm/JVM.unchecked_obj_arraycopy.([Ljava/lang/Object;I[Ljava/lang/Object;II)V", function(src, srcOffset, dst, dstOffset, length) {
     if (dst !== src || dstOffset < srcOffset) {
         for (var n = 0; n < length; ++n)
             dst[dstOffset++] = src[srcOffset++];
@@ -185,7 +185,7 @@ Native.create("com/sun/cldchi/jvm/JVM.unchecked_obj_arraycopy.([Ljava/lang/Objec
     }
 });
 
-Native.create("com/sun/cldchi/jvm/JVM.monotonicTimeMillis.()J", function(ctx) {
+Native.create("com/sun/cldchi/jvm/JVM.monotonicTimeMillis.()J", function() {
     return Long.fromNumber(performance.now());
 });
 
@@ -193,14 +193,14 @@ Native.create("java/lang/Object.getClass.()Ljava/lang/Class;", function(ctx) {
     return this.class.getClassObject(ctx);
 });
 
-Native.create("java/lang/Object.hashCode.()I", function(ctx) {
+Native.create("java/lang/Object.hashCode.()I", function() {
     var hashCode = this.hashCode;
     while (!hashCode)
         hashCode = this.hashCode = util.id();
     return hashCode;
 });
 
-Native.create("java/lang/Object.wait.(J)V", function(ctx, timeout, _) {
+Native.create("java/lang/Object.wait.(J)V", function(timeout, _, ctx) {
     ctx.wait(this, timeout.toNumber());
 });
 
@@ -241,11 +241,11 @@ Native.create("java/lang/Class.init9.()V", function(ctx) {
     runtime.initialized[className] = true;
 });
 
-Native.create("java/lang/Class.getName.()Ljava/lang/String;", function(ctx) {
+Native.create("java/lang/Class.getName.()Ljava/lang/String;", function() {
     return this.vmClass.className.replace(/\//g, ".");
 });
 
-Native.create("java/lang/Class.forName.(Ljava/lang/String;)Ljava/lang/Class;", function(ctx, name) {
+Native.create("java/lang/Class.forName.(Ljava/lang/String;)Ljava/lang/Class;", function(name, ctx) {
     try {
         if (!name)
             throw new Classes.ClassNotFoundException();
@@ -254,7 +254,7 @@ Native.create("java/lang/Class.forName.(Ljava/lang/String;)Ljava/lang/Class;", f
         classInfo = CLASSES.getClass(className);
     } catch (e) {
         if (e instanceof (Classes.ClassNotFoundException))
-            ctx.raiseExceptionAndYield("java/lang/ClassNotFoundException", "'" + className + "' not found.");
+            throw new JavaException("java/lang/ClassNotFoundException", "'" + className + "' not found.");
         throw e;
     }
     return classInfo.getClassObject(ctx);
@@ -291,28 +291,28 @@ Native.create("java/lang/Class.newInstance.()Ljava/lang/Object;", function(ctx) 
     throw VM.Yield;
 });
 
-Native.create("java/lang/Class.isInterface.()Z", function(ctx) {
+Native.create("java/lang/Class.isInterface.()Z", function() {
     return ACCESS_FLAGS.isInterface(this.vmClass.access_flags);
 });
 
-Native.create("java/lang/Class.isArray.()Z", function(ctx) {
+Native.create("java/lang/Class.isArray.()Z", function() {
     return !!this.vmClass.isArrayClass;
 });
 
-Native.create("java/lang/Class.isAssignableFrom.(Ljava/lang/Class;)Z", function(ctx, fromClass) {
+Native.create("java/lang/Class.isAssignableFrom.(Ljava/lang/Class;)Z", function(fromClass) {
     if (!fromClass)
         throw new JavaException("java/lang/NullPointerException");
     return fromClass.vmClass.isAssignableTo(this.vmClass);
 });
 
-Native.create("java/lang/Class.isInstance.(Ljava/lang/Object;)Z", function(ctx, obj) {
+Native.create("java/lang/Class.isInstance.(Ljava/lang/Object;)Z", function(obj) {
     return obj && obj.class.isAssignableTo(this.vmClass);
 });
 
 Native.create("java/lang/Float.floatToIntBits.(F)I", (function() {
     var fa = new Float32Array(1);
     var ia = new Int32Array(fa.buffer);
-    return function(ctx, val) {
+    return function(val) {
         fa[0] = val;
         return ia[0];
     }
@@ -321,7 +321,7 @@ Native.create("java/lang/Float.floatToIntBits.(F)I", (function() {
 Native.create("java/lang/Double.doubleToLongBits.(D)J", (function() {
     var da = new Float64Array(1);
     var ia = new Int32Array(da.buffer);
-    return function(ctx, val, _) {
+    return function(val, _) {
         da[0] = val;
         return Long.fromBits(ia[0], ia[1]);
     }
@@ -330,7 +330,7 @@ Native.create("java/lang/Double.doubleToLongBits.(D)J", (function() {
 Native.create("java/lang/Float.intBitsToFloat.(I)F", (function() {
     var fa = new Float32Array(1);
     var ia = new Int32Array(fa.buffer);
-    return function(ctx, val) {
+    return function(val) {
         ia[0] = val;
         return fa[0];
     }
@@ -339,7 +339,7 @@ Native.create("java/lang/Float.intBitsToFloat.(I)F", (function() {
 Native.create("java/lang/Double.longBitsToDouble.(J)D", (function() {
     var da = new Float64Array(1);
     var ia = new Int32Array(da.buffer);
-    return function(ctx, l, _) {
+    return function(l, _) {
         ia[0] = l.low_;
         ia[1] = l.high_;
         return da[0];
@@ -381,58 +381,58 @@ Native.create("java/lang/Throwable.obtainBackTrace.()Ljava/lang/Object;", functi
     return result;
 });
 
-Native.create("java/lang/Runtime.freeMemory.()J", function(ctx) {
+Native.create("java/lang/Runtime.freeMemory.()J", function() {
     return Long.fromInt(0x800000);
 });
 
-Native.create("java/lang/Runtime.totalMemory.()J", function(ctx) {
+Native.create("java/lang/Runtime.totalMemory.()J", function() {
     return Long.fromInt(0x1000000);
 });
 
-Native.create("java/lang/Runtime.gc.()V", function(ctx) {
+Native.create("java/lang/Runtime.gc.()V", function() {
 });
 
-Native.create("java/lang/Math.floor.(D)D", function(ctx, val, _) {
+Native.create("java/lang/Math.floor.(D)D", function(val, _) {
     return Math.floor(val);
 });
 
-Native.create("java/lang/Math.asin.(D)D", function(ctx, val, _) {
+Native.create("java/lang/Math.asin.(D)D", function(val, _) {
     return Math.asin(val);
 });
 
-Native.create("java/lang/Math.acos.(D)D", function(ctx, val, _) {
+Native.create("java/lang/Math.acos.(D)D", function(val, _) {
     return Math.acos(val);
 });
 
-Native.create("java/lang/Math.atan.(D)D", function(ctx, val, _) {
+Native.create("java/lang/Math.atan.(D)D", function(val, _) {
     return Math.atan(val);
 });
 
-Native.create("java/lang/Math.atan2.(DD)D", function(ctx, x, _1, y, _2) {
+Native.create("java/lang/Math.atan2.(DD)D", function(x, _1, y, _2) {
     return Math.atan2(x, y);
 });
 
-Native.create("java/lang/Math.sin.(D)D", function(ctx, val, _) {
+Native.create("java/lang/Math.sin.(D)D", function(val, _) {
     return Math.sin(val);
 });
 
-Native.create("java/lang/Math.cos.(D)D", function(ctx, val, _) {
+Native.create("java/lang/Math.cos.(D)D", function(val, _) {
     return Math.cos(val);
 });
 
-Native.create("java/lang/Math.tan.(D)D", function(ctx, val, _) {
+Native.create("java/lang/Math.tan.(D)D", function(val, _) {
     return Math.tan(val);
 });
 
-Native.create("java/lang/Math.sqrt.(D)D", function(ctx, val, _) {
+Native.create("java/lang/Math.sqrt.(D)D", function(val, _) {
     return Math.sqrt(val);
 });
 
-Native.create("java/lang/Math.ceil.(D)D", function(ctx, val, _) {
+Native.create("java/lang/Math.ceil.(D)D", function(val, _) {
     return Math.ceil(val);
 });
 
-Native.create("java/lang/Math.floor.(D)D", function(ctx, val, _) {
+Native.create("java/lang/Math.floor.(D)D", function(val, _) {
     return Math.floor(val);
 });
 
@@ -440,7 +440,7 @@ Native.create("java/lang/Thread.currentThread.()Ljava/lang/Thread;", function(ct
     return ctx.thread;
 });
 
-Native.create("java/lang/Thread.setPriority0.(II)V", function(ctx, oldPriority, newPriority) {
+Native.create("java/lang/Thread.setPriority0.(II)V", function(oldPriority, newPriority) {
 });
 
 Native.create("java/lang/Thread.start0.()V", function(ctx) {
@@ -489,21 +489,21 @@ Native.create("java/lang/Thread.start0.()V", function(ctx) {
     ctx.resume();
 });
 
-Native.create("java/lang/Thread.internalExit.()V", function(ctx) {
+Native.create("java/lang/Thread.internalExit.()V", function() {
     this.alive = false;
 });
 
-Native.create("java/lang/Thread.isAlive.()Z", function(ctx) {
+Native.create("java/lang/Thread.isAlive.()Z", function() {
     return !!this.alive;
 });
 
-Native.create("java/lang/Thread.sleep.(J)V", function(ctx, delay, _) {
+Native.create("java/lang/Thread.sleep.(J)V", function(delay, _) {
     return new Promise(function(resolve, reject) {
         window.setTimeout(resolve, delay.toNumber());
     })
 });
 
-Native.create("java/lang/Thread.yield.()V", function(ctx) {
+Native.create("java/lang/Thread.yield.()V", function() {
     throw VM.Yield;
 });
 
@@ -511,11 +511,11 @@ Native.create("java/lang/Thread.activeCount.()I", function(ctx) {
     return ctx.runtime.threadCount;
 });
 
-Native.create("com/sun/cldchi/io/ConsoleOutputStream.write.(I)V", function(ctx, ch) {
+Native.create("com/sun/cldchi/io/ConsoleOutputStream.write.(I)V", function(ch) {
     console.print(ch);
 });
 
-Native.create("com/sun/cldc/io/ResourceInputStream.open.(Ljava/lang/String;)Ljava/lang/Object;", function(ctx, name) {
+Native.create("com/sun/cldc/io/ResourceInputStream.open.(Ljava/lang/String;)Ljava/lang/Object;", function(name, ctx) {
     var fileName = util.fromJavaString(name);
     var data = CLASSES.loadFile(fileName);
     var obj = null;
@@ -527,7 +527,7 @@ Native.create("com/sun/cldc/io/ResourceInputStream.open.(Ljava/lang/String;)Ljav
     return obj;
 });
 
-Override.create("com/sun/cldc/io/ResourceInputStream.available.()I", function(ctx) {
+Override.create("com/sun/cldc/io/ResourceInputStream.available.()I", function() {
     var handle = this.class.getField("I.fileDecoder.Ljava/lang/Object;").get(this);
 
     if (!handle) {
@@ -537,7 +537,7 @@ Override.create("com/sun/cldc/io/ResourceInputStream.available.()I", function(ct
     return handle.data.length - handle.pos;
 });
 
-Override.create("com/sun/cldc/io/ResourceInputStream.read.()I", function(ctx) {
+Override.create("com/sun/cldc/io/ResourceInputStream.read.()I", function() {
     var handle = this.class.getField("I.fileDecoder.Ljava/lang/Object;").get(this);
 
     if (!handle) {
@@ -547,7 +547,7 @@ Override.create("com/sun/cldc/io/ResourceInputStream.read.()I", function(ctx) {
     return (handle.data.length - handle.pos > 0) ? handle.data[handle.pos++] : -1;
 });
 
-Native.create("com/sun/cldc/io/ResourceInputStream.readBytes.(Ljava/lang/Object;[BII)I", function(ctx, handle, b, off, len) {
+Native.create("com/sun/cldc/io/ResourceInputStream.readBytes.(Ljava/lang/Object;[BII)I", function(handle, b, off, len) {
     var data = handle.data;
     var remaining = data.length - handle.pos;
     if (len > remaining)
@@ -558,31 +558,31 @@ Native.create("com/sun/cldc/io/ResourceInputStream.readBytes.(Ljava/lang/Object;
     return (len > 0) ? len : -1;
 });
 
-Native.create("com/sun/cldc/i18n/uclc/DefaultCaseConverter.toLowerCase.(C)C", function(ctx, char) {
+Native.create("com/sun/cldc/i18n/uclc/DefaultCaseConverter.toLowerCase.(C)C", function(char) {
     return String.fromCharCode(char).toLowerCase().charCodeAt(0);
 });
 
-Native.create("com/sun/cldc/i18n/uclc/DefaultCaseConverter.toUpperCase.(C)C", function(ctx, char) {
+Native.create("com/sun/cldc/i18n/uclc/DefaultCaseConverter.toUpperCase.(C)C", function(char) {
     return String.fromCharCode(char).toUpperCase().charCodeAt(0);
 });
 
-Native.create("java/lang/ref/WeakReference.initializeWeakReference.(Ljava/lang/Object;)V", function(ctx, target) {
+Native.create("java/lang/ref/WeakReference.initializeWeakReference.(Ljava/lang/Object;)V", function(target) {
     this.target = target;
 });
 
-Native.create("java/lang/ref/WeakReference.get.()Ljava/lang/Object;", function(ctx) {
+Native.create("java/lang/ref/WeakReference.get.()Ljava/lang/Object;", function() {
     return this.target ? this.target : null;
 });
 
-Native.create("java/lang/ref/WeakReference.clear.()V", function(ctx) {
+Native.create("java/lang/ref/WeakReference.clear.()V", function() {
     this.target = null;
 });
 
-Native.create("com/sun/cldc/isolate/Isolate.registerNewIsolate.()V", function(ctx) {
+Native.create("com/sun/cldc/isolate/Isolate.registerNewIsolate.()V", function() {
     this.id = util.id();
 });
 
-Native.create("com/sun/cldc/isolate/Isolate.getStatus.()I", function(ctx) {
+Native.create("com/sun/cldc/isolate/Isolate.getStatus.()I", function() {
     return this.runtime ? this.runtime.status : 1; // NEW
 });
 
@@ -590,7 +590,7 @@ Native.create("com/sun/cldc/isolate/Isolate.nativeStart.()V", function(ctx) {
     ctx.runtime.vm.startIsolate(this);
 });
 
-Native.create("com/sun/cldc/isolate/Isolate.waitStatus.(I)V", function(ctx, status) {
+Native.create("com/sun/cldc/isolate/Isolate.waitStatus.(I)V", function(status) {
     return new Promise((function(resolve, reject) {
         var runtime = this.runtime;
         if (runtime.status >= status) {
@@ -621,11 +621,11 @@ Native.create("com/sun/cldc/isolate/Isolate.getIsolates0.()[Lcom/sun/cldc/isolat
     return isolates;
 });
 
-Native.create("com/sun/cldc/isolate/Isolate.id0.()I", function(ctx) {
+Native.create("com/sun/cldc/isolate/Isolate.id0.()I", function() {
     return this.id;
 });
 
-Native.create("com/sun/cldc/isolate/Isolate.setPriority0.(I)V", function(ctx, newPriority) {
+Native.create("com/sun/cldc/isolate/Isolate.setPriority0.(I)V", function(newPriority) {
 });
 
 var links = {};
@@ -647,7 +647,7 @@ Native.create("com/sun/midp/links/LinkPortal.getLinkCount0.()I", function(ctx) {
     });
 });
 
-Native.create("com/sun/midp/links/LinkPortal.getLinks0.([Lcom/sun/midp/links/Link;)V", function(ctx, linkArray) {
+Native.create("com/sun/midp/links/LinkPortal.getLinks0.([Lcom/sun/midp/links/Link;)V", function(linkArray, ctx) {
     var isolateId = ctx.runtime.isolate.id;
 
     for (var i = 0; i < links[isolateId].length; i++) {
@@ -658,7 +658,7 @@ Native.create("com/sun/midp/links/LinkPortal.getLinks0.([Lcom/sun/midp/links/Lin
     }
 });
 
-Native.create("com/sun/midp/links/LinkPortal.setLinks0.(I[Lcom/sun/midp/links/Link;)V", function(ctx, id, linkArray) {
+Native.create("com/sun/midp/links/LinkPortal.setLinks0.(I[Lcom/sun/midp/links/Link;)V", function(id, linkArray) {
     links[id] = linkArray;
 
     if (waitingForLinks[id]) {
@@ -666,23 +666,23 @@ Native.create("com/sun/midp/links/LinkPortal.setLinks0.(I[Lcom/sun/midp/links/Li
     }
 });
 
-Native.create("com/sun/midp/links/Link.init0.(II)V", function(ctx, sender, receiver) {
+Native.create("com/sun/midp/links/Link.init0.(II)V", function(sender, receiver) {
     this.sender = sender;
     this.receiver = receiver;
     this.class.getField("I.nativePointer.I").set(this, util.id());
 });
 
-Native.create("com/sun/midp/links/Link.receive0.(Lcom/sun/midp/links/LinkMessage;Lcom/sun/midp/links/Link;)V", function(ctx, linkMessage, link) {
+Native.create("com/sun/midp/links/Link.receive0.(Lcom/sun/midp/links/LinkMessage;Lcom/sun/midp/links/Link;)V", function(linkMessage, link) {
     // TODO: Implement when something hits send0
     console.warn("Called com/sun/midp/links/Link.receive0.(Lcom/sun/midp/links/LinkMessage;Lcom/sun/midp/links/Link;)V");
     return new Promise(function(){});
 });
 
-Native.create("com/sun/cldc/i18n/j2me/UTF_8_Reader.init.([B)V", function(ctx, data) {
+Native.create("com/sun/cldc/i18n/j2me/UTF_8_Reader.init.([B)V", function(data) {
     this.decoded = new TextDecoder("UTF-8").decode(data);
 });
 
-Native.create("com/sun/cldc/i18n/j2me/UTF_8_Reader.read.([CII)I", function(ctx, cbuf, off, len) {
+Native.create("com/sun/cldc/i18n/j2me/UTF_8_Reader.read.([CII)I", function(cbuf, off, len) {
     if (this.decoded.length === 0) {
       return -1;
     }
@@ -696,7 +696,7 @@ Native.create("com/sun/cldc/i18n/j2me/UTF_8_Reader.read.([CII)I", function(ctx, 
     return len;
 });
 
-Native.create("com/sun/cldc/i18n/j2me/UTF_8_Writer.encodeUTF8.([CII)[B", function(ctx, cbuf, off, len) {
+Native.create("com/sun/cldc/i18n/j2me/UTF_8_Writer.encodeUTF8.([CII)[B", function(cbuf, off, len, ctx) {
   var outputArray = [];
 
   var pendingSurrogate = this.class.getField("I.pendingSurrogate.I").get(this);
@@ -771,7 +771,7 @@ Native.create("com/sun/cldc/i18n/j2me/UTF_8_Writer.encodeUTF8.([CII)[B", functio
   return res;
 });
 
-Native.create("com/sun/cldc/i18n/j2me/UTF_8_Writer.sizeOf.([CII)I", function(ctx, cbuf, off, len) {
+Native.create("com/sun/cldc/i18n/j2me/UTF_8_Writer.sizeOf.([CII)I", function(cbuf, off, len) {
   var inputChar = 0;
   var outputSize = 0;
   var outputCount = 0;

--- a/override.js
+++ b/override.js
@@ -39,12 +39,12 @@ function createAlternateImpl(object, key, fn) {
   object[key] = function(ctx, stack, isStatic) {
     var args = new Array(numArgs);
 
-    args[0] = ctx;
+    args[numArgs - 1] = ctx;
 
     // NOTE: If your function accepts a Long/Double, you must specify
     // two arguments (since they take up two stack positions); we
     // could sugar this someday.
-    for (var i = numArgs - 1; i >= 1; i--) {
+    for (var i = numArgs - 2; i >= 0; i--) {
       args[i] = stack.pop();
     }
 
@@ -106,19 +106,19 @@ function createAlternateImpl(object, key, fn) {
 
 Override.create = createAlternateImpl.bind(null, Override);
 
-Override.create("com/ibm/oti/connection/file/Connection.decode.(Ljava/lang/String;)Ljava/lang/String;", function(ctx, string) {
+Override.create("com/ibm/oti/connection/file/Connection.decode.(Ljava/lang/String;)Ljava/lang/String;", function(string) {
   return decodeURIComponent(string.str);
 });
 
-Override.create("com/ibm/oti/connection/file/Connection.encode.(Ljava/lang/String;)Ljava/lang/String;", function(ctx, string) {
+Override.create("com/ibm/oti/connection/file/Connection.encode.(Ljava/lang/String;)Ljava/lang/String;", function(string) {
   return string.str.replace(/[^a-zA-Z0-9-_\.!~\*\\'()/:]/g, encodeURIComponent);
 });
 
-Override.create("java/lang/Math.min.(II)I", function(ctx, a, b) {
+Override.create("java/lang/Math.min.(II)I", function(a, b) {
   return Math.min(a, b);
 });
 
-Override.create("java/io/ByteArrayOutputStream.write.([BII)V", function(ctx, b, off, len) {
+Override.create("java/io/ByteArrayOutputStream.write.([BII)V", function(b, off, len, ctx) {
   if ((off < 0) || (off > b.length) || (len < 0) ||
       ((off + len) > b.length)) {
     throw new JavaException("java/lang/IndexOutOfBoundsException");
@@ -143,7 +143,7 @@ Override.create("java/io/ByteArrayOutputStream.write.([BII)V", function(ctx, b, 
   this.class.getField("I.count.I").set(this, newcount);
 });
 
-Override.create("java/io/ByteArrayOutputStream.write.(I)V", function(ctx, value) {
+Override.create("java/io/ByteArrayOutputStream.write.(I)V", function(value, ctx) {
   var count = this.class.getField("I.count.I").get(this);
   var buf = this.class.getField("I.buf.[B").get(this);
 
@@ -159,7 +159,7 @@ Override.create("java/io/ByteArrayOutputStream.write.(I)V", function(ctx, value)
   this.class.getField("I.count.I").set(this, newcount);
 });
 
-Override.create("java/io/ByteArrayInputStream.<init>.([B)V", function(ctx, buf) {
+Override.create("java/io/ByteArrayInputStream.<init>.([B)V", function(buf) {
   if (!buf) {
     throw new JavaException("java/lang/NullPointerException");
   }
@@ -169,7 +169,7 @@ Override.create("java/io/ByteArrayInputStream.<init>.([B)V", function(ctx, buf) 
   this.count = buf.length;
 });
 
-Override.create("java/io/ByteArrayInputStream.<init>.([BII)V", function(ctx, buf, offset, length) {
+Override.create("java/io/ByteArrayInputStream.<init>.([BII)V", function(buf, offset, length) {
   if (!buf) {
     throw new JavaException("java/lang/NullPointerException");
   }
@@ -179,11 +179,11 @@ Override.create("java/io/ByteArrayInputStream.<init>.([BII)V", function(ctx, buf
   this.count = (offset + length <= buf.length) ? (offset + length) : buf.length;
 });
 
-Override.create("java/io/ByteArrayInputStream.read.()I", function(ctx) {
+Override.create("java/io/ByteArrayInputStream.read.()I", function() {
   return (this.pos < this.count) ? (this.buf[this.pos++] & 0xFF) : -1;
 });
 
-Override.create("java/io/ByteArrayInputStream.read.([BII)I", function(ctx, b, off, len) {
+Override.create("java/io/ByteArrayInputStream.read.([BII)I", function(b, off, len) {
   if (!b) {
     throw new JavaException("java/lang/NullPointerException");
   }
@@ -209,7 +209,7 @@ Override.create("java/io/ByteArrayInputStream.read.([BII)I", function(ctx, b, of
   return len;
 });
 
-Override.create("java/io/ByteArrayInputStream.skip.(J)J", function(ctx, long, _) {
+Override.create("java/io/ByteArrayInputStream.skip.(J)J", function(long, _) {
   var n = long.toNumber();
 
   if (this.pos + n > this.count) {
@@ -225,15 +225,15 @@ Override.create("java/io/ByteArrayInputStream.skip.(J)J", function(ctx, long, _)
   return Long.fromNumber(n);
 });
 
-Override.create("java/io/ByteArrayInputStream.available.()I", function(ctx) {
+Override.create("java/io/ByteArrayInputStream.available.()I", function() {
   return this.count - this.pos;
 });
 
-Override.create("java/io/ByteArrayInputStream.mark.(I)V", function(ctx, readAheadLimit) {
+Override.create("java/io/ByteArrayInputStream.mark.(I)V", function(readAheadLimit) {
   this.mark = this.pos;
 });
 
-Override.create("java/io/ByteArrayInputStream.reset.()V", function(ctx) {
+Override.create("java/io/ByteArrayInputStream.reset.()V", function() {
   this.pos = this.mark;
 });
 
@@ -241,7 +241,7 @@ Override.create("java/io/ByteArrayInputStream.reset.()V", function(ctx) {
 // DomainPolicy.loadValues. This has the added benefit that we avoid many other
 // computations.
 
-Override.create("com/sun/midp/security/Permissions.forDomain.(Ljava/lang/String;)[[B", function(ctx, name) {
+Override.create("com/sun/midp/security/Permissions.forDomain.(Ljava/lang/String;)[[B", function(name, ctx) {
   // NUMBER_OF_PERMISSIONS = PermissionsStrings.PERMISSION_STRINGS.length + 2
   // The 2 is the two hardcoded MIPS and AMS permissions.
   var NUMBER_OF_PERMISSIONS = 61;
@@ -262,18 +262,18 @@ Override.create("com/sun/midp/security/Permissions.forDomain.(Ljava/lang/String;
 });
 
 // Always return true to make Java think the MIDlet domain is trusted.
-Override.create("com/sun/midp/security/Permissions.isTrusted.(Ljava/lang/String;)Z", function(ctx, name) {
+Override.create("com/sun/midp/security/Permissions.isTrusted.(Ljava/lang/String;)Z", function(name) {
   return true;
 });
 
 // Returns the ID of the permission. The callers will use this ID to check the
 // permission in the permissions array returned by Permissions::forDomain.
-Override.create("com/sun/midp/security/Permissions.getId.(Ljava/lang/String;)I", function(ctx, name) {
+Override.create("com/sun/midp/security/Permissions.getId.(Ljava/lang/String;)I", function(name) {
   return 0;
 });
 
 // The Java code that uses this method doesn't actually use the return value, but
 // passes it to Permissions.getId. So we can return anything.
-Override.create("com/sun/midp/security/Permissions.getName.(I)Ljava/lang/String;", function(ctx, id) {
+Override.create("com/sun/midp/security/Permissions.getName.(I)Ljava/lang/String;", function(id) {
   return "com.sun.midp";
 });

--- a/string.js
+++ b/string.js
@@ -19,25 +19,25 @@ function isString(obj) {
 //****************************************************************
 // Constructors
 
-Override.create("java/lang/String.<init>.()V", function(ctx) {
+Override.create("java/lang/String.<init>.()V", function() {
   this.str = "";
 });
 
-Override.create("java/lang/String.<init>.(Ljava/lang/String;)V", function(ctx, jStr) {
+Override.create("java/lang/String.<init>.(Ljava/lang/String;)V", function(jStr) {
   if (!jStr) {
     throw new JavaException("java/lang/NullPointerException");
   }
   this.str = jStr.str;
 });
 
-Override.create("java/lang/String.<init>.([C)V", function(ctx, chars) {
+Override.create("java/lang/String.<init>.([C)V", function(chars) {
   if (!chars) {
     throw new JavaException("java/lang/NullPointerException");
   }
   this.str = util.fromJavaChars(chars);
 });
 
-Override.create("java/lang/String.<init>.([CII)V", function(ctx, value, offset, count) {
+Override.create("java/lang/String.<init>.([CII)V", function(value, offset, count) {
   if (offset < 0 || count < 0 || offset > value.length - count) {
     throw new JavaException("java/lang/IndexOutOfBoundsException");
   }
@@ -57,55 +57,55 @@ function constructFromByteArray(bytes, off, len, enc) {
 
 Override.create(
   "java/lang/String.<init>.([BIILjava/lang/String;)V",
-  function(ctx, bytes, off, len, enc) {
+  function(bytes, off, len, enc) {
     constructFromByteArray.call(this, bytes, off, len, enc.str);
   });
 
 Override.create(
   "java/lang/String.<init>.([BLjava/lang/String;)V",
-  function(ctx, bytes, enc) {
+  function(bytes, enc) {
     constructFromByteArray.call(this, bytes, 0, bytes.length, enc.str);
   });
 
 Override.create(
   "java/lang/String.<init>.([BII)V",
-  function(ctx, bytes, offset, len) {
+  function(bytes, offset, len) {
     constructFromByteArray.call(this, bytes, offset, len, "UTF-8");
   });
 
 Override.create(
   "java/lang/String.<init>.([B)V",
-  function(ctx, bytes) {
+  function(bytes) {
     constructFromByteArray.call(this, bytes, 0, bytes.length, "UTF-8");
   });
 
 Override.create(
   "java/lang/String.<init>.(Ljava/lang/StringBuffer;)V",
-  function(ctx, jBuffer) {
+  function(jBuffer) {
     this.str = util.fromJavaChars(jBuffer.buf, 0, jBuffer.count);
   });
 
 Override.create(
   "java/lang/String.<init>.(II[C)V",
-  function(ctx, offset, count, value) {
+  function(offset, count, value) {
     this.str = util.fromJavaChars(value, offset, count);
   });
 
 //****************************************************************
 // Methods
 
-Override.create("java/lang/String.length.()I", function(ctx) {
+Override.create("java/lang/String.length.()I", function() {
   return this.str.length;
 });
 
-Override.create("java/lang/String.charAt.(I)C", function(ctx, index) {
+Override.create("java/lang/String.charAt.(I)C", function(index) {
   if (index < 0 || index >= this.str.length) {
     throw new JavaException("java/lang/IndexOutOfBoundsException");
   }
   return this.str.charCodeAt(index);
 });
 
-Override.create("java/lang/String.getChars.(II[CI)V", function(ctx, srcBegin, srcEnd, dst, dstBegin) {
+Override.create("java/lang/String.getChars.(II[CI)V", function(srcBegin, srcEnd, dst, dstBegin) {
   if (srcBegin < 0 || srcEnd > this.str.length || srcBegin > srcEnd ||
       dstBegin + (srcEnd - srcBegin) > dst.length || dstBegin < 0) {
     throw new JavaException("java/lang/IndexOutOfBoundsException");
@@ -123,7 +123,7 @@ function normalizeEncoding(enc) {
   return encoding;
 }
 
-Override.create("java/lang/String.getBytes.(Ljava/lang/String;)[B", function(ctx, jEnc) {
+Override.create("java/lang/String.getBytes.(Ljava/lang/String;)[B", function(jEnc) {
   try {
     var encoding = normalizeEncoding(jEnc.str);
     return new Int8Array(new TextEncoder(encoding).encode(this.str));
@@ -132,19 +132,19 @@ Override.create("java/lang/String.getBytes.(Ljava/lang/String;)[B", function(ctx
   }
 });
 
-Override.create("java/lang/String.getBytes.()[B", function(ctx) {
+Override.create("java/lang/String.getBytes.()[B", function() {
   return new Int8Array(new TextEncoder("utf-8").encode(this.str));
 });
 
-Override.create("java/lang/String.equals.(Ljava/lang/Object;)Z", function(ctx, anObject) {
+Override.create("java/lang/String.equals.(Ljava/lang/Object;)Z", function(anObject) {
   return !!(isString(anObject) && anObject.str === this.str);
 });
 
-Override.create("java/lang/String.equalsIgnoreCase.(Ljava/lang/String;)Z", function(ctx, anotherString) {
+Override.create("java/lang/String.equalsIgnoreCase.(Ljava/lang/String;)Z", function(anotherString) {
   return !!(isString(anotherString) && anotherString.str.toLowerCase() === this.str.toLowerCase());
 });
 
-Override.create("java/lang/String.compareTo.(Ljava/lang/String;)I", function(ctx, anotherString) {
+Override.create("java/lang/String.compareTo.(Ljava/lang/String;)I", function(anotherString) {
   // Sadly, JS String doesn't have a compareTo() method, so we must
   // replicate the Java algorithm. (There is String.localeCompare, but
   // that only returns {-1, 0, 1}, not a distance measure, which this
@@ -164,25 +164,25 @@ Override.create("java/lang/String.compareTo.(Ljava/lang/String;)I", function(ctx
   return len1 - len2;
 });
 
-Override.create("java/lang/String.regionMatches.(ZILjava/lang/String;II)Z", function(ctx, ignoreCase, toffset, other, ooffset, len) {
+Override.create("java/lang/String.regionMatches.(ZILjava/lang/String;II)Z", function(ignoreCase, toffset, other, ooffset, len) {
   var a = (ignoreCase ? this.str.toLowerCase() : this.str);
   var b = (ignoreCase ? other.str.toLowerCase() : other.str);
   return a.substr(toffset, len) === b.substr(ooffset, len);
 });
 
-Override.create("java/lang/String.startsWith.(Ljava/lang/String;I)Z", function(ctx, prefix, toffset) {
+Override.create("java/lang/String.startsWith.(Ljava/lang/String;I)Z", function(prefix, toffset) {
   return this.str.substr(toffset, prefix.str.length) === prefix.str;
 });
 
-Override.create("java/lang/String.startsWith.(Ljava/lang/String;)Z", function(ctx, prefix) {
+Override.create("java/lang/String.startsWith.(Ljava/lang/String;)Z", function(prefix) {
   return this.str.substr(0, prefix.str.length) === prefix.str;
 });
 
-Override.create("java/lang/String.endsWith.(Ljava/lang/String;)Z", function(ctx, suffix) {
+Override.create("java/lang/String.endsWith.(Ljava/lang/String;)Z", function(suffix) {
   return this.str.indexOf(suffix.str, this.str.length - suffix.str.length) !== -1;
 });
 
-Override.create("java/lang/String.hashCode.()I", function(ctx) {
+Override.create("java/lang/String.hashCode.()I", function() {
   var hash = 0;
   for (var i = 0; i < this.str.length; i++) {
     hash = Math.imul(31, hash) + this.str.charCodeAt(i) | 0;
@@ -190,45 +190,45 @@ Override.create("java/lang/String.hashCode.()I", function(ctx) {
   return hash;
 });
 
-Override.create("java/lang/String.indexOf.(I)I", function(ctx, ch) {
+Override.create("java/lang/String.indexOf.(I)I", function(ch) {
   return this.str.indexOf(String.fromCharCode(ch));
 });
 
-Override.create("java/lang/String.indexOf.(II)I", function(ctx, ch, fromIndex) {
+Override.create("java/lang/String.indexOf.(II)I", function(ch, fromIndex) {
   return this.str.indexOf(String.fromCharCode(ch), fromIndex);
 });
 
-Override.create("java/lang/String.lastIndexOf.(I)I", function(ctx, ch) {
+Override.create("java/lang/String.lastIndexOf.(I)I", function(ch) {
   return this.str.lastIndexOf(String.fromCharCode(ch));
 });
 
-Override.create("java/lang/String.lastIndexOf.(II)I", function(ctx, ch, fromIndex) {
+Override.create("java/lang/String.lastIndexOf.(II)I", function(ch, fromIndex) {
   return this.str.lastIndexOf(String.fromCharCode(ch), fromIndex);
 });
 
-Override.create("java/lang/String.indexOf.(Ljava/lang/String;)I", function(ctx, s) {
+Override.create("java/lang/String.indexOf.(Ljava/lang/String;)I", function(s) {
   return this.str.indexOf(s.str);
 });
 
-Override.create("java/lang/String.indexOf.(Ljava/lang/String;I)I", function(ctx, s, fromIndex) {
+Override.create("java/lang/String.indexOf.(Ljava/lang/String;I)I", function(s, fromIndex) {
   return this.str.indexOf(s.str, fromIndex);
 });
 
-Override.create("java/lang/String.substring.(I)Ljava/lang/String;", function(ctx, beginIndex) {
+Override.create("java/lang/String.substring.(I)Ljava/lang/String;", function(beginIndex) {
   if (beginIndex < 0 || beginIndex > this.str.length) {
     throw new JavaException("java/lang/IndexOutOfBoundsException");
   }
   return this.str.substring(beginIndex);
 });
 
-Override.create("java/lang/String.substring.(II)Ljava/lang/String;", function(ctx, beginIndex, endIndex) {
+Override.create("java/lang/String.substring.(II)Ljava/lang/String;", function(beginIndex, endIndex) {
   if (beginIndex < 0 || endIndex > this.str.length || beginIndex > endIndex) {
     throw new JavaException("java/lang/IndexOutOfBoundsException");
   }
   return this.str.substring(beginIndex, endIndex);
 });
 
-Override.create("java/lang/String.concat.(Ljava/lang/String;)Ljava/lang/String;", function(ctx, s) {
+Override.create("java/lang/String.concat.(Ljava/lang/String;)Ljava/lang/String;", function(s) {
   return this.str + s.str;
 });
 
@@ -237,22 +237,22 @@ function escapeRegExp(str) {
   return str.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&");
 }
 
-Override.create("java/lang/String.replace.(CC)Ljava/lang/String;", function(ctx, oldChar, newChar) {
+Override.create("java/lang/String.replace.(CC)Ljava/lang/String;", function(oldChar, newChar) {
   // Using a RegExp here to replace all matches of oldChar, rather than just the first.
   return this.str.replace(
     new RegExp(escapeRegExp(String.fromCharCode(oldChar)), "g"),
     String.fromCharCode(newChar));
 });
 
-Override.create("java/lang/String.toLowerCase.()Ljava/lang/String;", function(ctx) {
+Override.create("java/lang/String.toLowerCase.()Ljava/lang/String;", function() {
   return this.str.toLowerCase();
 });
 
-Override.create("java/lang/String.toUpperCase.()Ljava/lang/String;", function(ctx) {
+Override.create("java/lang/String.toUpperCase.()Ljava/lang/String;", function() {
   return this.str.toUpperCase();
 });
 
-Override.create("java/lang/String.trim.()Ljava/lang/String;", function(ctx) {
+Override.create("java/lang/String.trim.()Ljava/lang/String;", function() {
   // Java's String.trim() removes any character <= ASCII 32;
   // JavaScript's only removes a few whitespacey chars.
   var start = 0;
@@ -267,11 +267,11 @@ Override.create("java/lang/String.trim.()Ljava/lang/String;", function(ctx) {
   return this.str.substring(start, end);
 });
 
-Override.create("java/lang/String.toString.()Ljava/lang/String;", function(ctx) {
+Override.create("java/lang/String.toString.()Ljava/lang/String;", function() {
   return this; // Note: returning "this" so that we keep the same object.
 });
 
-Override.create("java/lang/String.toCharArray.()[C", function(ctx) {
+Override.create("java/lang/String.toCharArray.()[C", function() {
   return util.stringToCharArray(this.str);
 });
 
@@ -281,33 +281,33 @@ Override.create("java/lang/String.toCharArray.()[C", function(ctx) {
 // NOTE: String.valueOf(Object) left in Java to avoid having to call
 // back into Java for Object.toString().
 
-Override.create("java/lang/String.valueOf.([C)Ljava/lang/String;", function(ctx, chars) {
+Override.create("java/lang/String.valueOf.([C)Ljava/lang/String;", function(chars) {
   if (!chars) {
     throw new JavaException("java/lang/NullPointerException");
   }
   return util.fromJavaChars(chars);
 });
 
-Override.create("java/lang/String.valueOf.([CII)Ljava/lang/String;", function(ctx, chars, offset, count) {
+Override.create("java/lang/String.valueOf.([CII)Ljava/lang/String;", function(chars, offset, count) {
   if (!chars) {
     throw new JavaException("java/lang/NullPointerException");
   }
   return util.fromJavaChars(chars, offset, count);
 });
 
-Override.create("java/lang/String.valueOf.(Z)Ljava/lang/String;", function(ctx, bool) {
+Override.create("java/lang/String.valueOf.(Z)Ljava/lang/String;", function(bool) {
   return bool ? "true" : "false";
 });
 
-Override.create("java/lang/String.valueOf.(C)Ljava/lang/String;", function(ctx, ch) {
+Override.create("java/lang/String.valueOf.(C)Ljava/lang/String;", function(ch) {
   return String.fromCharCode(ch);
 });
 
-Override.create("java/lang/String.valueOf.(I)Ljava/lang/String;", function(ctx, n) {
+Override.create("java/lang/String.valueOf.(I)Ljava/lang/String;", function(n) {
   return n.toString();
 });
 
-Override.create("java/lang/String.valueOf.(J)Ljava/lang/String;", function(ctx, n, _) {
+Override.create("java/lang/String.valueOf.(J)Ljava/lang/String;", function(n, _) {
   // This function takes a dummy second argument, since we're taking a
   // Long and need to pop two items off the stack.
   return n.toString();
@@ -321,7 +321,7 @@ Override.create("java/lang/String.valueOf.(J)Ljava/lang/String;", function(ctx, 
 
 var internedStrings = new Map();
 
-Native.create("java/lang/String.intern.()Ljava/lang/String;", function(ctx) {
+Native.create("java/lang/String.intern.()Ljava/lang/String;", function() {
     var string = util.fromJavaString(this);
 
     var internedString = internedStrings.get(string);
@@ -339,12 +339,12 @@ Native.create("java/lang/String.intern.()Ljava/lang/String;", function(ctx) {
 //################################################################
 // java.lang.StringBuffer (manipulated via the 'buf' property)
 
-Override.create("java/lang/StringBuffer.<init>.()V", function(ctx) {
+Override.create("java/lang/StringBuffer.<init>.()V", function() {
   this.buf = new Uint16Array(16); // Initial buffer size: 16, per the Java implementation.
   this.count = 0;
 });
 
-Override.create("java/lang/StringBuffer.<init>.(I)V", function(ctx, length) {
+Override.create("java/lang/StringBuffer.<init>.(I)V", function(length) {
   if (length < 0) {
     throw new JavaException("java/lang/NegativeArraySizeException");
   }
@@ -352,22 +352,22 @@ Override.create("java/lang/StringBuffer.<init>.(I)V", function(ctx, length) {
   this.count = 0;
 });
 
-Override.create("java/lang/StringBuffer.<init>.(Ljava/lang/String;)V", function(ctx, jStr) {
+Override.create("java/lang/StringBuffer.<init>.(Ljava/lang/String;)V", function(jStr) {
   var stringBuf = util.stringToCharArray(jStr.str);
   this.buf = new Uint16Array(stringBuf.length + 16); // Add 16, per the Java implementation.
   this.buf.set(stringBuf, 0);
   this.count = stringBuf.length;
 });
 
-Override.create("java/lang/StringBuffer.length.()I", function(ctx) {
+Override.create("java/lang/StringBuffer.length.()I", function() {
   return this.count;
 });
 
-Override.create("java/lang/StringBuffer.capacity.()I", function(ctx) {
+Override.create("java/lang/StringBuffer.capacity.()I", function() {
   return this.buf.length;
 });
 
-Override.create("java/lang/StringBuffer.copy.()V", function(ctx) {
+Override.create("java/lang/StringBuffer.copy.()V", function() {
   // We don't support copying (there's no need unless we also support shared buffers).
 });
 
@@ -388,7 +388,7 @@ function expandCapacity(minCapacity) {
   this.buf.set(oldBuf, 0);
 }
 
-Override.create("java/lang/StringBuffer.ensureCapacity.(I)V", function(ctx, minCapacity) {
+Override.create("java/lang/StringBuffer.ensureCapacity.(I)V", function(minCapacity) {
   if (this.buf.length < minCapacity) {
     expandCapacity.call(this, minCapacity);
   }
@@ -396,7 +396,7 @@ Override.create("java/lang/StringBuffer.ensureCapacity.(I)V", function(ctx, minC
 
 // StringBuffer.expandCapacity is private and not needed with these overrides.
 
-Override.create("java/lang/StringBuffer.setLength.(I)V", function(ctx, newLength) {
+Override.create("java/lang/StringBuffer.setLength.(I)V", function(newLength) {
   if (newLength < 0) {
     throw new JavaException("java/lang/StringIndexOutOfBoundsException");
   }
@@ -411,14 +411,14 @@ Override.create("java/lang/StringBuffer.setLength.(I)V", function(ctx, newLength
 });
 
 
-Override.create("java/lang/StringBuffer.charAt.(I)C", function(ctx, index) {
+Override.create("java/lang/StringBuffer.charAt.(I)C", function(index) {
   if (index < 0 || index >= this.count) {
     throw new JavaException("java/lang/StringIndexOutOfBoundsException");
   }
   return this.buf[index];
 });
 
-Override.create("java/lang/StringBuffer.getChars.(II[CI)V", function(ctx, srcBegin, srcEnd, dst, dstBegin) {
+Override.create("java/lang/StringBuffer.getChars.(II[CI)V", function(srcBegin, srcEnd, dst, dstBegin) {
   if (srcBegin < 0 || srcEnd < 0 || srcEnd > this.count || srcBegin > srcEnd) {
     throw new JavaException("java/lang/StringIndexOutOfBoundsException");
   }
@@ -428,7 +428,7 @@ Override.create("java/lang/StringBuffer.getChars.(II[CI)V", function(ctx, srcBeg
   dst.set(this.buf.subarray(srcBegin, srcEnd), dstBegin);
 });
 
-Override.create("java/lang/StringBuffer.setCharAt.(IC)V", function(ctx, index, ch) {
+Override.create("java/lang/StringBuffer.setCharAt.(IC)V", function(index, ch) {
   if (index < 0 || index >= this.count) {
     throw new JavaException("java/lang/StringIndexOutOfBoundsException");
   }
@@ -461,18 +461,18 @@ function stringBufferAppend(data) {
 
 // StringBuffer.append(java.lang.Object) left in Java to avoid Object.toString().
 
-Override.create("java/lang/StringBuffer.append.(Ljava/lang/String;)Ljava/lang/StringBuffer;", function(ctx, jStr) {
+Override.create("java/lang/StringBuffer.append.(Ljava/lang/String;)Ljava/lang/StringBuffer;", function(jStr) {
   return stringBufferAppend.call(this, jStr ? jStr.str : "null");
 });
 
-Override.create("java/lang/StringBuffer.append.([C)Ljava/lang/StringBuffer;", function(ctx, chars) {
+Override.create("java/lang/StringBuffer.append.([C)Ljava/lang/StringBuffer;", function(chars) {
   if (chars == null) {
     throw new JavaException("java/lang/NullPointerException");
   }
   return stringBufferAppend.call(this, chars);
 });
 
-Override.create("java/lang/StringBuffer.append.([CII)Ljava/lang/StringBuffer;", function(ctx, chars, offset, length) {
+Override.create("java/lang/StringBuffer.append.([CII)Ljava/lang/StringBuffer;", function(chars, offset, length) {
   if (chars == null) {
     throw new JavaException("java/lang/NullPointerException");
   }
@@ -482,11 +482,11 @@ Override.create("java/lang/StringBuffer.append.([CII)Ljava/lang/StringBuffer;", 
   return stringBufferAppend.call(this, chars.subarray(offset, offset + length));
 });
 
-Override.create("java/lang/StringBuffer.append.(Z)Ljava/lang/StringBuffer;", function(ctx, bool) {
+Override.create("java/lang/StringBuffer.append.(Z)Ljava/lang/StringBuffer;", function(bool) {
   return stringBufferAppend.call(this, bool ? "true" : "false");
 });
 
-Override.create("java/lang/StringBuffer.append.(C)Ljava/lang/StringBuffer;", function(ctx, ch) {
+Override.create("java/lang/StringBuffer.append.(C)Ljava/lang/StringBuffer;", function(ch) {
   if (this.buf.length < this.count + 1) {
     expandCapacity.call(this, this.count + 1);
   }
@@ -494,11 +494,11 @@ Override.create("java/lang/StringBuffer.append.(C)Ljava/lang/StringBuffer;", fun
   return this;
 });
 
-Override.create("java/lang/StringBuffer.append.(I)Ljava/lang/StringBuffer;", function(ctx, n) {
+Override.create("java/lang/StringBuffer.append.(I)Ljava/lang/StringBuffer;", function(n) {
   return stringBufferAppend.call(this, n + "");
 });
 
-Override.create("java/lang/StringBuffer.append.(J)Ljava/lang/StringBuffer;", function(ctx, n, _) {
+Override.create("java/lang/StringBuffer.append.(J)Ljava/lang/StringBuffer;", function(n, _) {
   return stringBufferAppend.call(this, n + "");
 });
 
@@ -514,7 +514,7 @@ Override.create("java/lang/StringBuffer.append.(J)Ljava/lang/StringBuffer;", fun
  * @param {number} end
  * @return this
  */
-function stringBufferDelete(ctx, start, end) {
+function stringBufferDelete(start, end) {
   if (start < 0) {
     throw new JavaException("java/lang/StringIndexOutOfBoundsException");
   }
@@ -537,12 +537,12 @@ function stringBufferDelete(ctx, start, end) {
 Override.create("java/lang/StringBuffer.delete.(II)Ljava/lang/StringBuffer;",
                 stringBufferDelete);
 
-Override.create("java/lang/StringBuffer.deleteCharAt.(I)Ljava/lang/StringBuffer;", function(ctx, index) {
+Override.create("java/lang/StringBuffer.deleteCharAt.(I)Ljava/lang/StringBuffer;", function(index) {
   if (index >= this.count) {
     // stringBufferDelete handles the other boundary checks; this check is specific to deleteCharAt.
     throw new JavaException("java/lang/StringIndexOutOfBoundsException");
   }
-  return stringBufferDelete.call(this, ctx, index, index + 1);
+  return stringBufferDelete.call(this, index, index + 1);
 });
 
 /**
@@ -575,27 +575,27 @@ function stringBufferInsert(offset, data) {
 
 // StringBuffer.insert(Object) left in Java (for String.valueOf()).
 
-Override.create("java/lang/StringBuffer.insert.(ILjava/lang/String;)Ljava/lang/StringBuffer;", function(ctx, offset, jStr) {
+Override.create("java/lang/StringBuffer.insert.(ILjava/lang/String;)Ljava/lang/StringBuffer;", function(offset, jStr) {
   return stringBufferInsert.call(this, offset, jStr ? jStr.str : "null");
 });
 
-Override.create("java/lang/StringBuffer.insert.(I[C)Ljava/lang/StringBuffer;", function(ctx, offset, chars) {
+Override.create("java/lang/StringBuffer.insert.(I[C)Ljava/lang/StringBuffer;", function(offset, chars) {
   return stringBufferInsert.call(this, offset, chars);
 });
 
-Override.create("java/lang/StringBuffer.insert.(IZ)Ljava/lang/StringBuffer;", function(ctx, offset, bool) {
+Override.create("java/lang/StringBuffer.insert.(IZ)Ljava/lang/StringBuffer;", function(offset, bool) {
   return stringBufferInsert.call(this, offset, bool ? "true" : "false");
 });
 
-Override.create("java/lang/StringBuffer.insert.(IC)Ljava/lang/StringBuffer;", function(ctx, offset, ch) {
+Override.create("java/lang/StringBuffer.insert.(IC)Ljava/lang/StringBuffer;", function(offset, ch) {
   return stringBufferInsert.call(this, offset, String.fromCharCode(ch));
 });
 
-Override.create("java/lang/StringBuffer.insert.(II)Ljava/lang/StringBuffer;", function(ctx, offset, n) {
+Override.create("java/lang/StringBuffer.insert.(II)Ljava/lang/StringBuffer;", function(offset, n) {
   return stringBufferInsert.call(this, offset, n + "");
 });
 
-Override.create("java/lang/StringBuffer.insert.(IJ)Ljava/lang/StringBuffer;", function(ctx, offset, n, _) {
+Override.create("java/lang/StringBuffer.insert.(IJ)Ljava/lang/StringBuffer;", function(offset, n, _) {
   return stringBufferInsert.call(this, offset, n + "");
 });
 
@@ -603,7 +603,7 @@ Override.create("java/lang/StringBuffer.insert.(IJ)Ljava/lang/StringBuffer;", fu
 
 // StringBuffer.insert(double) left in Java.
 
-Override.create("java/lang/StringBuffer.reverse.()Ljava/lang/StringBuffer;", function(ctx) {
+Override.create("java/lang/StringBuffer.reverse.()Ljava/lang/StringBuffer;", function() {
   var buf = this.buf;
   for (var i = 0, j = this.count - 1; i < j; i++, j--) {
     var tmp = buf[i];
@@ -613,15 +613,15 @@ Override.create("java/lang/StringBuffer.reverse.()Ljava/lang/StringBuffer;", fun
   return this;
 });
 
-Override.create("java/lang/StringBuffer.toString.()Ljava/lang/String;", function(ctx) {
+Override.create("java/lang/StringBuffer.toString.()Ljava/lang/String;", function() {
   return util.fromJavaChars(this.buf, 0, this.count);
 });
 
-Override.create("java/lang/StringBuffer.setShared.()V", function(ctx) {
+Override.create("java/lang/StringBuffer.setShared.()V", function() {
   // Our StringBuffers are never shared. Everyone gets their very own!
 });
 
-Override.create("java/lang/StringBuffer.getValue.()[C", function(ctx) {
+Override.create("java/lang/StringBuffer.getValue.()[C", function() {
   // In theory, this method should only be called by String (which
   // we've overridden to not do), so it should never be called. In any
   // case, mutating this buf would have the same effect here as it

--- a/tests/native.js
+++ b/tests/native.js
@@ -1,51 +1,51 @@
 /* -*- Mode: Java; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
 /* vim: set shiftwidth=2 tabstop=2 autoindent cindent expandtab: */
 
-Native.create("gnu/testlet/vm/NativeTest.getInt.()I", function(ctx) {
+Native.create("gnu/testlet/vm/NativeTest.getInt.()I", function() {
   return 0xFFFFFFFF;
 });
 
-Native.create("gnu/testlet/vm/NativeTest.getLongReturnLong.(J)J", function(ctx, val, _) {
+Native.create("gnu/testlet/vm/NativeTest.getLongReturnLong.(J)J", function(val, _) {
   return Long.fromNumber(40 + val.toNumber());
 });
 
-Native.create("gnu/testlet/vm/NativeTest.getLongReturnInt.(J)I", function(ctx, val, _) {
+Native.create("gnu/testlet/vm/NativeTest.getLongReturnInt.(J)I", function(val, _) {
   return 40 + val.toNumber();
 });
 
-Native.create("gnu/testlet/vm/NativeTest.getIntReturnLong.(I)J", function(ctx, val) {
+Native.create("gnu/testlet/vm/NativeTest.getIntReturnLong.(I)J", function(val) {
   return Long.fromNumber(40 + val);
 });
 
-Native.create("gnu/testlet/vm/NativeTest.throwException.()V", function(ctx) {
+Native.create("gnu/testlet/vm/NativeTest.throwException.()V", function() {
   throw new JavaException("java/lang/NullPointerException", "An exception");
 });
 
-Native.create("gnu/testlet/vm/NativeTest.throwExceptionAfterPause.()V", function(ctx) {
+Native.create("gnu/testlet/vm/NativeTest.throwExceptionAfterPause.()V", function() {
   return new Promise(function(resolve, reject) {
     setTimeout(reject.bind(null, new JavaException("java/lang/NullPointerException", "An exception")), 100);
   });
 });
 
-Native.create("gnu/testlet/vm/NativeTest.returnAfterPause.()I", function(ctx) {
+Native.create("gnu/testlet/vm/NativeTest.returnAfterPause.()I", function() {
   return new Promise(function(resolve, reject) {
     setTimeout(resolve.bind(null, 42), 100);
   });
 });
 
-Native.create("gnu/testlet/vm/NativeTest.nonStatic.(I)I", function(ctx, val) {
+Native.create("gnu/testlet/vm/NativeTest.nonStatic.(I)I", function(val) {
   return val + 40;
 });
 
-Native.create("gnu/testlet/vm/NativeTest.fromJavaString.(Ljava/lang/String;)I", function(ctx, str) {
+Native.create("gnu/testlet/vm/NativeTest.fromJavaString.(Ljava/lang/String;)I", function(str) {
   return util.fromJavaString(str).length;
 });
 
-Native.create("gnu/testlet/vm/NativeTest.decodeUtf8.([B)I", function(ctx, str) {
+Native.create("gnu/testlet/vm/NativeTest.decodeUtf8.([B)I", function(str) {
   return util.decodeUtf8(str).length;
 });
 
-Native.create("gnu/testlet/vm/NativeTest.newFunction.()Z", function(ctx) {
+Native.create("gnu/testlet/vm/NativeTest.newFunction.()Z", function() {
   try {
     var fn = new Function("return true;");
     return fn();
@@ -55,7 +55,7 @@ Native.create("gnu/testlet/vm/NativeTest.newFunction.()Z", function(ctx) {
   }
 });
 
-Native.create("gnu/testlet/vm/NativeTest.dumbPipe.()Z", function(ctx) {
+Native.create("gnu/testlet/vm/NativeTest.dumbPipe.()Z", function() {
   return new Promise(function(resolve, reject) {
     // Ensure we can echo a large amount of data.
     var array = [];

--- a/tests/override.js
+++ b/tests/override.js
@@ -1,6 +1,6 @@
 /* -*- Mode: Java; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
 /* vim: set shiftwidth=2 tabstop=2 autoindent cindent expandtab: */
 
-Override["gnu/testlet/vm/OverrideTest.overridden.()I"] = function(ctx, stack) {
-  stack.push(2);
-}
+Override.create("gnu/testlet/vm/OverrideTest.overridden.()I", function() {
+  return 2;
+});


### PR DESCRIPTION
This way natives that don't need the _ctx_ parameter can avoid to define it.

In a followup, I'll make more natives be independent from _ctx_ by moving _newArray_ and its relatives to _util_.
