### PR TITLE
VM stops if RuntimeException is not handled in a thread.

### DIFF
--- a/tests/automation.js
+++ b/tests/automation.js
@@ -41,7 +41,7 @@ casper.test.begin("unit tests", 5 + gfxTests.length, function(test) {
     .withFrame(0, function() {
         casper.waitForText("DONE", function() {
             var content = this.getPageContent();
-            if (content.contains("DONE: 70965 pass, 0 fail, 180 known fail, 0 unknown pass")) {
+            if (content.contains("DONE: 70966 pass, 0 fail, 180 known fail, 0 unknown pass")) {
               test.pass('main unit tests');
             } else {
               this.debugPage();

--- a/tests/java/lang/TestThread.java
+++ b/tests/java/lang/TestThread.java
@@ -1,0 +1,28 @@
+package java.lang;
+
+import gnu.testlet.Testlet;
+import gnu.testlet.TestHarness;
+
+public class TestThread implements Testlet {
+    private boolean result = false;
+
+    class RuntimeExceptionThread extends Thread {
+        public void run() {
+             throw new RuntimeException("runtime exception");
+        }
+    }
+
+    public void test(TestHarness th) {
+        try {
+            Thread t = new RuntimeExceptionThread();
+            t.start();
+            t.join();
+            result = true;
+        } catch (InterruptedException e) {
+            th.fail("unexpected InterruptedException");
+        }
+
+        th.check(result);
+    }
+}
+


### PR DESCRIPTION
An error is thrown in context.js:
 TypeError: caller is undefined
