### PR TITLE
Add stub com.nokia.mid.imei property

### DIFF
--- a/native.js
+++ b/native.js
@@ -147,6 +147,10 @@ Native.create("java/lang/System.getProperty0.(Ljava/lang/String;)Ljava/lang/Stri
         // The concatenation of MCC and MNC for the network.
         value = util.pad(mobileInfo.network.mcc, 3) + util.pad(mobileInfo.network.mnc, 3);
         break;
+    case "com.nokia.mid.imei":
+        console.warn("Property 'com.nokia.mid.imei' is a stub");
+        value = "";
+        break;
     case "com.nokia.mid.ui.customfontsize":
         console.warn("Property 'com.nokia.mid.ui.customfontsize' is a stub");
         value = "false";


### PR DESCRIPTION
I'm testing a MIDlet that assumes this property exists.

There's a function in this MIDlet that parses the IMEI value.
It creates a StringBuffer using the value returned by System.getProperty, without checking if it is null (this is why we are currently failing).
_StringBuffer stringBuffer = new StringBuffer(System.getProperty("com.nokia.mid.imei");_
Then checks the length of the string buffer and returns early if the length is 0.

This PR makes the function return early instead of throwing an exception.

We may need to actually create a valid fake IMEI to make the MIDlet work correctly, but I haven't tested yet.
