### PR TITLE
ignore native without profile data when exiting async native

### DIFF
--- a/instrument.js
+++ b/instrument.js
@@ -89,6 +89,11 @@ var Instrument = {
 
   exitAsyncNative: function(key) {
     var profileData = this.asyncProfile[key];
+    if (!profileData) {
+      // Ignore native without profile data, which can happen when you start
+      // profiling while the native is pending.
+      return;
+    }
     profileData.count++;
     profileData.cost += performance.now() - profileData.then;
   },


### PR DESCRIPTION
When an async native is pending, and you start profiling, then _Instrument.exitAsyncNative_ will get called once the native resolves without _Instrument.enterAsyncNative_ ever having been called. So _exitAsyncNative_ shouldn't assume that _profileData_ is defined.
