### PR TITLE
profile if profiling enabled even if instrumentation disabled

### DIFF
--- a/instrument.js
+++ b/instrument.js
@@ -14,13 +14,11 @@ var Instrument = {
   enabled: "instrument" in urlParams && !/no|0/.test(urlParams.instrument),
 
   callEnterHooks: function(methodInfo, caller, callee) {
-    if (!this.enabled) {
-      return;
-    }
-
-    var key = methodInfo.implKey;
-    if (Instrument.enter[key]) {
-      Instrument.enter[key](caller, callee);
+    if (this.enabled) {
+      var key = methodInfo.implKey;
+      if (Instrument.enter[key]) {
+        Instrument.enter[key](caller, callee);
+      }
     }
 
     if (this.profiling) {
@@ -39,10 +37,6 @@ var Instrument = {
   },
 
   callExitHooks: function(methodInfo, caller, callee) {
-    if (!this.enabled) {
-      return;
-    }
-
     var key = methodInfo.implKey;
 
     if (this.profiling) {
@@ -64,8 +58,10 @@ var Instrument = {
       }
     }
 
-    if (Instrument.exit[key]) {
-      Instrument.exit[key](caller, callee);
+    if (this.enabled) {
+      if (Instrument.exit[key]) {
+        Instrument.exit[key](caller, callee);
+      }
     }
   },
 


### PR DESCRIPTION
Profiling doesn't currently work if instrumentation is disabled, which isn't what I intended when I recently landed support for disabling instrumentation. Instrumentation clutters the console and may distort the profile, so it should possible to profile without instrumentation.

Here's the minimal fix. Long-term we may want to separate these facilities in the code, so it's harder for a change in one to break the other. But that would be a bigger change.
