### PR TITLE
awaken text editor thread if there are dirty editors when sleep() called

### DIFF
--- a/midp/gfx.js
+++ b/midp/gfx.js
@@ -1037,6 +1037,8 @@
         return new Promise(function(resolve, reject) {
           if (!dirtyEditors.length) {
               textEditorResolve = resolve;
+          } else {
+              resolve();
           }
         });
     });


### PR DESCRIPTION
If there are dirty editors when _TextEditorThread.run_ calls _TextEditorThread.sleep_, the latter will never return, because it only sets _textEditorResolve_ if there aren't dirty editors, so it doesn't set it, and thus _wakeTextEditorThread_ doesn't call it.

That means it's possible to hang _TextEditorThread_ forever by racing _TextEditorThread.run_: enter two characters quickly enough that the second one triggers a call to _wakeTextEditorThread_ (which pushes the editor ID onto _dirtyEditors_) before _TextEditorThread.run_ processes the first character and calls _TextEditorThread.sleep_ again.

The fix is trivial: simply call the promise's _resolve_ function immediately if there are dirty editors when _TextEditorThread.run_ calls _TextEditorThread.sleep_.
