### PR TITLE
Improve perf of createAlternanteImpl

### DIFF
--- a/midp/fs.js
+++ b/midp/fs.js
@@ -19,7 +19,7 @@ function(filenameBase, name, ext) {
         var path = RECORD_STORE_BASE + "/" + util.fromJavaString(filenameBase) + "/" + util.fromJavaString(name) + "." + ext;
         fs.exists(path, resolve);
     });
-});
+}, true);
 
 Native.create("com/sun/midp/rms/RecordStoreUtil.deleteFile.(Ljava/lang/String;Ljava/lang/String;I)V",
 function(filenameBase, name, ext) {
@@ -28,7 +28,7 @@ function(filenameBase, name, ext) {
 
         fs.remove(path, resolve);
     });
-});
+}, true);
 
 Native.create("com/sun/midp/rms/RecordStoreFile.spaceAvailableNewRecordStore0.(Ljava/lang/String;I)I", function(filenameBase, storageId) {
     // Pretend there is 50MiB available.  Our implementation is backed
@@ -82,7 +82,7 @@ function(filenameBase, name, ext) {
             }
         });
     });
-});
+}, true);
 
 Native.create("com/sun/midp/rms/RecordStoreFile.setPosition.(II)V", function(handle, pos) {
     fs.setpos(handle, pos);
@@ -112,7 +112,7 @@ Native.create("com/sun/midp/rms/RecordStoreFile.commitWrite.(I)V", function(hand
     return new Promise(function(resolve, reject) {
       fs.flush(handle, resolve);
     });
-});
+}, true);
 
 Native.create("com/sun/midp/rms/RecordStoreFile.closeFile.(I)V", function(handle) {
     return new Promise(function(resolve, reject) {
@@ -121,7 +121,7 @@ Native.create("com/sun/midp/rms/RecordStoreFile.closeFile.(I)V", function(handle
           resolve();
       });
     });
-});
+}, true);
 
 Native.create("com/sun/midp/rms/RecordStoreFile.truncateFile.(II)V", function(handle, size) {
     return new Promise(function(resolve, reject) {
@@ -130,7 +130,7 @@ Native.create("com/sun/midp/rms/RecordStoreFile.truncateFile.(II)V", function(ha
           resolve();
       });
     });
-});
+}, true);
 
 MIDP.RecordStoreCache = [];
 
@@ -282,7 +282,7 @@ Native.create("com/ibm/oti/connection/file/Connection.existsImpl.([B)Z", functio
     return new Promise(function(resolve, reject) {
       fs.exists(util.decodeUtf8(path), resolve);
     });
-});
+}, true);
 
 Native.create("com/ibm/oti/connection/file/Connection.fileSizeImpl.([B)J", function(path) {
     return new Promise(function(resolve, reject) {
@@ -290,7 +290,7 @@ Native.create("com/ibm/oti/connection/file/Connection.fileSizeImpl.([B)J", funct
             resolve(Long.fromNumber(size));
         });
     });
-});
+}, true);
 
 Native.create("com/ibm/oti/connection/file/Connection.isDirectoryImpl.([B)Z", function(path) {
     return new Promise(function(resolve, reject) {
@@ -298,7 +298,7 @@ Native.create("com/ibm/oti/connection/file/Connection.isDirectoryImpl.([B)Z", fu
             resolve(!!stat && stat.isDir);
         });
     });
-});
+}, true);
 
 Native.create("com/ibm/oti/connection/file/Connection.listImpl.([B[BZ)[[B",
 function(jPath, filterArray, includeHidden) {
@@ -364,7 +364,7 @@ function(jPath, filterArray, includeHidden) {
             });
         });
     });
-});
+}, true);
 
 
 Native.create("com/ibm/oti/connection/file/Connection.mkdirImpl.([B)I", function(path) {
@@ -374,7 +374,7 @@ Native.create("com/ibm/oti/connection/file/Connection.mkdirImpl.([B)I", function
             resolve(created ? 0 : 42);
         });
     });
-});
+}, true);
 
 Native.create("com/ibm/oti/connection/file/Connection.newFileImpl.([B)I", function(jPath) {
     var path = util.decodeUtf8(jPath);
@@ -394,13 +394,13 @@ Native.create("com/ibm/oti/connection/file/Connection.newFileImpl.([B)I", functi
             }
         });
     });
-});
+}, true);
 
 Native.create("com/ibm/oti/connection/file/Connection.deleteFileImpl.([B)Z", function(path) {
     return new Promise(function(resolve, reject) {
         fs.remove(util.decodeUtf8(path), resolve);
     });
-});
+}, true);
 
 Native["com/ibm/oti/connection/file/Connection.deleteDirImpl.([B)Z"] =
   Native["com/ibm/oti/connection/file/Connection.deleteFileImpl.([B)Z"]
@@ -421,7 +421,7 @@ Native.create("com/ibm/oti/connection/file/Connection.lastModifiedImpl.([B)J", f
             resolve(Long.fromNumber(stat != null ? stat.mtime : 0));
         });
     });
-});
+}, true);
 
 Native.create("com/ibm/oti/connection/file/Connection.renameImpl.([B[B)V", function(oldPath, newPath) {
     return new Promise(function(resolve, reject) {
@@ -434,7 +434,7 @@ Native.create("com/ibm/oti/connection/file/Connection.renameImpl.([B[B)V", funct
             resolve();
         });
     });
-});
+}, true);
 
 Native.create("com/ibm/oti/connection/file/Connection.truncateImpl.([BJ)V", function(path, newLength, _) {
     return new Promise(function(resolve, reject) {
@@ -451,13 +451,13 @@ Native.create("com/ibm/oti/connection/file/Connection.truncateImpl.([BJ)V", func
           });
         });
     });
-});
+}, true);
 
 Native.create("com/ibm/oti/connection/file/FCInputStream.openImpl.([B)I", function(path) {
     return new Promise(function(resolve, reject) {
       fs.open(util.decodeUtf8(path), resolve);
     });
-});
+}, true);
 
 Native.create("com/ibm/oti/connection/file/FCInputStream.availableImpl.(I)I", function(fd) {
     return fs.getsize(fd) - fs.getpos(fd);
@@ -517,7 +517,7 @@ Native.create("com/ibm/oti/connection/file/FCOutputStream.closeImpl.(I)V", funct
             resolve();
         });
     });
-});
+}, true);
 
 Native.create("com/ibm/oti/connection/file/FCOutputStream.openImpl.([B)I", function(jPath) {
     var path = util.decodeUtf8(jPath);
@@ -543,7 +543,7 @@ Native.create("com/ibm/oti/connection/file/FCOutputStream.openImpl.([B)I", funct
             }
         });
     });
-});
+}, true);
 
 Native.create("com/ibm/oti/connection/file/FCOutputStream.openOffsetImpl.([BJ)I", function(jPath, offset, _) {
     var path = util.decodeUtf8(jPath);
@@ -570,13 +570,13 @@ Native.create("com/ibm/oti/connection/file/FCOutputStream.openOffsetImpl.([BJ)I"
             }
         });
     });
-});
+}, true);
 
 Native.create("com/ibm/oti/connection/file/FCOutputStream.syncImpl.(I)V", function(fd) {
     return new Promise(function(resolve, reject) {
         fs.flush(fd, resolve);
     });
-});
+}, true);
 
 Native.create("com/ibm/oti/connection/file/FCOutputStream.writeByteImpl.(II)V", function(val, fd) {
     var buf = new Uint8Array(1);
@@ -619,7 +619,7 @@ Native.create("com/sun/midp/io/j2me/storage/RandomAccessStream.open.(Ljava/lang/
             }
         });
     });
-});
+}, true);
 
 Native.create("com/sun/midp/io/j2me/storage/RandomAccessStream.read.(I[BII)I",
 function(handle, buffer, offset, length) {
@@ -647,7 +647,7 @@ Native.create("com/sun/midp/io/j2me/storage/RandomAccessStream.commitWrite.(I)V"
     return new Promise(function(resolve, reject) {
         fs.flush(handle, resolve);
     });
-});
+}, true);
 
 Native.create("com/sun/midp/io/j2me/storage/RandomAccessStream.position.(II)V", function(handle, position) {
     fs.setpos(handle, position);
@@ -670,4 +670,4 @@ Native.create("com/sun/midp/io/j2me/storage/RandomAccessStream.close.(I)V", func
             resolve();
         });
     });
-});
+}, true);

--- a/midp/gfx.js
+++ b/midp/gfx.js
@@ -162,7 +162,7 @@
                 reject(new JavaException("java/lang/IllegalArgumentException", "error decoding image"));
             }
         });
-    });
+    }, true);
 
     Native.create("javax/microedition/lcdui/ImageDataFactory.createMutableImageData.(Ljavax/microedition/lcdui/ImageData;II)V",
     function(imageData, width, height) {
@@ -1041,7 +1041,7 @@
               resolve();
           }
         });
-    });
+    }, true);
 
     Native.create("com/nokia/mid/ui/TextEditorThread.getNextDirtyEditor.()I", function() {
         if (!dirtyEditors.length) {

--- a/midp/localmsg.js
+++ b/midp/localmsg.js
@@ -512,7 +512,7 @@ Native.create("org/mozilla/io/LocalMsgConnection.init.(Ljava/lang/String;)V", fu
 
         resolve();
     }).bind(this));
-});
+}, true);
 
 Native.create("org/mozilla/io/LocalMsgConnection.waitConnection.()V", function() {
     return MIDP.LocalMsgConnections[this.protocolName].waitConnection();
@@ -546,7 +546,7 @@ Native.create("org/mozilla/io/LocalMsgConnection.receiveData.([B)I", function(da
     }
 
     return MIDP.LocalMsgConnections[this.protocolName].clientReceiveMessage(data);
-});
+}, true);
 
 Native.create("org/mozilla/io/LocalMsgConnection.closeConnection.()V", function() {
     if (this.server) {

--- a/midp/midp.js
+++ b/midp/midp.js
@@ -715,7 +715,7 @@ Native.create("com/sun/midp/util/isolate/InterIsolateMutex.lock0.(I)V", function
             resolve();
         });
     });
-});
+}, true);
 
 Native.create("com/sun/midp/util/isolate/InterIsolateMutex.unlock0.(I)V", function(id, ctx) {
     var mutex;
@@ -844,7 +844,7 @@ function(nativeEvent, ctx) {
 
         MIDP.deliverWaitForNativeEventResult(resolve, nativeEvent, isolateId);
     });
-});
+}, true);
 
 Native.create("com/sun/midp/events/NativeEventMonitor.readNativeEvent.(Lcom/sun/midp/events/NativeEvent;)Z",
 function(obj, ctx) {
@@ -908,7 +908,7 @@ Native.create("com/sun/midp/main/CommandState.saveCommandState.(Lcom/sun/midp/ma
 Native.create("com/sun/midp/main/CommandState.exitInternal.(I)V", function(exit) {
     console.info("Exit: " + exit);
     return new Promise(function(){});
-});
+}, true);
 
 Native.create("com/sun/midp/suspend/SuspendSystem$MIDPSystem.allMidletsKilled.()Z", function() {
     console.warn("SuspendSystem$MIDPSystem.allMidletsKilled.()Z not implemented");
@@ -1053,7 +1053,7 @@ Native.create("com/sun/midp/io/j2me/push/ConnectionRegistry.poll0.(J)I", functio
             resolve(id);
         });
     });
-});
+}, true);
 
 Native.create("com/sun/midp/io/j2me/push/ConnectionRegistry.add0.(Ljava/lang/String;)I", function(connection) {
     var values = util.fromJavaString(connection).split(',');

--- a/midp/sms.js
+++ b/midp/sms.js
@@ -116,7 +116,7 @@ function(port, msid, handle, smsPacket) {
           }
         }
     });
-});
+}, true);
 
 Native.create("com/sun/midp/io/j2me/sms/Protocol.close0.(III)I", function(port, handle, deRegister) {
     delete MIDP.smsConnections[handle];

--- a/midp/socket.js
+++ b/midp/socket.js
@@ -90,7 +90,7 @@ Native.create("com/sun/midp/io/j2me/socket/Protocol.open0.([BI)V", function(ipBy
             }
         }).bind(this);
     }).bind(this));
-});
+}, true);
 
 Native.create("com/sun/midp/io/j2me/socket/Protocol.available0.()I", function() {
     // console.log("Protocol.available0: " + this.data.byteLength);
@@ -129,7 +129,7 @@ Native.create("com/sun/midp/io/j2me/socket/Protocol.read0.([BII)I", function(dat
 
         copyData();
     }).bind(this));
-});
+}, true);
 
 Native.create("com/sun/midp/io/j2me/socket/Protocol.write0.([BII)I", function(data, offset, length) {
     return new Promise(function(resolve, reject) {
@@ -155,7 +155,7 @@ Native.create("com/sun/midp/io/j2me/socket/Protocol.write0.([BII)I", function(da
 
         this.socket.send(data, offset, length);
     }.bind(this));
-});
+}, true);
 
 Native.create("com/sun/midp/io/j2me/socket/Protocol.setSockOpt0.(II)V", function(option, value) {
     if (!(option in this.options)) {
@@ -190,7 +190,7 @@ Native.create("com/sun/midp/io/j2me/socket/Protocol.close0.()V", function() {
 
         this.socket.close();
     }).bind(this));
-});
+}, true);
 
 Native.create("com/sun/midp/io/j2me/socket/Protocol.shutdownOutput0.()V", function() {
     // We don't have the ability to close the output stream independently

--- a/native.js
+++ b/native.js
@@ -508,7 +508,7 @@ Native.create("java/lang/Thread.sleep.(J)V", function(delay, _) {
     return new Promise(function(resolve, reject) {
         window.setTimeout(resolve, delay.toNumber());
     })
-});
+}, true);
 
 Native.create("java/lang/Thread.yield.()V", function() {
     throw VM.Yield;
@@ -613,7 +613,7 @@ Native.create("com/sun/cldc/isolate/Isolate.waitStatus.(I)V", function(status) {
         }
         waitForStatus();
     }).bind(this));
-});
+}, true);
 
 Native.create("com/sun/cldc/isolate/Isolate.currentIsolate0.()Lcom/sun/cldc/isolate/Isolate;", function(ctx) {
     return ctx.runtime.isolate;
@@ -652,7 +652,7 @@ Native.create("com/sun/midp/links/LinkPortal.getLinkCount0.()I", function(ctx) {
 
         resolve(links[isolateId].length);
     });
-});
+}, true);
 
 Native.create("com/sun/midp/links/LinkPortal.getLinks0.([Lcom/sun/midp/links/Link;)V", function(linkArray, ctx) {
     var isolateId = ctx.runtime.isolate.id;
@@ -683,7 +683,7 @@ Native.create("com/sun/midp/links/Link.receive0.(Lcom/sun/midp/links/LinkMessage
     // TODO: Implement when something hits send0
     console.warn("Called com/sun/midp/links/Link.receive0.(Lcom/sun/midp/links/LinkMessage;Lcom/sun/midp/links/Link;)V");
     return new Promise(function(){});
-});
+}, true);
 
 Native.create("com/sun/cldc/i18n/j2me/UTF_8_Reader.init.([B)V", function(data) {
     this.decoded = new TextDecoder("UTF-8").decode(data);

--- a/tests/native.js
+++ b/tests/native.js
@@ -25,13 +25,13 @@ Native.create("gnu/testlet/vm/NativeTest.throwExceptionAfterPause.()V", function
   return new Promise(function(resolve, reject) {
     setTimeout(reject.bind(null, new JavaException("java/lang/NullPointerException", "An exception")), 100);
   });
-});
+}, true);
 
 Native.create("gnu/testlet/vm/NativeTest.returnAfterPause.()I", function() {
   return new Promise(function(resolve, reject) {
     setTimeout(resolve.bind(null, 42), 100);
   });
-});
+}, true);
 
 Native.create("gnu/testlet/vm/NativeTest.nonStatic.(I)I", function(val) {
   return val + 40;
@@ -66,4 +66,4 @@ Native.create("gnu/testlet/vm/NativeTest.dumbPipe.()Z", function() {
       resolve(JSON.stringify(array) === JSON.stringify(message));
     });
   });
-});
+}, true);


### PR DESCRIPTION
- Creates return-type specific return functions that are determined at
  creation time.
- Splits off promise handling to it's own function. Overrides that use promises
  must indicate so when creating the override with the usesPromise param.
- Updates overrides that use promises
