### PR TITLE
Implement nokia.image-processing localmsg server

### DIFF
--- a/midp/localmsg.js
+++ b/midp/localmsg.js
@@ -520,12 +520,6 @@ NokiaImageProcessingLocalMsgConnection.prototype.sendMessageToServer = function(
         return;
       }
 
-      console.log("fileName: " + fileName);
-      console.log("max_vres: " + max_vres);
-      console.log("max_hres: " + max_hres);
-      console.log("aspect: " + aspect);
-      console.log("quality: " + quality);
-
       fs.open("/" + fileName, (function(fd) {
         var imgData = fs.read(fd);
         fs.close(fd);
@@ -533,9 +527,6 @@ NokiaImageProcessingLocalMsgConnection.prototype.sendMessageToServer = function(
         var img = new Image();
         img.src = URL.createObjectURL(new Blob([ imgData ]));
         img.onload = (function() {
-          console.log("width: " + img.naturalWidth);
-          console.log("height: " + img.naturalHeight);
-
           var canvas = document.createElement("canvas");
           canvas.width = Math.min(img.naturalWidth, max_hres);
           canvas.height = Math.min(img.naturalHeight, max_vres);
@@ -545,8 +536,6 @@ NokiaImageProcessingLocalMsgConnection.prototype.sendMessageToServer = function(
           canvas.toBlob((function(blob) {
             createUniqueFile("/nokiaimageprocessing", "image", blob, (function(fileName) {
               var encoder = new DataEncoder();
-
-              console.log("CREATED: " + fileName);
 
               encoder.putStart(DataType.STRUCT, "event");
               encoder.put(DataType.METHOD, "name", "Scale");
@@ -564,6 +553,7 @@ NokiaImageProcessingLocalMsgConnection.prototype.sendMessageToServer = function(
             }).bind(this));
           }).bind(this), "image/jpeg", quality / 100);
         }).bind(this);
+
         img.onerror = function(e) {
           console.error("Error in decoding image");
         };


### PR DESCRIPTION
This implements the nokia.image-processing localmsg server.

Images are always stored under the /nokiaimageprocessing directory and with an "image-XXX" name. I've decided this because I don't know what Nokia actually does, but looks like the MIDlet I'm testing is making no assumptions on where the file is placed.

The image is always stored as "image/jpeg", because AFAICT the MIDlet I'm testing always uses JPEG images here (when I tried to use a PNG image, the MIDlet said it wasn't supported).

I'll implement a test tomorrow, either in this PR or in a followup.
