### PR TITLE
Enable image.processing to work also if aspect is "LockToPartialView"

### DIFF
--- a/midp/localmsg.js
+++ b/midp/localmsg.js
@@ -594,7 +594,7 @@ NokiaImageProcessingLocalMsgConnection.prototype.sendMessageToServer = function(
       var quality = decoder.getValue(DataType.BYTE);
 
       if (aspect != "FullImage" && aspect != "LockToPartialView") {
-        console.error("(nokia.image-processing) event " + name + " with aspect != 'FullImage' not implemented " +
+        console.error("(nokia.image-processing) event " + name + " with aspect != 'FullImage' or 'LockToPartialView' not implemented " +
                       util.decodeUtf8(new Uint8Array(message.data.buffer, message.offset, message.length)));
         return;
       }


### PR DESCRIPTION
I'm not sure what the difference should be between the two, but a MIDlet I'm testing works correctly if we support LockToPartialView just like FullImage .
