### PR TITLE
specify origin for packaged app in manifest

### DIFF
--- a/manifest.webapp
+++ b/manifest.webapp
@@ -2,6 +2,7 @@
   "name": "j2me.js",
   "description": "j2me interpreter for firefox os",
   "launch_path": "/index.html?autosize=1&logConsole=web",
+  "origin": "app://j2mejs.mozilla.org",
   "icons": {
     "128": "/img/icon-128.png"
   },


### PR DESCRIPTION
When you _Open Packaged App…_ in WebIDE, the devtool assigns the app a random ID, so if you push the app to a device, _Remove Project_, and then _Open Packaged App…_ again, it gets a new ID, and pushing it to the device again results in two instances of the app on the device.

To prevent this, and make it possible to update the same app on device after removing and reopening it (or pushing it from a different Firefox profile, f.e. when using the Developer Edition with a different profile from the one you use for Nightly), we should assign the app an origin, which WebIDE will then use as the app ID.

Note [bug 1096524](https://bugzilla.mozilla.org/show_bug.cgi?id=1096524), which will make it look like WebIDE is still assigning the app a random ID, even though it's actually using the origin as the ID.
