### PR TITLE
Implement FileSystemRegistry.listRoots.

### DIFF
--- a/java/custom/javax/microedition/io/file/FileSystemRegistry.java
+++ b/java/custom/javax/microedition/io/file/FileSystemRegistry.java
@@ -18,8 +18,9 @@ public class FileSystemRegistry {
     }
 
     public static Enumeration listRoots() {
-        System.out.println("FileSystemRegistry::listRoots() not implemented.");
-        return new Vector().elements();
+        Vector roots = new Vector();
+        roots.addElement("");
+        return roots.elements();
     }
 }
 

--- a/tests/automation.js
+++ b/tests/automation.js
@@ -44,7 +44,7 @@ casper.test.begin("unit tests", 7 + gfxTests.length, function(test) {
     function basicUnitTests() {
         casper.waitForText("DONE", function() {
             var content = this.getPageContent();
-            if (content.contains("DONE: 71085 pass, 0 fail, 180 known fail, 0 unknown pass")) {
+            if (content.contains("DONE: 71087 pass, 0 fail, 180 known fail, 0 unknown pass")) {
                 test.pass('main unit tests');
             } else {
                 this.debugPage();

--- a/tests/javax/microedition/io/file/TestFileSystemRegistry.java
+++ b/tests/javax/microedition/io/file/TestFileSystemRegistry.java
@@ -1,0 +1,29 @@
+package javax.microedition.io.file;
+
+import gnu.testlet.TestHarness;
+import gnu.testlet.Testlet;
+import java.io.IOException;
+import java.util.Enumeration;
+import javax.microedition.io.Connector;
+
+public class TestFileSystemRegistry implements Testlet {
+
+    public void test(TestHarness th) {
+        try {
+            testListRoots(th);
+        } catch (Throwable e) {
+            th.todo(false, "Unexpected exception: " + e);
+            e.printStackTrace();
+        }
+    }
+
+    public void testListRoots(TestHarness th) throws IOException {
+        Enumeration rootEnum = FileSystemRegistry.listRoots();
+        th.check(rootEnum != null);
+        while (rootEnum.hasMoreElements()) {
+            String root = (String)rootEnum.nextElement();
+            FileConnection fc = (FileConnection)Connector.open("file:///" + root);
+            th.check(fc != null);
+        }
+    }
+}


### PR DESCRIPTION
This patch implements 
`public static java.util.Enumeration listRoots()`.

Currently we only have one root with the url `file:///`. 
FileSystemRegistry is part of JSR75. According to the spec as following, the root name should be "". So `listRoots()` returns an Emuneration of a single element "".
## JSR75 spec for FileSystemRegistry.listRoots

This method returns the currently mounted root file systems on a device as String objects in an Enumeration. If there are no roots available on the device, a zero length Enumeration is returned. If file systems are not supported on a device, a zero length Enumeration is also returned (this check is performed prior to security checks).

The first directory in the file URI is referred to as the root, which corresponds to a logical mount point for a particular storage unit or memory. Root strings are defined by the platform or implementation and can be a string of zero or more characters ("" can be a valid root string on some systems) followed by a trailing "/" to denote that the root is a directory. Each root string is guaranteed to uniquely refer to a root. Root names are device specific and are not required to adhere to any standard. Examples of possible root strings and how to open them include:

| Possible Root Value | Opening the Root |
| --- | --- |
| CFCard/ | Connector.open("file:///CFCard/"); |
| SDCard/ | Connector.open("file:///SDCard/"); |
| MemoryStick/ | Connector.open("file:///MemoryStick/"); |
| C:/ | Connector.open("file:///C:/"); |
| / | Connector.open("file:////"); |

The following is a sample showing the use of listRoots to retrieve the available size of all roots on a device:

```
   Enumeration rootEnum = FileSystemRegistry.listRoots();
   while (e.hasMoreElements()) {
      String root = (String) e.nextElement();
      FileConnection fc = Connector.open("file:///" + root);
      System.out.println(fc.availableSize());
   } 


Returns:
    an Eumeration of mounted file systems as String objects. 
Throws:
    java.lang.SecurityException - if application is not given permission to read files.
See Also:
    FileConnection
```
