### PR TITLE
specify -bootclasspath and -extdirs when compiling Java classes

### DIFF
--- a/java/Makefile
+++ b/java/Makefile
@@ -10,8 +10,8 @@ VPATH=./cldc1.1.1 ./vm ./midp ./custom
 classes.jar: $(SRCS) $(CUSTOM_SRCS) $(JPP_DESTS)
 	rm -rf build
 	mkdir build
-	javac -cp cldc1.1.1:vm:midp -source 1.3 -target 1.3 -d ./build $(SRCS) > /dev/null
-	javac -sourcepath custom -cp build -source 1.3 -target 1.3 -d ./build $(CUSTOM_SRCS) > /dev/null
+	javac -cp cldc1.1.1:vm:midp -source 1.3 -target 1.3 -bootclasspath "" -extdirs "" -d ./build $(SRCS) > /dev/null
+	javac -sourcepath custom -cp build -source 1.3 -target 1.3 -bootclasspath "" -extdirs "" -d ./build $(CUSTOM_SRCS) > /dev/null
 	cd build && jar cvf0 ../classes.jar *
 	jar uvf0 classes.jar $(EXTRA)
 	rm -rf build

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -32,9 +32,9 @@ tests.jar: $(SRCS) Testlets.java
 	rm -rf build
 	mkdir build
 	# Build the buildtime support classes in-place, not in ./build, so they aren't available at runtime.
-	javac -source 1.3 -target 1.3 -encoding UTF-8 -bootclasspath ../java/classes.jar $(BUILDTIME_SUPPORT_SRCS) > /dev/null
-	javac -source 1.3 -target 1.3 -encoding UTF-8 -bootclasspath ../java/classes.jar:$(BUILDTIME_SUPPORT_DIR) -d ./build $^ > /dev/null
-	javac -source 1.3 -target 1.3 -encoding UTF-8 -bootclasspath ../java/classes.jar -d ./build $(RUNTIME_SUPPORT_SRCS) > /dev/null
+	javac -source 1.3 -target 1.3 -encoding UTF-8 -bootclasspath ../java/classes.jar -extdirs "" $(BUILDTIME_SUPPORT_SRCS) > /dev/null
+	javac -source 1.3 -target 1.3 -encoding UTF-8 -bootclasspath ../java/classes.jar:$(BUILDTIME_SUPPORT_DIR) -extdirs "" -d ./build $^ > /dev/null
+	javac -source 1.3 -target 1.3 -encoding UTF-8 -bootclasspath ../java/classes.jar -extdirs "" -d ./build $(RUNTIME_SUPPORT_SRCS) > /dev/null
 	jar cvfe tests.jar RunTests -C build/ .
 	jar uvf $(PACKAGE_FILES) > /dev/null
 	rm -rf build


### PR DESCRIPTION
`make java` warns:

> warning: [options] bootstrap class path not set in conjunction with -source 1.3

That's because the compiler expects us to specify the location of the bootstrap and extension classes for the version we specify in the _-target_ flag. Otherwise, it uses the classes that came with the compiler, which may be incompatible with the ones our VM uses, leading to compile time errors, like the one @marco-c encountered while developing #583), or runtime errors, per `man javac`, whose Cross-Compilation Example says:

> The Java 2 SDk's javac would also by default compile against its own bootstrap classes, so we need to tell javac to compile against JDK 1.4 bootstrap classes instead.  We  do this  with -bootclasspath and -extdirs.  Failing to do this might allow compilation against a Java 2 Platform API that would not be present on a 1.4 VM and would fail at run-time.

So this change adds _-bootclasspath_ and _-extdirs_ flags to all the _javac_ invocations, which suppresses the warning and fixes the compilation issue in #583.

The combinations of path flags (_-cp_, _-bootclasspath_, _-extdirs_, _-sourcepath_) may not be entirely correct. For example, maybe we should actually replace _-cp_ with _-bootclasspath_ when compiling the _custom_ directory. But this appears to output the correct set of class files.
