### PR TITLE
measure async natives per promise

### DIFF
--- a/instrument.js
+++ b/instrument.js
@@ -78,20 +78,20 @@ var Instrument = {
     }
   },
 
-  enterAsyncNative: function(key) {
+  enterAsyncNative: function(key, promise) {
     var profileData = this.asyncProfile[key] || (this.asyncProfile[key] = { count: 0, cost: 0 });
-    profileData.then = performance.now();
+    promise.startTime = performance.now();
   },
 
-  exitAsyncNative: function(key) {
+  exitAsyncNative: function(key, promise) {
     var profileData = this.asyncProfile[key];
-    if (!profileData) {
+    if (!profileData || !promise.startTime) {
       // Ignore native without profile data, which can happen when you start
       // profiling while the native is pending.
       return;
     }
     profileData.count++;
-    profileData.cost += performance.now() - profileData.then;
+    profileData.cost += performance.now() - promise.startTime;
   },
 
   startProfile: function() {

--- a/override.js
+++ b/override.js
@@ -60,7 +60,7 @@ function executePromise(stack, ret, doReturn, ctx, key) {
   if (ret && ret.then) { // ret.constructor.name == "Promise"
     ret.then(function(res) {
       if (Instrument.profiling) {
-        Instrument.exitAsyncNative(key);
+        Instrument.exitAsyncNative(key, ret);
       }
 
       doReturn(stack, res);
@@ -69,7 +69,7 @@ function executePromise(stack, ret, doReturn, ctx, key) {
     }).then(ctx.start.bind(ctx));
 
     if (Instrument.profiling) {
-      Instrument.enterAsyncNative(key);
+      Instrument.enterAsyncNative(key, ret);
     }
 
     throw VM.Pause;


### PR DESCRIPTION
@marco-c I think this is correct, as async native calls can overlap, so calculating their execution time only by method key could cause inaccurate measurements. This change calculates the execution time per promise.
