### PR TITLE
add 'app' target to make output dir containing app files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all test tests java certs clean
+.PHONY: all test tests java certs app clean
 
 all: java tests
 
@@ -25,6 +25,10 @@ java:
 
 certs:
 	make -C certs
+
+# Makes an output/ directory containing the packaged open web app files.
+app: java certs
+	tools/package.sh
 
 clean:
 	rm -f j2me.js `find . -name "*~"`


### PR DESCRIPTION
@EricRahm landed tools/output.sh for copying the subset of files needed for the app to the output/ directory. This Makefile target calls that script to make that directory.
