### PR TITLE
start numbering file descriptors from 3

### DIFF
--- a/libs/fs.js
+++ b/libs/fs.js
@@ -87,7 +87,7 @@ var fs = (function() {
     });
   }
 
-  var openedFiles = [];
+  var openedFiles = [null, null, null];
   var fileStats = {};
 
   function open(path, cb) {

--- a/tests/fstests.js
+++ b/tests/fstests.js
@@ -25,6 +25,8 @@ function ok(a, msg) {
 
 var tests = [];
 
+var fd;
+
 function next() {
   if (tests.length == 0) {
     ok(true, "TESTS COMPLETED");
@@ -323,167 +325,168 @@ tests.push(function() {
 
 tests.push(function() {
   fs.open("/tmp/tmp.txt", function(fd) {
-    is(fd, 0, "opened a file");
+    is(fd, 3, "opened a file");
     next();
   });
 });
 
 tests.push(function() {
-  fs.close(0, next);
+  fs.close(3, next);
 });
 
 tests.push(function() {
-  fs.open("/tmp/tmp.txt", function(fd) {
-    is(fd, 1, "reopened a file");
+  fs.open("/tmp/tmp.txt", function(newFd) {
+    is(newFd, 4, "reopened a file");
+    fd = newFd;
     next();
   });
 });
 
 tests.push(function() {
-  var data = fs.read(1);
+  var data = fs.read(fd);
   is(data.byteLength, 0, "read from an empty file");
   next();
 });
 
 tests.push(function() {
-  var data = fs.read(1, 5);
+  var data = fs.read(fd, 5);
   is(data.byteLength, 0, "trying to read empty file with from > file size");
   next();
 });
 
 tests.push(function() {
-  var data = fs.read(1, 0, 5);
+  var data = fs.read(fd, 0, 5);
   is(data.byteLength, 0, "trying to read too much with empty file");
   next();
 });
 
 tests.push(function() {
-  fs.write(1, new TextEncoder().encode("marco"));
+  fs.write(fd, new TextEncoder().encode("marco"));
   next();
 });
 
 tests.push(function() {
-  var data = fs.read(1, 10);
+  var data = fs.read(fd, 10);
   is(data.byteLength, 0, "trying to read with from > file size");
   next();
 });
 
 tests.push(function() {
-  var data = fs.read(1, 5);
+  var data = fs.read(fd, 5);
   is(data.byteLength, 0, "trying to read with from == file size");
   next();
 });
 
 tests.push(function() {
-  var data = fs.read(1, 0, 10);
+  var data = fs.read(fd, 0, 10);
   is(data.byteLength, 5, "trying to read too much");
   is(new TextDecoder().decode(data), "marco", "read correct");
   next();
 });
 
 tests.push(function() {
-  fs.setpos(1, 0);
-  var data = fs.read(1);
+  fs.setpos(fd, 0);
+  var data = fs.read(fd);
   is(data.byteLength, 5, "read from a file with 5 bytes");
   is(new TextDecoder().decode(data), "marco", "read correct");
   next();
 });
 
 tests.push(function() {
-  fs.setpos(1, 0);
-  fs.write(1, new TextEncoder().encode("marco2"));
+  fs.setpos(fd, 0);
+  fs.write(fd, new TextEncoder().encode("marco2"));
   next();
 });
 
 tests.push(function() {
-  fs.setpos(1, 0);
-  var data = fs.read(1);
+  fs.setpos(fd, 0);
+  var data = fs.read(fd);
   is(data.byteLength, 6, "read from a file with 6 bytes");
   is(new TextDecoder().decode(data), "marco2", "read correct");
   next();
 });
 
 tests.push(function() {
-  var data = fs.read(1, 1);
+  var data = fs.read(fd, 1);
   is(data.byteLength, 5, "read 5 bytes from a file with 6 bytes");
   is(new TextDecoder().decode(data), "arco2", "read correct");
   next();
 });
 
 tests.push(function() {
-  var data = fs.read(1, 0, 1);
+  var data = fs.read(fd, 0, 1);
   is(data.byteLength, 1, "read 1 byte from a file with 6 bytes");
   is(new TextDecoder().decode(data), "m", "read correct");
   next();
 });
 
 tests.push(function() {
-  var data = fs.read(1, 1, 3);
+  var data = fs.read(fd, 1, 3);
   is(data.byteLength, 2, "read 2 bytes from a file with 6 bytes");
   is(new TextDecoder().decode(data), "ar", "read correct");
   next();
 });
 
 tests.push(function() {
-  var data = fs.read(1, 1, 1);
+  var data = fs.read(fd, 1, 1);
   is(data.byteLength, 0, "read 0 bytes from a file with 5 bytes");
   is(new TextDecoder().decode(data), "", "read correct");
   next();
 });
 
 tests.push(function() {
-  fs.write(1, new TextEncoder().encode("marco"), 1);
+  fs.write(fd, new TextEncoder().encode("marco"), 1);
   ok(true, "write with from");
   next();
 });
 
 tests.push(function() {
-  fs.setpos(1, 0);
-  var data = fs.read(1);
+  fs.setpos(fd, 0);
+  var data = fs.read(fd);
   is(data.byteLength, 6, "read from a file with 6 bytes");
   is(new TextDecoder().decode(data), "mmarco", "read correct");
   next();
 });
 
 tests.push(function() {
-  fs.setpos(1, 0);
-  fs.write(1, new TextEncoder().encode("mar"));
+  fs.setpos(fd, 0);
+  fs.write(fd, new TextEncoder().encode("mar"));
   ok(true, "write overwriting first bytes");
   next();
 });
 
 tests.push(function() {
-  fs.setpos(1, 0);
-  var data = fs.read(1);
+  fs.setpos(fd, 0);
+  var data = fs.read(fd);
   is(data.byteLength, 6, "read from a file with 6 bytes");
   is(new TextDecoder().decode(data), "marrco", "read correct");
   next();
 });
 
 tests.push(function() {
-  fs.write(1, new TextEncoder().encode("marco"), 2);
+  fs.write(fd, new TextEncoder().encode("marco"), 2);
   ok(true, "write overwriting and appending");
   next();
 });
 
 tests.push(function() {
-  fs.setpos(1, 0);
-  var data = fs.read(1);
+  fs.setpos(fd, 0);
+  var data = fs.read(fd);
   is(data.byteLength, 7, "read from a file with 7 bytes");
   is(new TextDecoder().decode(data), "mamarco", "read correct");
   next();
 });
 
 tests.push(function() {
-  fs.setpos(1, 0);
-  fs.write(1, new TextEncoder().encode("marco"), 20);
+  fs.setpos(fd, 0);
+  fs.write(fd, new TextEncoder().encode("marco"), 20);
   ok(true, "write appending with from > size of file");
   next();
 });
 
 tests.push(function() {
-  fs.setpos(1, 0);
-  var data = fs.read(1);
+  fs.setpos(fd, 0);
+  var data = fs.read(fd);
   is(data.byteLength, 12, "read from a file with 12 bytes");
   is(new TextDecoder().decode(data), "mamarcomarco", "read correct");
   next();
@@ -497,14 +500,14 @@ tests.push(function() {
 });
 
 tests.push(function() {
-  fs.flush(1, function() {
+  fs.flush(fd, function() {
     ok(true, "file data flushed");
     next();
   });
 });
 
 tests.push(function() {
-  is(fs.getsize(1), 12, "file's size is 12");
+  is(fs.getsize(fd), 12, "file's size is 12");
   next();
 });
 
@@ -514,18 +517,18 @@ tests.push(function() {
 });
 
 tests.push(function() {
-  fs.ftruncate(1, 6);
-  is(fs.getsize(1), 6, "truncated file's size is 6");
+  fs.ftruncate(fd, 6);
+  is(fs.getsize(fd), 6, "truncated file's size is 6");
   next();
 });
 
 tests.push(function() {
   // Test writing enough data to make the fs internal buffer increase (exponentially)
-  fs.write(1, new Uint8Array(6065), 6);
+  fs.write(fd, new Uint8Array(6065), 6);
 
-  is(fs.getsize(1), 6071, "file size is now 6071");
+  is(fs.getsize(fd), 6071, "file size is now 6071");
 
-  var data = fs.read(1, 0);
+  var data = fs.read(fd, 0);
 
   is(new TextDecoder().decode(data).substring(0, 6), "mamarc", "read correct");
 
@@ -534,11 +537,11 @@ tests.push(function() {
 
 tests.push(function() {
   // Test writing enough data to make the fs internal buffer increase (linearly)
-  fs.write(1, new Uint8Array(131073), 6);
+  fs.write(fd, new Uint8Array(131073), 6);
 
-  is(fs.getsize(1), 131079, "file size is now 131079");
+  is(fs.getsize(fd), 131079, "file size is now 131079");
 
-  var data = fs.read(1, 0);
+  var data = fs.read(fd, 0);
 
   is(new TextDecoder().decode(data).substring(0, 6), "mamarc", "read correct");
 
@@ -546,7 +549,7 @@ tests.push(function() {
 });
 
 tests.push(function() {
-  fs.close(1, next);
+  fs.close(fd, next);
 });
 
 tests.push(function() {


### PR DESCRIPTION
FCOutputStream hardcodes 1 and 2 as file descriptors for stdout and stderr, respectively; and it ignores calls to flush() for descriptors < 3; so we should start incrementing descriptors from 3.

But our descriptors are just indexes into an array, so we have to do that by making the array long enough.

Along the way, I made fstests.js store the descriptor for the file it uses for a bunch of its tests (instead of hardcoding it everywhere), so we won't have to touch as many lines of code the next time the descriptor changes.

We may want to change the way we increment and store descriptors in the future, but this is the minimal fix for the bug.
