### PR TITLE
Handle nested try-catch-finally block correctly. Fix #396

### DIFF
--- a/tests/automation.js
+++ b/tests/automation.js
@@ -44,7 +44,7 @@ casper.test.begin("unit tests", 7 + gfxTests.length, function(test) {
     function basicUnitTests() {
         casper.waitForText("DONE", function() {
             var content = this.getPageContent();
-            if (content.contains("DONE: 71095 pass, 0 fail, 179 known fail, 0 unknown pass")) {
+            if (content.contains("DONE: 71097 pass, 0 fail, 179 known fail, 0 unknown pass")) {
                 test.pass('main unit tests');
             } else {
                 this.debugPage();

--- a/tests/java/lang/TestNestedFinally.java
+++ b/tests/java/lang/TestNestedFinally.java
@@ -1,0 +1,55 @@
+package java.lang;
+
+import gnu.testlet.Testlet;
+import gnu.testlet.TestHarness;
+
+public class TestNestedFinally implements Testlet {
+    private boolean foo1Reached = false;
+    private int foo2Value = 1;
+
+    private void foo1() throws Exception {
+        synchronized(this) {
+            try {
+                throw new Exception();
+            } finally {
+                foo1Reached = true;
+                System.out.println("foo1 inner finally reached!");
+            }
+        }
+    }
+
+    private void foo2() throws Exception {
+        // We should reach the inner finally statement first, then the outer
+        // finally and set foo2Value to 20.
+        // If we miss either finally statement, or reach in reverse order,
+        // foo2Value will be set to other value.
+        try {
+            try {
+                throw new Exception();
+            } finally {
+                ++foo2Value;
+                System.out.println("foo2 inner finally reached!");
+            }
+        } finally {
+            foo2Value *= 10;
+            System.out.println("foo2 outer finally reached!");
+        }
+    }
+
+    public void test(TestHarness th) {
+        try {
+            foo1();
+            th.fail();
+        } catch (Exception e) {
+            th.check(foo1Reached);
+        }
+
+        try {
+            foo2();
+            th.fail();
+        } catch (Exception e) {
+            th.check(foo2Value, 20);
+        }
+    }
+}
+

--- a/vm.js
+++ b/vm.js
@@ -135,6 +135,7 @@ function throw_(ex, ctx) {
             if (frame.ip >= exception_table[i].start_pc && frame.ip <= exception_table[i].end_pc) {
                 if (exception_table[i].catch_type === 0) {
                     handler_pc = exception_table[i].handler_pc;
+                    break;
                 } else {
                     var classInfo = resolve(ctx, cp, exception_table[i].catch_type);
                     if (ex.class.isAssignableTo(classInfo)) {


### PR DESCRIPTION
There is a bug when the vm handling nested  try-catch-finally blocks. 
For the following code. There is a try-finally inside another try-finally. When an exception thrown from the inner try-finally, execution will goes into the outer `finally` other than the inner `finally`.

``` java
    void foo() throws Exception {
        try {
            try {
                throw new Exception();
            } finally {
                System.out.println("inner finally reached!");
            }
        } finally {
            System.out.println("outer finally reached!");
        }
    }
```

Another similar case is that to use `synchronized` block with try-catch-finally block. The `synchronized` block implies a try-catch-block when compiled to byte codes.  So for the following code, the inner `finally` could not be reached due to this VM bug:

``` java
    private void foo1() throws Exception {
        synchronized(this) {
            try {
                throw new Exception();
            } finally {
                foo1Reached = true;
                System.out.println("foo1 inner finally reached!");
            }
        }
    }
```
