### PR TITLE
Accept dot as seperator for the full class name components.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ If testing sockets, 4 servers are necessary:
 To run specific tests (e.g. TestSystem and TestRC4):
 
         python tests/httpServer.py &
-        http://localhost:8000/index.html?args=java/lang/TestSystem,javax/crypto/TestRC4
+        http://localhost:8000/index.html?args=java.lang.TestSystem,javax.crypto.TestRC4
 
 Full list of RunTests tests available in the tests/Testlets.java generated file
 

--- a/libs/urlparams.js
+++ b/libs/urlparams.js
@@ -38,7 +38,7 @@ var urlParams = (function() {
     params[param[0]] = param[1];
   });
 
-  params.args = (params.args || "").split(",");
+  params.args = (params.args || "").replace(".", "/", "g").split(",");
 
   return params;
 })();


### PR DESCRIPTION
For convenience, this allows us to run unit test using

`http://localhost:8000/index.html?args=java.lang.TestSystem`

as well as 

`http://localhost:8000/index.html?args=java/lang/TestSystem`
