### PR TITLE
Display pass/fail numbers that don't match expectations.

### DIFF
--- a/tests/automation.js
+++ b/tests/automation.js
@@ -17,7 +17,7 @@ casper.options.onWaitTimeout = function() {
 
 var gfxTests = [
   { name: "gfx/AlertTest", maxDifferent: 1621 },
-  { name: "gfx/CanvasTest", maxDifferent: 269 },
+  { name: "gfx/CanvasTest", maxDifferent: 271 },
   { name: "gfx/DrawRegionTest", maxDifferent: 0 },
   { name: "gfx/ImageRenderingTest", maxDifferent: 266 },
   { name: "gfx/FillRectTest", maxDifferent: 0 },
@@ -40,16 +40,37 @@ var gfxTests = [
   { name: "gfx/DrawSubstringTest", maxDifferent: 332 },
 ];
 
+var expectedUnitTestResults = [
+  { name: "pass", number: 71097 },
+  { name: "fail", number: 0 },
+  { name: "known fail", number: 179 },
+  { name: "unknown pass", number: 0 }
+];
+
 casper.test.begin("unit tests", 7 + gfxTests.length, function(test) {
     function basicUnitTests() {
         casper.waitForText("DONE", function() {
             var content = this.getPageContent();
-            if (content.contains("DONE: 71097 pass, 0 fail, 179 known fail, 0 unknown pass")) {
-                test.pass('main unit tests');
-            } else {
+            var regex = /DONE: (\d+) pass, (\d+) fail, (\d+) known fail, (\d+) unknown pass/;
+            var match = content.match(regex);
+            if (!match || !match.length || match.length < 5) {
                 this.debugPage();
                 this.echo(this.captureBase64('png'));
-                test.fail('main unit tests');
+                test.fail('failed to parse status line of main unit tests');
+            } else {
+                var msg = "";
+                for (var i = 0; i < expectedUnitTestResults.length; i++) {
+                    if (match[i+1] != expectedUnitTestResults[i].number) {
+                        msg += "\n\tExpected " + expectedUnitTestResults[i].number + " " + expectedUnitTestResults[i].name + ". Got " + match[i+1];
+                    }
+                }
+                if (!msg) {
+                    test.pass('main unit tests');
+                } else {
+                    this.debugPage();
+                    this.echo(this.captureBase64('png'));
+                    test.fail(msg);
+                }
             }
         });
     }


### PR DESCRIPTION
Also update CanvasTest to expect 271 pixel difference.

Fixes #613 and #614
