### PR TITLE
actually return the empty string for com.nokia.mid.imei

### DIFF
--- a/midp/midp.js
+++ b/midp/midp.js
@@ -433,7 +433,7 @@ Native.create("com/sun/midp/main/Configuration.getProperty0.(Ljava/lang/String;)
         value = null;
         break;
     }
-    return value ? value : null;
+    return value;
 });
 
 Native.create("com/sun/midp/chameleon/skins/resources/LoadedSkinData.beginReadingSkinFile.(Ljava/lang/String;)V", function(fileName) {

--- a/native.js
+++ b/native.js
@@ -65,7 +65,7 @@ Native.create("java/lang/System.getProperty0.(Ljava/lang/String;)Ljava/lang/Stri
         value = urlParams.platform ? urlParams.platform : "NOKIA503/JAVA_RUNTIME_VERSION=NOKIA_ASHA_1_2";
         break;
     case "microedition.platformimpl":
-        value = "";
+        value = null;
         break;
     case "microedition.profiles":
         value = "MIDP-2.0"
@@ -172,9 +172,10 @@ Native.create("java/lang/System.getProperty0.(Ljava/lang/String;)Ljava/lang/Stri
         break;
     default:
         console.warn("UNKNOWN PROPERTY (java/lang/System): " + util.fromJavaString(key));
+        value = null;
         break;
     }
-    return value ? value : null;
+    return value;
 });
 
 Native.create("java/lang/System.currentTimeMillis.()J", function() {

--- a/tests/automation.js
+++ b/tests/automation.js
@@ -41,7 +41,7 @@ var gfxTests = [
 ];
 
 var expectedUnitTestResults = [
-  { name: "pass", number: 71105 },
+  { name: "pass", number: 71106 },
   { name: "fail", number: 0 },
   { name: "known fail", number: 179 },
   { name: "unknown pass", number: 0 }

--- a/tests/gnu/testlet/java/lang/System/getProperty.java
+++ b/tests/gnu/testlet/java/lang/System/getProperty.java
@@ -35,6 +35,7 @@ public class getProperty implements Testlet
     getPropTest(null, "NullPointerException");
     getPropTest("", "IllegalArgumentException");
     getPropTest("__dummy_mauve_prop_not_set__", null);
+    getPropTest("com.nokia.mid.imei", "");
   }
 
   void getPropTest(String key, String expect)


### PR DESCRIPTION
_System.getProperty0_ is supposed to return an empty string for _com.nokia.mid.imei_, but it actually returns the `null` value, because it checks the return value for truthiness, and an empty string is falsy.

This fix makes it return the empty string (and tests that it does so).  It requires that each _case_ block explicitly set _value_ to the desired value, even if that's `null` (most were already doing so, but _microedition.platformimpl_ needed to be updated to set the value explicitly). It also makes the same change to _Configuration.getProperty0_.
