### PR TITLE
Flush unclosed files actively to work around bug #227.

### DIFF
--- a/libs/fs.js
+++ b/libs/fs.js
@@ -210,6 +210,24 @@ var fs = (function() {
     });
   }
 
+  function flushAll() {
+    for (var fd = 0; fd < openedFiles.length; fd++) {
+      if (!openedFiles[fd] || !openedFiles[fd].dirty) {
+        continue;
+      }
+      flush(fd);
+    }
+  }
+
+  // Due to bug #227, we don't support Object::finalize(). But the Java
+  // filesystem implementation requires the `finalize` method to save cached
+  // file data if user doesn't flush or close the file explicitly. To avoid
+  // losing data, we flush files periodically.
+  setInterval(flushAll, 5000);
+
+  // Flush files when app goes into background.
+  window.addEventListener("pagehide", flushAll);
+
   function list(path, cb) {
     path = normalizePath(path);
 


### PR DESCRIPTION
The `RecordStore` and file system related java APIs use `finalize` to flush file data if a file isn't closed explicitly. Since we don't implement `finalize` (#227), we will lose file data in this case.

This pull request flushes the unclosed file periodically and ensures all files are saved before closed.
