### PR TITLE
Handle max_kb in nokia.image-processing localmsg api

### DIFF
--- a/midp/localmsg.js
+++ b/midp/localmsg.js
@@ -649,7 +649,7 @@ NokiaImageProcessingLocalMsgConnection.prototype.sendMessageToServer = function(
       encoder.put(DataType.METHOD, "name", "Common");
       encoder.putStart(DataType.STRUCT, "message");
       encoder.put(DataType.METHOD, "name", "ProtocolVersion");
-      encoder.put(DataType.STRING, "version", "1.[0-10]");
+      encoder.put(DataType.STRING, "version", "1.0");
       encoder.putEnd(DataType.STRUCT, "message");
       encoder.putEnd(DataType.STRUCT, "event");
 
@@ -664,17 +664,35 @@ NokiaImageProcessingLocalMsgConnection.prototype.sendMessageToServer = function(
     case "Scale":
       var trans_id = decoder.getValue(DataType.BYTE);
       var fileName = decoder.getValue(DataType.WSTRING);
+      var max_vres = 0;
+      var max_hres = 0;
+      var max_kb = 0;
       decoder.getStart(DataType.LIST);
-      if (decoder.getName() == "max_kb") {
-        console.error("(nokia.image-processing) event " + name + " with max_kb not implemented " +
-                      util.decodeUtf8(new Uint8Array(message.data.buffer, message.offset, message.length)));
-        return;
+      while (true) {
+        var paramName = decoder.getName();
+        var value = decoder.getValue(DataType.USHORT);
+        if (paramName === "limits")
+          break;
+
+        switch (paramName) {
+          case "max_kb":
+            max_kb = value;
+            break;
+          case "max_vres":
+            max_vres = value;
+            break;
+          case "max_hres":
+            max_hres = value;
+            break;
+          default:
+            console.error("(nokia.image-processing) event " + name + " with " +
+              paramName + " = " + value + " not implemented.");
+            return;
+        }
       }
-      var max_vres = decoder.getValue(DataType.USHORT);
-      var max_hres = decoder.getValue(DataType.USHORT);
       decoder.getEnd(DataType.LIST);
       var aspect = decoder.getValue(DataType.STRING);
-      var quality = decoder.getValue(DataType.BYTE);
+      var quality = decoder.getValue(DataType.BYTE) || 80;
 
       if (aspect != "FullImage" && aspect != "LockToPartialView") {
         console.error("(nokia.image-processing) event " + name + " with aspect != 'FullImage' or 'LockToPartialView' not implemented " +
@@ -683,37 +701,75 @@ NokiaImageProcessingLocalMsgConnection.prototype.sendMessageToServer = function(
       }
 
       fs.open("/" + fileName, (function(fd) {
+        var _sendBackScaledImage = function(blob) {
+          createUniqueFile("/nokiaimageprocessing", "image", blob, (function(fileName) {
+            var encoder = new DataEncoder();
+
+            encoder.putStart(DataType.STRUCT, "event");
+            encoder.put(DataType.METHOD, "name", "Scale");
+            encoder.put(DataType.BYTE, "trans_id", trans_id);
+            encoder.put(DataType.STRING, "result", "Complete"); // Name unknown
+            encoder.put(DataType.WSTRING, "filename", "nokiaimageprocessing/" + fileName); // Name unknown
+            encoder.putEnd(DataType.STRUCT, "event");
+
+            var data = new TextEncoder().encode(encoder.getData());
+            this.sendMessageToClient({
+              data: data,
+              length: data.length,
+              offset: 0,
+            });
+          }).bind(this));
+        }.bind(this);
+
         var imgData = fs.read(fd);
+        var fileSize = fs.getsize(fd);
         fs.close(fd);
 
         var img = new Image();
         img.src = URL.createObjectURL(new Blob([ imgData ]));
         img.onload = (function() {
+          // If the image size is less than the given max_kb, and height/width
+          // are less than max_hres/max_wres, send the original image immediately
+          // without any scaling.
+          if (max_kb > 0 && (max_kb * 1024) >= fileSize &&
+              (max_hres <= 0 || img.naturalHeight <= max_vres) &&
+              (max_vres <= 0 || img.naturalWidth <= max_hres)) {
+            _sendBackScaledImage(new Blob([ imgData ]));
+            return;
+          }
+
+          function _imageToBlob(aCanvas, aImage, aHeight, aWidth, aQuality) {
+            aCanvas.width = aWidth;
+            aCanvas.height = aHeight;
+            var ctx = aCanvas.getContext("2d");
+            ctx.drawImage(aImage, 0, 0, aWidth, aHeight);
+
+            return new Promise(function(resolve, reject) {
+              aCanvas.toBlob(resolve, "image/jpeg", aQuality / 100);
+            });
+          }
+
           var canvas = document.createElement("canvas");
-          canvas.width = Math.min(img.naturalWidth, max_hres);
-          canvas.height = Math.min(img.naturalHeight, max_vres);
-          var ctx = canvas.getContext("2d");
-          ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+          if (max_kb <= 0) {
+            _imageToBlob(canvas, img, Math.min(img.naturalHeight, max_vres),
+                         Math.min(img.naturalWidth, max_hres), quality).then(_sendBackScaledImage);
+            return;
+          }
 
-          canvas.toBlob((function(blob) {
-            createUniqueFile("/nokiaimageprocessing", "image", blob, (function(fileName) {
-              var encoder = new DataEncoder();
+          _imageToBlob(canvas, img, img.naturalHeight,
+                       img.naturalWidth, quality).then(function(blob) {
+            var imgSizeInKb = blob.size / 1024;
 
-              encoder.putStart(DataType.STRUCT, "event");
-              encoder.put(DataType.METHOD, "name", "Scale");
-              encoder.put(DataType.BYTE, "trans_id", trans_id);
-              encoder.put(DataType.STRING, "result", "Complete"); // Name unknown
-              encoder.put(DataType.WSTRING, "filename", "nokiaimageprocessing/" + fileName); // Name unknown
-              encoder.putEnd(DataType.STRUCT, "event");
+            // Roughly recalc max_vres and max_hres based on the max_kb and the real resolution.
+            var ratio = Math.sqrt(max_kb / imgSizeInKb);
+            max_hres = Math.min(img.naturalWidth * ratio,
+              max_hres <= 0 ? img.naturalWidth : max_hres);
+            max_vres = Math.min(img.naturalHeight * ratio,
+              max_vres <=0 ? img.naturalHeight : max_vres);
 
-              var data = new TextEncoder().encode(encoder.getData());
-              this.sendMessageToClient({
-                data: data,
-                length: data.length,
-                offset: 0,
-              });
-            }).bind(this));
-          }).bind(this), "image/jpeg", quality / 100);
+            return _imageToBlob(canvas, img, Math.min(img.naturalHeight, max_vres),
+                                Math.min(img.naturalWidth, max_hres), quality);
+          }).then(_sendBackScaledImage);
         }).bind(this);
 
         img.onerror = function(e) {

--- a/tests/automation.js
+++ b/tests/automation.js
@@ -51,7 +51,7 @@ var gfxTests = [
 ];
 
 var expectedUnitTestResults = [
-  { name: "pass", number: 71151 },
+  { name: "pass", number: 71175 },
   { name: "fail", number: 0 },
   { name: "known fail", number: 180 },
   { name: "unknown pass", number: 0 }


### PR DESCRIPTION
I tested with several images, the size of generated image is about 10%-20% larger than the given size which I think it's acceptable.
