### PR TITLE
Add testing for creating/removing files in multi-thread.

### DIFF
--- a/tests/automation.js
+++ b/tests/automation.js
@@ -41,7 +41,7 @@ var gfxTests = [
 ];
 
 var expectedUnitTestResults = [
-  { name: "pass", number: 71130 },
+  { name: "pass", number: 71141 },
   { name: "fail", number: 0 },
   { name: "known fail", number: 180 },
   { name: "unknown pass", number: 0 }


### PR DESCRIPTION
I encountered multi-thread problems with `fs.create` and `fs.remove`, then this issue disappeared after I updated my repository, i think it's fixed by making `setItem` synchronized. I added some testing for this issue.
