### PR TITLE
Create typed array from array buffer for reading.

### DIFF
--- a/midp/fs.js
+++ b/midp/fs.js
@@ -183,8 +183,9 @@ function(lookupId, headerData, headerDataSize, headerVersion) {
         if (size > headerDataSize) {
             size = headerDataSize;
         }
+        var sharedHeaderData = new Int8Array(sharedHeader.headerData);
         for (var i = 0; i < size; i++) {
-            headerData[i] = sharedHeader.headerData[i];
+            headerData[i] = sharedHeaderData[i];
         }
         return sharedHeader.headerVersion;
     }


### PR DESCRIPTION
We were reading from an array buffer which does not work and was causing all the headerData to be zeroed.
