### PR TITLE
Fix #718 Prevent <clinit> of the super class being called more than once

### DIFF
--- a/native.js
+++ b/native.js
@@ -272,7 +272,7 @@ Native.create("java/lang/Class.invoke_clinit.()V", function(ctx) {
         ctx.runtime.setStatic(CLASSES.getField(classInfo, "S._API_access_ok.I"), 1);
     }
     var clinit = CLASSES.getMethod(classInfo, "S.<clinit>.()V");
-    if (clinit)
+    if (clinit && clinit.classInfo.className === className)
         ctx.pushFrame(clinit, 0);
     if (classInfo.superClass)
         ctx.pushClassInitFrame(classInfo.superClass);

--- a/tests/automation.js
+++ b/tests/automation.js
@@ -57,7 +57,7 @@ var gfxTests = [
 ];
 
 var expectedUnitTestResults = [
-  { name: "pass", number: 71220 },
+  { name: "pass", number: 71222 },
   { name: "fail", number: 0 },
   { name: "known fail", number: 180 },
   { name: "unknown pass", number: 0 }

--- a/tests/java/lang/TestStaticInit.java
+++ b/tests/java/lang/TestStaticInit.java
@@ -1,0 +1,20 @@
+package java.lang;
+
+import gnu.testlet.Testlet;
+import gnu.testlet.TestHarness;
+
+public class TestStaticInit implements Testlet {
+    static class TestClass {
+        static int value = 0;
+    }
+
+    static class TestClassB extends TestClass {
+    }
+
+    public void test(TestHarness th) {
+        TestClass.value = 1;
+        TestClassB newInstance = new TestClassB();
+        th.check(TestClass.value, 1);
+        th.check(TestClassB.value, 1);
+    }
+}


### PR DESCRIPTION
When a sub class is initialized, if it doesn't have a <clinit> method, it will try to call the <clinit> method of the super class event if the super class has been initialized already. This leads to the <clinit> method of the super class being called more than once.

This pull request fixes the bug of this case.
