### PR TITLE
fix JAR/JAD download regression (fixes #749)

### DIFF
--- a/index.js
+++ b/index.js
@@ -466,39 +466,8 @@ DumbPipe.registerOpener("notification", function(message, sender) {
   }
 });
 
-function load(file, responseType, successCb, failureCb, progressCb, length) {
-  var xhr = new XMLHttpRequest({ mozSystem: true });
-  xhr.open("GET", file, true);
-  xhr.responseType = responseType;
-
-  if (progressCb) {
-    xhr.onprogress = function(e) {
-
-      if (e.lengthComputable) {
-        progressCb(e.loaded / e.total * 100);
-      } else if (length) {
-        progressCb(e.loaded / length * 100);
-      }
-    }
-  }
-
-  xhr.onload = function() {
-    if (xhr.status === 200) {
-      successCb(xhr.response);
-    } else {
-      failureCb();
-    }
-  };
-
-  xhr.onerror = function() {
-    failureCb();
-  };
-
-  xhr.send(null);
-}
-
 DumbPipe.registerOpener("JARDownloader", function(message, sender) {
-  load(urlParams.downloadJAD, "text", function(data) {
+  loadWithProgress(urlParams.downloadJAD, "text", function(data) {
     try {
       var manifest = {};
 
@@ -522,7 +491,7 @@ DumbPipe.registerOpener("JARDownloader", function(message, sender) {
         jarURL = urlParams.downloadJAD.substring(0, urlParams.downloadJAD.lastIndexOf("/") + 1) + jarName;
       }
 
-      load(jarURL, "arraybuffer", function(data) {
+      loadWithProgress(jarURL, "arraybuffer", function(data) {
         sender({ type: "done", data: data });
       }, function() {
         sender({ type: "fail" });

--- a/libs/load.js
+++ b/libs/load.js
@@ -18,6 +18,37 @@ function load(file, responseType) {
   });
 }
 
+function loadWithProgress(file, responseType, successCb, failureCb, progressCb, length) {
+  var xhr = new XMLHttpRequest({ mozSystem: true });
+  xhr.open("GET", file, true);
+  xhr.responseType = responseType;
+
+  if (progressCb) {
+    xhr.onprogress = function(e) {
+
+      if (e.lengthComputable) {
+        progressCb(e.loaded / e.total * 100);
+      } else if (length) {
+        progressCb(e.loaded / length * 100);
+      }
+    }
+  }
+
+  xhr.onload = function() {
+    if (xhr.status === 200) {
+      successCb(xhr.response);
+    } else {
+      failureCb();
+    }
+  };
+
+  xhr.onerror = function(event) {
+    failureCb();
+  };
+
+  xhr.send(null);
+}
+
 function loadScript(path) {
   return new Promise(function(resolve, reject) {
     var element = document.createElement('script');


### PR DESCRIPTION
The normalize-dir-list branch refactored the _load_ function, in the middle of which we landed a different _load_ function in index.js, which caused a conflict, so bd0ff96 renames/refactors the new one. Not sure that's the ideal solution, but it should resolve that regression.

Unfortunately, it still doesn't resolve the issue I'm seeing of a persistent "download failure" on startup. According to my tests, the XHR in renamed _loadWithProgress_ function has its _onerror_ function called with _xhr.statusCode_ `0` but _xhr.statusText_ `OK`. Perhaps this is to do with SystemXHR?
