### PR TITLE
sync fs db after test steps that change it

### DIFF
--- a/tests/automation.js
+++ b/tests/automation.js
@@ -77,9 +77,7 @@ var expectedUnitTestResults = [
  * when the page is unloaded.
  */
 function syncFS() {
-    casper.waitForText("SYNC FILESYSTEM", function() {
-        console.log("SYNC FILESYSTEM");
-    });
+    casper.waitForText("SYNC FILESYSTEM");
     casper.evaluate(function() {
         fs.syncStore(function() {
             console.log("SYNC FILESYSTEM");


### PR DESCRIPTION
There have been some intermittent failures recently in the fs init test script, which doesn't find the files it expects. I've also seen an occasional "error opening database: AbortError" from the db, like in [this run](https://travis-ci.org/andreasgal/j2me.js/builds/44406031).

The former is almost certainly because the fs doesn't immediately sync changes to the db, but the test runner immediately unloads the init script after initialization is complete. Which means the sync races the unload (and sometimes loses, since IndexedDB transactions don't block unload).

So we should sync changes to the db after evaluating scripts that change it, especially if subsequent test steps rely on those changes. Even when they don't, it seems like a good idea, to avoid the possibility that an unload puts the database into an inconsistent state (although it shouldn't be possible, as worst case the transactions should be rolled back).
