### PR TITLE
increase max difference for text box test

### DIFF
--- a/tests/automation.js
+++ b/tests/automation.js
@@ -24,7 +24,7 @@ var gfxTests = [
   { name: "gfx/DrawAndFillArcTest", maxDifferent: 2000 },
   { name: "gfx/DrawStringTest", maxDifferent: 345 },
   { name: "gfx/DrawRedStringTest", maxDifferent: 513 },
-  { name: "gfx/TextBoxTest", maxDifferent: 4677 },
+  { name: "gfx/TextBoxTest", maxDifferent: 4722 },
   { name: "gfx/DirectUtilsCreateImageTest", maxDifferent: 0 },
   { name: "gfx/GetPixelsDrawPixelsTest", maxDifferent: 0 },
   { name: "gfx/OffScreenCanvasTest", maxDifferent: 0 },


### PR DESCRIPTION
The text box test has started failing (intermittently?) with 4722 different pixels, but it looks like the rendering is correct, and it's just a difference in the font that causes the problem (reference image on the left; Travis result on the right):

![textboxtest](https://cloud.githubusercontent.com/assets/305455/5533325/9cd11cd8-89fa-11e4-8704-25dce5788872.png) ![textboxtest-travis](https://cloud.githubusercontent.com/assets/305455/5533331/ca1ca478-89fa-11e4-957c-9bdef067e087.png)

So this branch updates the maximum number of pixels that can be different for the test.
