### PR TITLE
Reduce ImmutableImageFromByteArrayTest failure rate

### DIFF
--- a/tests/gfx/ImmutableImageFromByteArrayTest.java
+++ b/tests/gfx/ImmutableImageFromByteArrayTest.java
@@ -23,6 +23,14 @@ public class ImmutableImageFromByteArrayTest extends MIDlet {
     
         display.setCurrent(fmMain);
 
+        try {
+            do {
+                Thread.sleep(100);
+            } while (!fmMain.isShown());
+        } catch (InterruptedException e) {
+            System.out.println("FAIL");
+        }
+
         System.out.println("PAINTED");
     }
 


### PR DESCRIPTION
This isn't actually fixing the test, but it should reduce its failure rate
