### PR TITLE
rename file without changing mtime

### DIFF
--- a/libs/fs.js
+++ b/libs/fs.js
@@ -832,36 +832,26 @@ var fs = (function() {
         return;
       }
 
-      var recreatePath = remove.bind(null, oldPath, function(removed) {
-        if (!removed) {
-          cb(false);
-          return;
-        }
-
-        if (oldRecord.isDir) {
-          mkdir(newPath, cb);
-        } else {
-          create(newPath, oldRecord.data, cb);
-        }
-      });
+      var moveItem = function() {
+        store.removeItem(oldPath);
+        oldRecord.parentDir = dirname(newPath);
+        store.setItem(newPath, oldRecord);
+        cb(true);
+      };
 
       if (oldRecord.isDir) {
         store.isEmpty(oldPath, function(empty) {
           if (empty) {
-            recreatePath();
+            moveItem();
           } else {
             // If the old path is a dir with files in it, we don't move it.
             // We should move it along with its files
             console.error("rename directory containing files not implemented: " + oldPath + " to " + newPath);
             cb(false);
-            return;
           }
         });
       } else {
-        store.removeItem(oldPath);
-        oldRecord.parentDir = dirname(newPath);
-        store.setItem(newPath, oldRecord);
-        cb(true);
+        moveItem();
       }
     });
   }

--- a/tests/automation.js
+++ b/tests/automation.js
@@ -159,7 +159,7 @@ casper.test.begin("unit tests", 11 + gfxTests.length, function(test) {
     casper
     .thenOpen("http://localhost:8000/tests/fs/fstests.html")
     .waitForText("DONE", function() {
-        test.assertTextExists("DONE: 137 PASS, 0 FAIL", "run fs.js unit tests");
+        test.assertTextExists("DONE: 138 PASS, 0 FAIL", "run fs.js unit tests");
         syncFS();
     });
 

--- a/tests/fs/automation.js
+++ b/tests/fs/automation.js
@@ -43,7 +43,7 @@ casper.test.begin("fs tests", 6, function(test) {
     casper
     .thenOpen("http://localhost:8000/tests/fs/fstests.html")
     .waitForText("DONE", function() {
-        test.assertTextExists("DONE: 137 PASS, 0 FAIL", "run fs.js unit tests");
+        test.assertTextExists("DONE: 138 PASS, 0 FAIL", "run fs.js unit tests");
     });
 
     casper
@@ -66,7 +66,7 @@ casper.test.begin("fs tests", 6, function(test) {
     casper
     .thenOpen("http://localhost:8000/tests/fs/fstests.html")
     .waitForText("DONE", function() {
-        test.assertTextExists("DONE: 137 PASS, 0 FAIL", "run fs.js unit tests");
+        test.assertTextExists("DONE: 138 PASS, 0 FAIL", "run fs.js unit tests");
     });
 
     casper
@@ -89,7 +89,7 @@ casper.test.begin("fs tests", 6, function(test) {
     casper
     .thenOpen("http://localhost:8000/tests/fs/fstests.html")
     .waitForText("DONE", function() {
-        test.assertTextExists("DONE: 137 PASS, 0 FAIL", "run fs.js unit tests");
+        test.assertTextExists("DONE: 138 PASS, 0 FAIL", "run fs.js unit tests");
     });
 
     casper

--- a/tests/fs/fstests.js
+++ b/tests/fs/fstests.js
@@ -941,6 +941,22 @@ tests.push(function() {
 })();
 
 tests.push(function() {
+  fs.mkdir("/tmp/stat", function() {
+    fs.stat("/tmp/stat", function(stat) {
+      var mtime = stat.mtime;
+      window.setTimeout(function() {
+        fs.rename("/tmp/stat", "/tmp/stat2", function() {
+          fs.stat("/tmp/stat2", function(stat) {
+            is(stat.mtime, mtime, "rename directory doesn't update mtime");
+            next();
+          });
+        });
+      }, 1);
+    });
+  });
+});
+
+tests.push(function() {
   fs.mkdir("/statDir", function() {
     fs.stat("/statDir", function(stat) {
       ok(stat.isDir, "/statDir is a directory");


### PR DESCRIPTION
Renaming a file currently changes its mtime, since the file gets deleted and recreated. It shouldn't do that. Here's the fix.
