### PR TITLE
Enable aot target by default and add optimized compiler tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,9 @@ before_script:
   - wget -P /tmp/j2me.js -N https://ftp.mozilla.org/pub/mozilla.org/xulrunner/releases/31.0/runtimes/xulrunner-31.0.en-US.linux-x86_64.tar.bz2
   - tar x -C /tmp -f /tmp/j2me.js/xulrunner-31.0.en-US.linux-x86_64.tar.bz2
   - export SLIMERJSLAUNCHER=/tmp/xulrunner/xulrunner
+  - wget -P /tmp/j2me.js -N http://ftp.mozilla.org/pub/mozilla.org/firefox/nightly/36.0b1-candidates/build1/jsshell-linux-x86_64.zip
+  - unzip -d /tmp/js /tmp/j2me.js/jsshell-linux-x86_64.zip
+  - export PATH=$PATH:/tmp/js
 script:
   - make test
 sudo: false

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ BASIC_SRCS=$(shell find . -maxdepth 2 -name "*.ts")
 JIT_SRCS=$(shell find jit -name "*.ts")
 SHUMWAY_SRCS=$(shell find shumway -name "*.ts")
 
-all: java jasmin tests j2me shumway
+all: java jasmin tests j2me aot shumway
 
 test: all
 	tests/runtests.py
@@ -22,9 +22,10 @@ build/jsc.js: jsc.ts build/j2me.js
 j2me: build/j2me.js build/jsc.js
 
 aot: java j2me
-	js build/jsc.js -cp java/classes.jar -d -jf java/classes.jar -cff classes.txt > build/classes.jar.js
+	js build/jsc.js -cp java/classes.jar -d -jf java/classes.jar > build/classes.jar.js
+	js build/jsc.js -cp java/classes.jar tests/tests.jar -d -jf tests/tests.jar > build/tests.jar.js
 	if test -f program.jar; then \
-		js build/jsc.js -cp java/classes.jar program.jar -d -jf program.jar -cff classes.txt > build/program.jar.js; \
+		js build/jsc.js -cp java/classes.jar program.jar -d -jf program.jar > build/program.jar.js; \
 	fi
 
 closure: build/j2me.js aot

--- a/libs/load.js
+++ b/libs/load.js
@@ -56,5 +56,8 @@ function loadScript(path) {
     element.setAttribute("src", path);
     document.getElementsByTagName("head")[0].appendChild(element);
     element.onload = resolve;
+    element.onerror = function() {
+      reject("Failed to load script: " + path);
+    };
   });
 }

--- a/libs/urlparams.js
+++ b/libs/urlparams.js
@@ -26,6 +26,7 @@
  *    pushMidlet
  *    autosize
  *    fontSize
+ *    jsFiles
  *
  * Keep this list up-to-date!
  */
@@ -41,6 +42,7 @@ var urlParams = (function() {
   });
 
   params.args = (params.args || "").split(",");
+  params.jsFiles = (params.jsFiles || "").split(",");
 
   for (var name in params) {
     config[name] = params[name];

--- a/main.html
+++ b/main.html
@@ -55,10 +55,6 @@
   <script type="text/javascript" src="game-ui.js" defer></script>
   <script type="text/javascript" src="desktop-ui.js" defer></script>
   <script type="text/javascript" src="main.js" defer></script>
-
-  <!-- run make aot to generate these -->
-  <script type="text/javascript" src="build/classes.jar.js" defer></script>
-  <script type="text/javascript" src="build/program.jar.js" defer></script>
 </head>
 
 <body>

--- a/main.js
+++ b/main.js
@@ -58,6 +58,12 @@ jars.forEach(function(jar) {
   }));
 });
 
+if (config.jsFiles) {
+  config.jsFiles.forEach(function(jsFile) {
+    loadingPromises.push(loadScript(jsFile));
+  });
+}
+
 function processJAD(data) {
   data
   .replace(/\r\n|\r/g, "\n")
@@ -200,7 +206,9 @@ function start() {
   jvm.startIsolate0(main, config.args);
 }
 
-Promise.all(loadingPromises).then(start);
+Promise.all(loadingPromises).then(start, function (reason) {
+  console.error("Loading failed: \"" + reason + "\"");
+});
 
 document.getElementById("start").onclick = function() {
   start();

--- a/runtime.ts
+++ b/runtime.ts
@@ -47,6 +47,10 @@ module J2ME {
     timeline && timeline.leave(name, data);
   }
 
+  export class MozillaRuntime {
+    static linkedCompiledMethodCount = 0
+  }
+
   export var Klasses = {
     java: {
       lang: {
@@ -1194,6 +1198,7 @@ module J2ME {
         fn = findCompiledMethod(klass, methodInfo);
         if (fn && !methodInfo.isSynchronized) {
           linkWriter && linkWriter.greenLn("Method: " + methodDescription + " -> Compiled");
+          MozillaRuntime.linkedCompiledMethodCount++;
           methodType = MethodType.Compiled;
           if (!traceWriter) {
             linkWriter && linkWriter.outdent();

--- a/utilities.ts
+++ b/utilities.ts
@@ -15,7 +15,7 @@
  */
 
 var jsGlobal = (function() { return this || (1, eval)('this'); })();
-var inBrowser = typeof console != "undefined";
+var inBrowser = typeof jsGlobal.module == "undefined" && typeof jsGlobal.pc2line == "undefined";
 
 declare var putstr;
 declare var printErr;


### PR DESCRIPTION
To load compiled js files I've added the jsFiles option to config/urlparam. I'm open to suggestions on other ways to do this, as it doesn't seem all that great.

BTW: We're still having a problems a midlet with compiled code enabled, but all the test are passing.