### PR TITLE
Use new Function() instead of eval() in linkMethod().

### DIFF
--- a/runtime.ts
+++ b/runtime.ts
@@ -1565,13 +1565,14 @@ module J2ME {
   export function linkMethod(methodInfo: MethodInfo, source: string, referencedClasses: string[]) {
     jitWriter && jitWriter.writeLn("Link method: " + methodInfo.implKey);
 
-    enterTimeline("Eval Compiled Code");
-    // This overwrites the method on the global object.
-    (1, eval)(source);
-    leaveTimeline("Eval Compiled Code");
+    enterTimeline("Link Compiled Code");
+    // Still not as bad as eval!
+    var fn = new Function('return ' + source)();
+    leaveTimeline("Link Compiled Code");
 
     var mangledClassAndMethodName = methodInfo.mangledClassAndMethodName;
-    var fn = jsGlobal[mangledClassAndMethodName];
+
+    jsGlobal[mangledClassAndMethodName] = fn;
     methodInfo.fn = fn;
     methodInfo.state = MethodState.Compiled;
 


### PR DESCRIPTION
From experience with Shumway, https://github.com/mozilla/shumway/commit/81d53f0ee1f375a35835825e40be4eadcee60940, "new Function()" is significantly faster than "eval()", the latter being a huge deopt point in the JS engine. Some internal refactoring could likely get rid of the anonymous wrapper too.

The majority of the functions produced by j2me.js are still through eval() after this patch, in emitKlassConstructor(). I attempted to make a similar change to that function, but it results in a "too much recursion" error that I don't understand.