### PR TITLE
[WIP] Share stack array with all frames.

### DIFF
--- a/interpreter.ts
+++ b/interpreter.ts
@@ -165,6 +165,7 @@ module J2ME {
 
         return;
       }
+      frame.free();
       ctx.popFrame();
       frame = ctx.current();
       if (Frame.isMarker(frame)) {

--- a/interpreter.ts
+++ b/interpreter.ts
@@ -10,7 +10,6 @@ module J2ME {
 
   import Bytecodes = Bytecode.Bytecodes;
   import assert = Debug.assert;
-  import popManyInto = ArrayUtilities.popManyInto;
 
   export var interpreterCounter = null; // new Metrics.Counter(true);
   export var interpreterMethodCounter = new Metrics.Counter(true);

--- a/interpreter.ts
+++ b/interpreter.ts
@@ -1065,7 +1065,7 @@ module J2ME {
               for (var i = 0; i < num; i++) {
                 local.unshift(frame.stackPop());
               }
-              var calleeFrame = Frame.create(calleeTargetMethodInfo, local);
+              var calleeFrame = Frame.create(calleeTargetMethodInfo, local, ctx.stack);
               ctx.pushFrame(calleeFrame);
               frame = calleeFrame;
               mi = frame.methodInfo;
@@ -1176,7 +1176,7 @@ module J2ME {
               for (var i = 0; i < num; i++) {
                 local.unshift(frame.stackPop());
               }
-              var calleeFrame = Frame.create(calleeTargetMethodInfo, local);
+              var calleeFrame = Frame.create(calleeTargetMethodInfo, local, ctx.stack);
               ctx.pushFrame(calleeFrame);
               frame = calleeFrame;
               mi = frame.methodInfo;

--- a/jit/baseline.ts
+++ b/jit/baseline.ts
@@ -620,7 +620,7 @@ module J2ME {
           this.bodyEmitter.writeLn("ins=O.lockObject;");
         }
         this.bodyEmitter.writeLn("pc=O.pc;");
-        this.bodyEmitter.writeLn("O=null;");
+        this.bodyEmitter.writeLn("O.free();O=null;");
         if (this.methodInfo.isSynchronized) {
           this.bodyEmitter.leaveAndEnter("}else{");
           this.emitMonitorEnter(this.bodyEmitter, 0, this.lockObject);

--- a/native.js
+++ b/native.js
@@ -9,9 +9,9 @@ function asyncImpl(returnKind, promise) {
 
   promise.then(function(res) {
     if (returnKind === "J" || returnKind === "D") {
-      ctx.current().stack.push2(res);
+      ctx.current().stackPush2(res);
     } else if (returnKind !== "V") {
-      ctx.current().stack.push(res);
+      ctx.current().stackPush(res);
     } else {
       // void, do nothing
     }

--- a/native.js
+++ b/native.js
@@ -19,7 +19,7 @@ function asyncImpl(returnKind, promise) {
   }, function(exception) {
     var classInfo = CLASSES.getClass("org/mozilla/internal/Sys");
     var methodInfo = classInfo.getMethodByNameString("throwException", "(Ljava/lang/Exception;)V", true);
-    ctx.pushFrame(Frame.create(methodInfo, [exception]));
+    ctx.pushFrame(Frame.create(methodInfo, [exception], ctx.stack));
     ctx.execute();
   });
   $.pause(asyncImplStringAsync);
@@ -310,7 +310,8 @@ Native["java/lang/Class.invoke_clinit.()V"] = function() {
     var className = classInfo.getClassNameSlow();
     var clinit = classInfo.staticInitializer;
     if (clinit && clinit.classInfo.getClassNameSlow() === className) {
-        $.ctx.executeFrame(Frame.create(clinit, []));
+        var ctx = $.ctx;
+        ctx.executeFrame(Frame.create(clinit, [], ctx.bailoutStack));
     }
 };
 
@@ -539,7 +540,7 @@ Native["java/lang/Thread.start0.()V"] = function() {
 
     var classInfo = CLASSES.getClass("org/mozilla/internal/Sys");
     var run = classInfo.getMethodByNameString("runThread", "(Ljava/lang/Thread;)V", true);
-    newCtx.start([Frame.create(run, [ this ])]);
+    newCtx.start([Frame.create(run, [ this ], newCtx.stack)]);
 }
 
 Native["java/lang/Thread.isAlive.()Z"] = function() {

--- a/utilities.ts
+++ b/utilities.ts
@@ -84,7 +84,7 @@ module J2ME {
       throw new Error(message);
     }
 
-    export function assert(condition: any, message: any = "assertion failed") {
+    export function assert(condition: any, message: any = "assertion failed: " + Error().stack) {
       if (condition === "") {     // avoid inadvertent false positive
         condition = true;
       }

--- a/utilities.ts
+++ b/utilities.ts
@@ -124,21 +124,6 @@ module J2ME {
       return arrays;
     }
 
-    /**
-     * Pops elements from a source array into a destination array. This avoids
-     * allocations and should be faster. The elements in the destination array
-     * are pushed in the same order as they appear in the source array:
-     *
-     * popManyInto([1, 2, 3], 2, dst) => dst = [2, 3]
-     */
-    export function popManyInto(src: any [], count: number, dst: any []) {
-      release || assert(src.length >= count);
-      for (var i = count - 1; i >= 0; i--) {
-        dst[i] = src.pop();
-      }
-      dst.length = count;
-    }
-
     export function pushMany(dst: any [], src: any []) {
       for (var i = 0; i < src.length; i++) {
         dst.push(src[i]);

--- a/vm/context.ts
+++ b/vm/context.ts
@@ -112,6 +112,7 @@ module J2ME {
       this.methodInfo = methodInfo;
       this.cp = methodInfo ? methodInfo.classInfo.constantPool : null;
       this.code = methodInfo ? methodInfo.codeAttribute.code : null;
+      var max_stack = methodInfo ? methodInfo.codeAttribute.max_stack : 0;
       this.pc = 0;
       this.opPC = 0;
       this.stack = {};

--- a/vm/context.ts
+++ b/vm/context.ts
@@ -6,14 +6,6 @@
 declare var Shumway;
 declare var profiling;
 
-interface Array<T> {
-  push2: (value) => void;
-  pop2: () => any;
-  pushKind: (kind: J2ME.Kind, value) => void;
-  popKind: (kind: J2ME.Kind) => any;
-  read: (i) => any;
-}
-
 module J2ME {
   import assert = Debug.assert;
   import Bytecodes = Bytecode.Bytecodes;
@@ -38,39 +30,6 @@ module J2ME {
    * Toggle VM tracing here.
    */
   export var writers = WriterFlags.None;
-
-  Array.prototype.push2 = function(value) {
-    this.push(value);
-    this.push(null);
-    return value;
-  }
-
-  Array.prototype.pop2 = function() {
-    this.pop();
-    return this.pop();
-  }
-
-  Array.prototype.pushKind = function(kind: Kind, value) {
-    if (isTwoSlot(kind)) {
-      this.push2(value);
-      return;
-    }
-    this.push(value);
-  }
-
-  Array.prototype.popKind = function(kind: Kind) {
-    if (isTwoSlot(kind)) {
-      return this.pop2();
-    }
-    return this.pop();
-  }
-
-  // A convenience function for retrieving values in reverse order
-  // from the end of the stack.  stack.read(1) returns the topmost item
-  // on the stack, while stack.read(2) returns the one underneath it.
-  Array.prototype.read = function(i) {
-    return this[this.length - i];
-  };
 
   export class StackManager {
     buffer: { [sp: number]: any } = {};

--- a/vm/jvm.ts
+++ b/vm/jvm.ts
@@ -36,11 +36,12 @@ module J2ME {
       for (var n = 0; n < args.length; ++n)
         array[n] = args[n] ? J2ME.newString(args[n]) : null;
 
+      var stack = ctx.stack;
       // The <init> frames go at the end of the array so they are executed first to initialize the thread and isolate.
       ctx.start([
-        Frame.create(isolateClassInfo.getMethodByNameString("start", "()V"), [ isolate ]),
+        Frame.create(isolateClassInfo.getMethodByNameString("start", "()V"), [ isolate ], stack),
         Frame.create(isolateClassInfo.getMethodByNameString("<init>", "(Ljava/lang/String;[Ljava/lang/String;)V"),
-                                       [ isolate, J2ME.newString(className.replace(/\./g, "/")), array ])
+                                       [ isolate, J2ME.newString(className.replace(/\./g, "/")), array ], stack)
       ]);
       release || Debug.assert(!U, "Unexpected unwind during isolate initialization.");
     }
@@ -69,10 +70,11 @@ module J2ME {
         args[n] = mainArgs[n];
       }
 
+      var stack = ctx.stack;
       ctx.start([
-        Frame.create(entryPoint, [ args ]),
+        Frame.create(entryPoint, [ args ], stack),
         Frame.create(CLASSES.java_lang_Thread.getMethodByNameString("<init>", "(Ljava/lang/String;)V"),
-                     [ runtime.mainThread, J2ME.newString("main") ])
+                     [ runtime.mainThread, J2ME.newString("main") ], stack)
       ]);
       release || Debug.assert(!U, "Unexpected unwind during isolate initialization.");
     }

--- a/vm/runtime.ts
+++ b/vm/runtime.ts
@@ -1276,7 +1276,8 @@ module J2ME {
     // Adapter for the most common case.
     if (!methodInfo.isSynchronized && !methodInfo.hasTwoSlotArguments) {
       var method = function fastInterpreterFrameAdapter() {
-        var frame = Frame.create(methodInfo, []);
+        var ctx = $.ctx;
+        var frame = Frame.create(methodInfo, [], ctx.bailoutStack);
         var j = 0;
         if (!methodInfo.isStatic) {
           frame.local[j++] = this;
@@ -1285,14 +1286,15 @@ module J2ME {
         for (var i = 0; i < slots; i++) {
           frame.local[j++] = arguments[i];
         }
-        return $.ctx.executeFrame(frame);
+        return ctx.executeFrame(frame);
       };
       (<any>method).methodInfo = methodInfo;
       return method;
     }
 
     var method = function interpreterFrameAdapter() {
-      var frame = Frame.create(methodInfo, []);
+      var ctx = $.ctx;
+      var frame = Frame.create(methodInfo, [], ctx.bailoutStack);
       var j = 0;
       if (!methodInfo.isStatic) {
         frame.local[j++] = this;
@@ -1312,9 +1314,9 @@ module J2ME {
             ? methodInfo.classInfo.getClassObject()
             : frame.local[0];
         }
-        $.ctx.monitorEnter(frame.lockObject);
+        ctx.monitorEnter(frame.lockObject);
         if (U === VMState.Pausing) {
-          $.ctx.pushFrame(frame);
+          ctx.pushFrame(frame);
           return;
         }
       }


### PR DESCRIPTION
We allocate two arrays for each frame, one storing local variables and one as operand stack. I try to reduce the number of arrays by merging the two array into one and making all frames share the same stack.

Also, for  the stack containing different types of value, it is little faster to implement with object properties than an array:
http://jsperf.com/stack-implementation-with-array-object

The new implementation is not equivalent to the original one and I'm trying to figure out why...