### PR TITLE
test: try assuming we can always yield

### DIFF
--- a/jit/analyze.ts
+++ b/jit/analyze.ts
@@ -224,7 +224,9 @@ module J2ME {
   }
 
   export function canYield(methodInfo: MethodInfo): YieldReason {
-    return YieldReason.Likely;
+    if (phase === ExecutionPhase.Runtime) {
+      return YieldReason.Likely;
+    }
 
     if (phase === ExecutionPhase.Runtime && methodInfo.codeAttribute && methodInfo.codeAttribute.code.length > 100) {
       // Large methods are likely to yield, so don't even bother checking at runtime.

--- a/jit/analyze.ts
+++ b/jit/analyze.ts
@@ -224,6 +224,8 @@ module J2ME {
   }
 
   export function canYield(methodInfo: MethodInfo): YieldReason {
+    return YieldReason.Likely;
+
     if (phase === ExecutionPhase.Runtime && methodInfo.codeAttribute && methodInfo.codeAttribute.code.length > 100) {
       // Large methods are likely to yield, so don't even bother checking at runtime.
       return YieldReason.Likely;


### PR DESCRIPTION
@brendandahl suggested we try making *canYield* return early with a positive result to see if it improves firstrun startup time, and this branch does that (immediately returns *YieldReason.likely*), but I don't see a significant change in the startup benchmark (with "delete JIT cache" checked to simulate a first run on every round) on a complex midlet where we compile ~400 methods during startup:

|      Test     | Baseline Mean |   Mean   |   +/-  |   %   |       P       |    Min   |    Max   | 
|:--------------|--------------:|---------:|-------:|------:|--------------:|---------:|---------:|
| startupTime   |       1,540ms |  1,537ms |   -3ms | -0.20 | INSIGNIFICANT |  1,466ms |  1,715ms | 
| totalSize     |      29,249kb | 28,750kb | -499kb | -1.70 |        BETTER | 27,816kb | 29,567kb | 
| domSize       |         153kb |    153kb |    0kb |  0.00 | INSIGNIFICANT |    153kb |    153kb | 
| styleSize     |         412kb |    412kb |    0kb | -0.02 |        BETTER |    411kb |    412kb | 
| jsObjectsSize |      17,163kb | 17,141kb |  -22kb | -0.13 |        BETTER | 17,134kb | 17,147kb | 
| jsStringsSize |         722kb |    715kb |   -7kb | -0.91 |        BETTER |    715kb |    717kb | 
| jsOtherSize   |      10,406kb |  9,936kb | -470kb | -4.52 |        BETTER |  9,009kb | 10,750kb | 
| otherSize     |         393kb |    393kb |    0kb |  0.05 |         WORSE |    393kb |    394kb | 
 
But perhaps if *canYield* only exits early during runtime instead of also during AOT compilation.
