### PR TITLE
Long Optimizations

### DIFF
--- a/jit/baseline.ts
+++ b/jit/baseline.ts
@@ -900,11 +900,13 @@ module J2ME {
         args.unshift(this.pop(signatureKinds[i]));
       }
       var object = null, call;
+      var classConstant = this.localClassConstant(methodInfo.classInfo);
+      var methodConstant = "(" + classConstant + ".M[" + methodInfo.index + "]||" + classConstant + ".m(" + methodInfo.index + "))";
       if (opcode !== Bytecodes.INVOKESTATIC) {
         object = this.pop(Kind.Reference);
         if (opcode === Bytecodes.INVOKESPECIAL) {
           args.unshift(object);
-          call = this.localClassConstant(methodInfo.classInfo) + ".m(" + methodInfo.index + ").call(" + args.join(",") + ")";
+          call = methodConstant + ".call(" + args.join(",") + ")";
         } else if (opcode === Bytecodes.INVOKEVIRTUAL) {
           call = object + "." + methodInfo.virtualName + "(" + args.join(",") + ")";
         } else if (opcode === Bytecodes.INVOKEINTERFACE) {
@@ -913,7 +915,7 @@ module J2ME {
           Debug.unexpected(Bytecodes[opcode]);
         }
       } else {
-        call = this.localClassConstant(methodInfo.classInfo) + ".m(" + methodInfo.index + ")" + "(" + args.join(",") + ")";
+        call = methodConstant + "(" + args.join(",") + ")";
       }
       if (methodInfo.implKey in inlineMethods) {
         emitDebugInfoComments && this.blockEmitter.writeLn("// Inlining: " + methodInfo.implKey);

--- a/jit/baseline.ts
+++ b/jit/baseline.ts
@@ -71,7 +71,7 @@ module J2ME {
    * Emits array bounds checks. Although this is necessary for correctness, most
    * applications work without them.
    */
-  export var emitCheckArrayBounds = true;
+  export var emitCheckArrayBounds = false;
 
   /**
    * Inline calls to runtime methods whenever possible.
@@ -1304,7 +1304,7 @@ module J2ME {
         case Bytecodes.I2B: v = "(" + x + "<<24)>>24"; break;
         case Bytecodes.I2C: v = x + "&0xffff"; break;
         case Bytecodes.I2S: v = "(" + x + "<<16)>>16"; break;
-        case Bytecodes.L2I: v = x + ".toInt()"; break;
+        case Bytecodes.L2I: v = x + ".low_"; break;
         case Bytecodes.L2F: v = "Math.fround(" + x + ".toNumber())"; break;
         case Bytecodes.L2D: v = x + ".toNumber()"; break;
         case Bytecodes.D2I:

--- a/jit/baseline.ts
+++ b/jit/baseline.ts
@@ -71,7 +71,7 @@ module J2ME {
    * Emits array bounds checks. Although this is necessary for correctness, most
    * applications work without them.
    */
-  export var emitCheckArrayBounds = false;
+  export var emitCheckArrayBounds = true;
 
   /**
    * Inline calls to runtime methods whenever possible.

--- a/libs/long.js
+++ b/libs/long.js
@@ -45,6 +45,7 @@
     function Long(low, high) {
         this.low_ = low | 0; // force into 32 signed bits.
         this.high_ = high | 0; // force into 32 signed bits.
+        this.string_ = null;
     }
 
     var IntCache = {};
@@ -183,7 +184,9 @@
         if (radix < 2 || 36 < radix) {
             throw Error('radix out of range: ' + radix);
         }
-
+        if (radix === 10 && this.string_) {
+            return this.string_;
+        }
         if (this.isZero()) {
             return '0';
         }
@@ -197,7 +200,11 @@
                 var rem = div.multiply(radixLong).subtract(this);
                 return div.toString(radix) + rem.toInt().toString(radix);
             } else {
-                return '-' + this.negate().toString(radix);
+                var result = '-' + this.negate().toString(radix);
+                if (radix === 10) {
+                    this.string_ = result;
+                }
+                return result;
             }
         }
 
@@ -214,7 +221,11 @@
 
             rem = remDiv;
             if (rem.isZero()) {
-                return digits + result;
+                result = digits + result;
+                if (radix === 10) {
+                    this.string_ = result;
+                }
+                return result;
             } else {
                 while (digits.length < 6) {
                     digits = '0' + digits;

--- a/libs/long.js
+++ b/libs/long.js
@@ -342,6 +342,15 @@
     *     if the given one is greater.
     */
     Long.prototype.compare = function (other) {
+        if (other.isZero()) {
+            if (this.isZero()) {
+                return 0;
+            } else if (this.high_ < 0) {
+                return -1;
+            } else {
+                return 1;
+            }
+        }
         if (this.equals(other)) {
             return 0;
         }

--- a/libs/long.js
+++ b/libs/long.js
@@ -89,6 +89,11 @@
         }
     };
 
+    var LongCache = new Array(4093);
+    for (var i = 0; i < LongCache.length; i++) {
+      LongCache[i] = null;
+    }
+
     /**
     * Returns a Long representing the 64-bit integer that comes by concatenating
     * the given high and low bits.  Each is assumed to use 32 bits.
@@ -107,7 +112,14 @@
                 case 4: return FOUR;
             }
         }
-        return new Long(lowBits, highBits);
+        // Cache Longs.
+        var index = (((((lowBits * 32) | 0) + highBits) | 0) & 0x7fffffff) % 4093;
+        var entry = LongCache[index];
+        if (entry && entry.high_ === highBits && entry.low_ === lowBits) {
+            return entry;
+        } else {
+            return (LongCache[index] = new Long(lowBits, highBits));
+        }
     };
 
     /**

--- a/libs/long.js
+++ b/libs/long.js
@@ -96,7 +96,17 @@
     * @param {number} highBits The high 32-bits.
     * @return {!Long} The corresponding Long value.
     */
+    var count = 0;
     function fromBits(lowBits, highBits) {
+        if (highBits === 0) {
+            switch (lowBits) {
+                case 0: return ZERO;
+                case 1: return ONE;
+                case 2: return TWO;
+                case 3: return THREE;
+                case 4: return FOUR;
+            }
+        }
         return new Long(lowBits, highBits);
     };
 
@@ -345,6 +355,14 @@
     * @return {!Long} The sum of this and the given Long.
     */
     Long.prototype.add = function (other) {
+        if (other === ONE && this.high_ === 0) {
+            switch (this.low_) {
+                case 0: return ONE;
+                case 1: return TWO;
+                case 2: return THREE;
+                case 3: return FOUR;
+            }
+        }
         // Divide each number into 4 chunks of 16 bits, and then sum the chunks.
         var a48 = this.high_ >>> 16;
         var a32 = this.high_ & 0xFFFF;
@@ -620,6 +638,9 @@
     *     zeros placed into the new leading bits.
     */
     Long.prototype.shiftRightUnsigned = function (numBits) {
+        if (this === ZERO) {
+            return this;
+        }
         numBits &= 63;
         if (numBits == 0) {
             return this;
@@ -638,6 +659,10 @@
 
     var ZERO = fromInt(0);
     var ONE = fromInt(1);
+    var TWO = fromInt(2);
+    var THREE = fromInt(3);
+    var FOUR = fromInt(4);
+
     var NEG_ONE = fromInt(-1);
     var MAX_VALUE = fromBits(0xFFFFFFFF, 0x7FFFFFFF);
     var MIN_VALUE = fromBits(0, 0x80000000);

--- a/libs/long.js
+++ b/libs/long.js
@@ -102,8 +102,9 @@
     * @param {number} highBits The high 32-bits.
     * @return {!Long} The corresponding Long value.
     */
-    var count = 0;
     function fromBits(lowBits, highBits) {
+        // Don't allocate Long objects for -1, 0, 1, 2, 3, 4. These low/high bit patterns occur
+        // frequently in computations.
         if (highBits === 0) {
             switch (lowBits) {
                 case 0: return ZERO;
@@ -112,6 +113,8 @@
                 case 3: return THREE;
                 case 4: return FOUR;
             }
+        } else if (highBits === -1 && lowBits === -1) {
+          return NEG_ONE;
         }
         // Cache Longs.
         var index = (((((lowBits * 32) | 0) + highBits) | 0) & 0x7fffffff) % 4093;

--- a/tests/MainStaticInitializer.java
+++ b/tests/MainStaticInitializer.java
@@ -1,0 +1,10 @@
+class MainStaticInitializer {
+    static {
+        System.out.println("1) static init");
+    }
+    public static void main(String args[]) {
+        System.out.println("2) main");
+        System.out.println("DONE");
+    }
+}
+

--- a/tests/automation.js
+++ b/tests/automation.js
@@ -176,7 +176,7 @@ function syncFS() {
     });
 }
 
-casper.test.begin("unit tests", 24 + gfxTests.length, function(test) {
+casper.test.begin("unit tests", 25 + gfxTests.length, function(test) {
     casper.start("data:text/plain,start");
 
     casper.page.onLongRunningScript = function(message) {
@@ -263,6 +263,15 @@ casper.test.begin("unit tests", 24 + gfxTests.length, function(test) {
                                   "I 3\n" +
                                   "I marc\n" +
                                   "I Main isolate still running");
+        });
+    });
+
+    casper
+    .thenOpen("http://localhost:8000/index.html?main=MainStaticInitializer&logLevel=info&logConsole=web,page,raw")
+    .withFrame(0, function() {
+        casper.waitForText("DONE", function() {
+            test.assertTextExists("I 1) static init\n" +
+                                  "I 2) main");
         });
     });
 

--- a/vm/jvm.ts
+++ b/vm/jvm.ts
@@ -69,11 +69,17 @@ module J2ME {
         args[n] = mainArgs[n];
       }
 
-      ctx.start([
-        Frame.create(entryPoint, [ args ]),
-        Frame.create(CLASSES.java_lang_Thread.getMethodByNameString("<init>", "(Ljava/lang/String;)V"),
-                     [ runtime.mainThread, J2ME.newString("main") ])
-      ]);
+      var frames = [Frame.create(entryPoint, [ args ])];
+
+      var clinit = classInfo.staticInitializer;
+      if (clinit) {
+        frames.push(Frame.create(clinit, []));
+      }
+
+      frames.push(Frame.create(CLASSES.java_lang_Thread.getMethodByNameString("<init>", "(Ljava/lang/String;)V"),
+                               [ runtime.mainThread, J2ME.newString("main") ]));
+
+      ctx.start(frames);
       release || Debug.assert(!U, "Unexpected unwind during isolate initialization.");
     }
 

--- a/vm/runtime.ts
+++ b/vm/runtime.ts
@@ -841,7 +841,7 @@ module J2ME {
     /**
      * Linked class methods.
      */
-    methods: Function[];
+    M: Function[];
   }
 
   export class RuntimeKlass {
@@ -1476,7 +1476,7 @@ module J2ME {
       fn = wrapMethod(fn, methodInfo, methodType);
     }
 
-    klass.methods[methodInfo.index] = methodInfo.fn = fn;
+    klass.M[methodInfo.index] = methodInfo.fn = fn;
 
     if (!methodInfo.isStatic && methodInfo.virtualName) {
       release || assert(klass.prototype.hasOwnProperty(methodInfo.virtualName));
@@ -1630,13 +1630,13 @@ module J2ME {
 
   function klassMethodLink(index: number) {
     var klass: Klass = this;
-    var fn = klass.methods[index];
+    var fn = klass.M[index];
     if (fn) {
       return fn;
     }
     linkKlassMethod(klass, klass.classInfo.getMethodByIndex(index));
-    release || assert(klass.methods[index], "Method should be linked now.");
-    return klass.methods[index];
+    release || assert(klass.M[index], "Method should be linked now.");
+    return klass.M[index];
   }
 
   function klassResolveConstantPoolEntry(index: number) {
@@ -1667,7 +1667,7 @@ module J2ME {
     // Method linking.
     klass.m = klassMethodLink;
     klass.c = klassResolveConstantPoolEntry;
-    klass.methods = new Array(classInfo.getMethodCount());
+    klass.M = new Array(classInfo.getMethodCount());
   }
 
   /**
@@ -1791,7 +1791,7 @@ module J2ME {
       fn = wrapMethod(fn, methodInfo, MethodType.Compiled);
     }
     var klass = methodInfo.classInfo.klass;
-    klass.methods[methodInfo.index] = methodInfo.fn = fn;
+    klass.M[methodInfo.index] = methodInfo.fn = fn;
     methodInfo.state = MethodState.Compiled;
     methodInfo.onStackReplacementEntryPoints = onStackReplacementEntryPoints;
 


### PR DESCRIPTION
Most of the optimizations in this PR deal with reducing the number of Long box allocations through caching. Caching takes more space, but reduces drastically the number of allocations. In some midlets, scrolling through UI elements can allocate upwards of 10K temporary Long objects. This PR reduces that to a few hundred.

