### PR TITLE
Remove macro byte codes to fix interpreter only mode.

### DIFF
--- a/bytecodes.ts
+++ b/bytecodes.ts
@@ -671,11 +671,6 @@ module J2ME.Bytecode {
       define(Bytecodes.GOTO_W              , "goto_w"          , "boooo", Flags.STOP | Flags.BRANCH);
       define(Bytecodes.JSR_W               , "jsr_w"           , "boooo", Flags.STOP | Flags.BRANCH);
       define(Bytecodes.BREAKPOINT          , "breakpoint"      , "b"    , Flags.TRAP);
-
-
-      define(Bytecodes.ALOAD_ILOAD                   , "aload_iload"               , "bi"   , Flags.LOAD);
-      define(Bytecodes.IINC_GOTO                     , "iinc_goto"                 , "bic"  , Flags.LOAD | Flags.STORE | Flags.STOP | Flags.BRANCH);
-      define(Bytecodes.ARRAYLENGTH_IF_ICMPGE         , "arraylength_IF_ICMPGE"     , "b"    , Flags.COMMUTATIVE | Flags.FALL_THROUGH | Flags.BRANCH | Flags.TRAP);
     }
     defineBytecodes();
   }

--- a/vm/parser.ts
+++ b/vm/parser.ts
@@ -780,7 +780,6 @@ module J2ME {
 
     exception_table_length: number = -1;
     exception_table_offset: number = -1;
-    isOptimized: boolean = false;
 
     constructor(classInfo: ClassInfo, offset: number, index: number) {
       super(classInfo.buffer, offset);


### PR DESCRIPTION
Let's remove for now since a popular midlet is broken when running in interpreter only mode with optimizations enabled. Happy to add back if there is some perf increase.