### PR TITLE
WIP Implement an AMS MIDlet

### DIFF
--- a/java/custom/com/nokia/mid/s40/bg/BGUtils.java
+++ b/java/custom/com/nokia/mid/s40/bg/BGUtils.java
@@ -1,55 +1,6 @@
 package com.nokia.mid.s40.bg;
 
-import com.sun.cldc.isolate.Isolate;
-import com.sun.midp.main.AmsUtil;
-import com.sun.midp.midletsuite.MIDletSuiteStorage;
-
-import com.sun.midp.events.Event;
-import com.sun.midp.events.NativeEvent;
-import com.sun.midp.events.EventQueue;
-import com.sun.midp.events.EventTypes;
-import com.sun.midp.events.EventListener;
-
-public class BGUtils implements EventListener {
-    private static native int getFGMIDletNumber();
-    private static native String getFGMIDletClass();
-    public static native void maybeWaitUserInteraction(String midletClassName);
-
-    public static void setBGMIDletResident(boolean param) {
-        AmsUtil.executeWithArgs(MIDletSuiteStorage.getMIDletSuiteStorage(), 0, BGUtils.getFGMIDletNumber(),
-                                BGUtils.getFGMIDletClass(), null, null, null, null, -1, -1, Isolate.MAX_PRIORITY,
-                                null, false);
-    }
-
+public class BGUtils {
+    public static native void setBGMIDletResident(boolean param);
     public static native boolean launchIEMIDlet(String midletSuiteVendor, String midletName, int midletNumber, String startupNoteText, String args);
-
-    static {
-        EventQueue.getEventQueue()
-                  .registerEventListener(EventTypes.NATIVE_MIDLET_EXECUTE_REQUEST,
-                                         BGUtils.getBGUtilsInstance());
-    }
-    private static BGUtils bgUtils = null;
-    private static BGUtils getBGUtilsInstance() {
-        if (bgUtils == null) {
-            bgUtils = new BGUtils();
-        }
-
-        return bgUtils;
-    }
-
-    public boolean preprocess(Event event, Event waitingEvent) {
-        return true;
-    }
-
-    public void process(Event event) {
-        NativeEvent nativeEvent = (NativeEvent)event;
-
-        switch (nativeEvent.getType()) {
-            case EventTypes.NATIVE_MIDLET_EXECUTE_REQUEST:
-              AmsUtil.executeWithArgs(MIDletSuiteStorage.getMIDletSuiteStorage(), 0, BGUtils.getFGMIDletNumber(),
-                                      BGUtils.getFGMIDletClass(), null, null, null, null, -1, -1, Isolate.MAX_PRIORITY,
-                                      null, false);
-            break;
-        }
-    }
 }

--- a/java/custom/org/mozilla/ams/AmsMIDlet.java
+++ b/java/custom/org/mozilla/ams/AmsMIDlet.java
@@ -1,0 +1,64 @@
+package org.mozilla.ams;
+
+import com.sun.cldc.isolate.Isolate;
+
+import com.sun.midp.events.EventQueue;
+import com.sun.midp.main.AmsUtil;
+import com.sun.midp.main.MIDletProxy;
+import com.sun.midp.main.MIDletProxyList;
+
+import javax.microedition.midlet.MIDlet;
+
+class MIDletLauncher implements Runnable {
+    public void run() {
+        init0();
+    }
+
+    private native void init0();
+}
+
+public class AmsMIDlet extends MIDlet
+                       implements NativeAMSEventConsumer {
+    public AmsMIDlet() {
+    }
+
+    public void startApp() {
+        new NativeAMSEventListener(EventQueue.getEventQueue(), this);
+        new Thread(new MIDletLauncher()).start();
+    }
+
+    public void pauseApp() {
+    }
+
+    public void destroyApp(boolean unconditional) {
+    }
+
+    public void handleNativeMIDletExecuteRequest(int suiteId, String className, String displayName, String arg0, String arg1, String arg2) {
+            Isolate isolate = AmsUtil.startMidletInNewIsolate(suiteId,
+                                                              className,
+                                                              displayName,
+                                                              arg0,
+                                                              arg1,
+                                                              arg2);
+            if (!isBGMIDlet0(className)) {
+                isolate.setPriority(Isolate.MAX_PRIORITY);
+            }
+    }
+
+    public void handleNativeMIDletDestroyRequest(int suiteId, String className) {
+        MIDletProxyList mpl = MIDletProxyList.getMIDletProxyList();
+        if (null == mpl) {
+            return;
+        }
+
+        MIDletProxy m = mpl.findMIDletProxy(suiteId, className);
+        if (null == m) {
+            System.out.println("Could not find MIDlet to destroy: " + suiteId + ", " + className);
+            return;
+        }
+
+        m.destroyMidlet();
+    }
+
+    private native boolean isBGMIDlet0(String className);
+}

--- a/java/custom/org/mozilla/ams/NativeAMSEventConsumer.java
+++ b/java/custom/org/mozilla/ams/NativeAMSEventConsumer.java
@@ -1,0 +1,49 @@
+package org.mozilla.ams;
+
+/**
+ * NativeAMSEventConsumer
+ *
+ */
+public interface NativeAMSEventConsumer {
+    /**
+     * Processes NATIVE_MIDLET_EXECUTE_REQUEST
+     *
+     * @param suiteId the suiteId of the MIDlet to launch
+     * @param className the className of the MIDlet to launch
+     * @param displayName the name to display for the running MIDlet
+     * @param arg0 the first arg to pass to the MIDlet
+     * @param arg1 the second arg to pass to the MIDlet
+     * @param arg2 the third arg to pass to the MIDlet
+     */
+    public void handleNativeMIDletExecuteRequest(
+        int suiteId,
+        String className,
+        String displayName,
+        String arg0,
+        String arg1,
+        String arg2);
+
+    /**
+     * Processes NATIVE_MIDLET_DESTROY_REQUEST
+     *
+     * @param suiteId the suiteId of the MIDlet to destroy
+     * @param className the className of the MIDlet to destroy
+     */
+    public void handleNativeMIDletDestroyRequest(
+        int suiteId,
+        String className);
+
+
+    /*
+     * TODO: We can add these as we need them
+     *
+     * Processes NATIVE_MIDLET_RESUME_REQUEST
+    public void handleNativeMIDletResumeRequest();
+
+     * Processes NATIVE_MIDLET_PAUSE_REQUEST
+    public void handleNativeMIDletPauseRequest();
+
+     * Processes NATIVE_MIDLET_GETINFO_REQUEST
+    public void handleNativeMIDletGetInfoRequest();
+    */
+}

--- a/java/custom/org/mozilla/ams/NativeAMSEventListener.java
+++ b/java/custom/org/mozilla/ams/NativeAMSEventListener.java
@@ -1,0 +1,103 @@
+package org.mozilla.ams;
+
+import com.sun.midp.events.Event;
+import com.sun.midp.events.EventListener;
+import com.sun.midp.events.EventQueue;
+import com.sun.midp.events.EventTypes;
+import com.sun.midp.events.NativeEvent;
+
+/**
+ * NativeAMSEventListener
+ */
+class NativeAMSEventListener implements EventListener {
+    private NativeAMSEventConsumer consumer;
+
+    NativeAMSEventListener(
+        EventQueue eventQueue,
+        NativeAMSEventConsumer aConsumer) {
+
+        consumer = aConsumer;
+
+        eventQueue.registerEventListener(
+            EventTypes.NATIVE_MIDLET_EXECUTE_REQUEST, this);
+        eventQueue.registerEventListener(
+            EventTypes.NATIVE_MIDLET_DESTROY_REQUEST, this);
+
+        /*
+         * TODO: We can add these as we want them
+         *
+        eventQueue.registerEventListener(
+            EventTypes.NATIVE_MIDLET_RESUME_REQUEST, this);
+        eventQueue.registerEventListener(
+            EventTypes.NATIVE_MIDLET_PAUSE_REQUEST, this);
+        eventQueue.registerEventListener(
+            EventTypes.NATIVE_MIDLET_GETINFO_REQUEST, this);
+        */
+    }
+
+    /**
+     * Preprocess
+     *
+     * @param event event to preprocess
+     *
+     * @param waitingEvent previous event of same type if one is waiting
+     *
+     * @return false to block event from being posted
+     */
+    public boolean preprocess(Event event, Event waitingEvent) {
+        return true;
+    }
+
+    /**
+     * Process
+     *
+     * @param event event to process
+     */
+    public void process(Event event) {
+        try {
+            NativeEvent nativeEvent = (NativeEvent)event;
+
+            switch (nativeEvent.getType()) {
+
+                case EventTypes.NATIVE_MIDLET_EXECUTE_REQUEST:
+                    consumer.handleNativeMIDletExecuteRequest(
+                        nativeEvent.intParam1, // suiteId
+                        nativeEvent.stringParam1, // className
+                        nativeEvent.stringParam2, // displayName
+                        nativeEvent.stringParam3, // arg0
+                        nativeEvent.stringParam4, // arg1
+                        nativeEvent.stringParam5); // arg2
+                    return;
+
+                case EventTypes.NATIVE_MIDLET_DESTROY_REQUEST:
+                    consumer.handleNativeMIDletDestroyRequest(
+                        nativeEvent.intParam1, // suiteId
+                        nativeEvent.stringParam1); // midlet class name
+                    return;
+
+                    /*
+                     * TODO: We can add these as we need them
+                     *
+                case EventTypes.NATIVE_MIDLET_RESUME_REQUEST:
+                    consumer.handleNativeMIDletResumeRequest();
+                    return;
+
+                case EventTypes.NATIVE_MIDLET_PAUSE_REQUEST:
+                    consumer.handleNativeMIDletPauseRequest();
+                    return;
+
+
+                case EventTypes.NATIVE_MIDLET_GETINFO_REQUEST:
+                    consumer.handleNativeMIDletGetInfoRequest();
+                    return;
+                    */
+
+            default:
+                System.out.println("Unknown native AMS event: " + nativeEvent.getType());
+                return;
+            }
+        } catch (Throwable t) {
+            System.out.println("Exception while processing native AMS event");
+        }
+    }
+}

--- a/jit/analyze.ts
+++ b/jit/analyze.ts
@@ -25,6 +25,7 @@ module J2ME {
    * at the right spots.
    */
   export var yieldMap = {
+    "org/mozilla/MIDletLauncher.init0.()V": YieldReason.Root,
     "com/sun/midp/lcdui/RepaintEventProducer.waitForAnimationFrame.()V": YieldReason.Root,
     "com/sun/midp/main/MIDletSuiteUtils.vmBeginStartUp.(I)V": YieldReason.Root,
     "com/sun/midp/lcdui/DisplayDevice.gainedForeground0.(II)V": YieldReason.Root,

--- a/midp/background.js
+++ b/midp/background.js
@@ -3,8 +3,10 @@
 
 'use strict';
 
-var fgMidletNumber;
+var bgMidletClass;
+var bgMidletDisplayName;
 var fgMidletClass;
+var fgMidletDisplayName;
 
 var display = document.getElementById("display");
 
@@ -51,6 +53,9 @@ function showExitScreen() {
 }
 
 function backgroundCheck() {
+  fgMidletClass = config.midletClassName;
+  fgMidletDisplayName = "";
+
   var bgServer = MIDP.manifest["Nokia-MIDlet-bg-server"];
   if (!bgServer) {
     showSplashScreen();
@@ -58,30 +63,54 @@ function backgroundCheck() {
     return;
   }
 
-  // We're assuming there are only two midlets
-  fgMidletNumber = (bgServer == 2) ? 1 : 2;
-  fgMidletClass = MIDP.manifest["MIDlet-" + fgMidletNumber].split(",")[2];
+  bgMidletClass = MIDP.manifest["MIDlet-" + bgServer].split(",")[2];
+  bgMidletDisplayName = MIDP.manifest["MIDlet-" + bgServer].split(",")[0];
+
+  if (fgMidletClass === bgMidletClass) {
+    // The config is targeting the BG MIDlet. We have to make an educated guess about
+    // which MIDlet is intended to be the FG MIDlet.
+    // We're assuming there are only two midlets
+    var fgMidletNumber = (bgServer == 2) ? 1 : 2;
+    fgMidletClass = MIDP.manifest["MIDlet-" + fgMidletNumber].split(",")[2];
+    fgMidletDisplayName = MIDP.manifest["MIDlet-" + fgMidletNumber].split(",")[0];
+  }
+
 
   DumbPipe.close(DumbPipe.open("backgroundCheck", {}));
 }
 
-Native["com/nokia/mid/s40/bg/BGUtils.getFGMIDletClass.()Ljava/lang/String;"] = function() {
-  return J2ME.newString(fgMidletClass);
-};
-
-Native["com/nokia/mid/s40/bg/BGUtils.getFGMIDletNumber.()I"] = function() {
-  return fgMidletNumber;
-};
-
 MIDP.additionalProperties = {};
 
 Native["com/nokia/mid/s40/bg/BGUtils.launchIEMIDlet.(Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;)Z"] = function(midletSuiteVendor, midletName, midletNumber, startupNoteText, args) {
+  var vendor = J2ME.fromJavaString(midletSuiteVendor);
+  if (vendor !== MIDP.manifest["MIDlet-Vendor"]) {
+    console.warn("Launching MIDlets from other suites is not supported! (vendor mismatch)");
+    return 0;
+  }
+
+  var name = J2ME.fromJavaString(midletName);
+  if (name !== MIDP.manifest["MIDlet-Name"]) {
+    console.warn("Launching MIDlets from other suites is not supported! (name mismatch)");
+    return 0;
+  }
+
+  // Set up args
+  MIDP.additionalProperties = {};
   J2ME.fromJavaString(args).split(";").splice(1).forEach(function(arg) {
     var elems = arg.split("=");
     MIDP.additionalProperties[elems[0]] = elems[1];
   });
 
+  var className = MIDP.manifest["MIDlet-" + midletNumber].split(",")[2];
+  var displayName = MIDP.manifest["MIDlet-" + midletNumber].split(",")[0];
+
+  MIDP.sendExecuteMIDletEvent(1, className, displayName, "", "", "");
+
   return 1;
+};
+
+Native["com/nokia/mid/s40/bg/BGUtils.setBGMIDletResident.(Z)V"] = function(param) {
+  console.log("BGUtils.setBGMIDletResident(" + param + ")");
 };
 
 Native["com/nokia/mid/s40/bg/BGUtils.maybeWaitUserInteraction.(Ljava/lang/String;)V"] = function(midletClassName) {
@@ -121,6 +150,28 @@ Native["com/nokia/mid/s40/bg/BGUtils.maybeWaitUserInteraction.(Ljava/lang/String
     hideBackgroundScreen();
     profile === 3 && startTimeline();
   }));
+};
+
+Native["org/mozilla/ams/MIDletLauncher.init0.()V"] = function() {
+  asyncImpl("V", Promise.all(loadingMIDletPromises).then(function() {
+    var suiteId = (config.midletClassName === "internal") ? -1 : 1;
+
+    if (bgMidletClass) {
+      MIDP.sendExecuteMIDletEvent(suiteId, bgMidletClass, bgMidletDisplayName, "", "", "");
+    }
+
+    var args = config.args;
+    MIDP.sendExecuteMIDletEvent(suiteId,
+                                fgMidletClass,
+                                fgMidletDisplayName,
+                                (args.length > 0) ? args[0] : "",
+                                (args.length > 1) ? args[1] : "",
+                                (args.length > 2) ? args[2] : "");
+  }));
+};
+
+Native["org/mozilla/ams/AmsMIDlet.isBGMIDlet0.(Ljava/lang/String;)Z"] = function(className) {
+  return bgMidletClass === J2ME.fromJavaString(className) ? 1 : 0;
 };
 
 // If the document is hidden, then we've been started by an alarm and are in

--- a/midp/midp.js
+++ b/midp/midp.js
@@ -169,11 +169,10 @@ var MIDP = (function() {
   Native["com/sun/midp/main/CommandState.restoreCommandState.(Lcom/sun/midp/main/CommandState;)V"] = function(state) {
     var suiteId = (config.midletClassName === "internal") ? -1 : 1;
     state.suiteId = suiteId;
-    state.midletClassName = J2ME.newString(config.midletClassName);
-    var args = config.args;
-    state.arg0 = J2ME.newString((args.length > 0) ? args[0] : "");
-    state.arg1 = J2ME.newString((args.length > 1) ? args[1] : "");
-    state.arg2 = J2ME.newString((args.length > 2) ? args[2] : "");
+    state.midletClassName = J2ME.newString("org.mozilla.ams.AmsMIDlet");
+    state.arg0 = J2ME.newString("");
+    state.arg1 = J2ME.newString("");
+    state.arg2 = J2ME.newString("");
   };
 
   Native["com/sun/midp/main/MIDletSuiteUtils.getIsolateId.()I"] = function() {
@@ -830,17 +829,24 @@ var MIDP = (function() {
     }, false);
   }
 
-  function sendExecuteMIDletEvent() {
+  function sendExecuteMIDletEvent(suiteId, className, displayName, arg0, arg1, arg2) {
     AMS.sendNativeEventToAMSIsolate({
       type: NATIVE_MIDLET_EXECUTE_REQUEST,
+      intParam1: suiteId,
+      stringParam1: J2ME.newString(className),
+      stringParam2: J2ME.newString(displayName),
+      stringParam3: J2ME.newString(arg0),
+      stringParam4: J2ME.newString(arg1),
+      stringParam5: J2ME.newString(arg2),
     });
   }
 
-  function sendDestroyMIDletEvent(midletClassName) {
-    FG.sendNativeEventToForeground({
-      type: DESTROY_MIDLET_EVENT,
-      stringParam1: midletClassName,
-    }, false);
+  function sendDestroyMIDletEvent(suiteId, className) {
+    AMS.sendNativeEventToAMSIsolate({
+      type: NATIVE_MIDLET_DESTROY_REQUEST,
+      intParam1: suiteId,
+      stringParam1: J2ME.newString(className),
+    });
   }
 
   var KEY_EVENT = 1;
@@ -850,7 +856,7 @@ var MIDP = (function() {
   var DRAGGED = 3;
   var COMMAND_EVENT = 3;
   var NATIVE_MIDLET_EXECUTE_REQUEST = 36;
-  var DESTROY_MIDLET_EVENT = 14;
+  var NATIVE_MIDLET_DESTROY_REQUEST = 39;
   var EVENT_QUEUE_SHUTDOWN = 31;
   var ROTATION_EVENT = 43;
   var MMAPI_EVENT = 45;

--- a/tests/midlets/background/BackgroundMIDlet3.java
+++ b/tests/midlets/background/BackgroundMIDlet3.java
@@ -26,7 +26,7 @@ public class BackgroundMIDlet3 extends MIDlet {
         }
 
         BGUtils.setBGMIDletResident(true);
-        BGUtils.launchIEMIDlet("Mozilla", "ForegroundMIDlet", 1, "unknown", ";prop1=hello;prop2=ciao");
+        BGUtils.launchIEMIDlet("Mozilla", "Background3", 1, "unknown", ";prop1=hello;prop2=ciao");
     }
 
     public void pauseApp() {

--- a/tests/midlets/background/background1.jad
+++ b/tests/midlets/background/background1.jad
@@ -7,7 +7,7 @@ Nokia-MIDlet-bg-memory-size: 350
 Nokia-MIDlet-Background-Exit-Confirm-en: DO NOT EXIT!
 Nokia-MIDlet-Save-Location: Root
 Nokia-MIDlet-bg-server: 2
-MIDlet-Name: BackgroundMIDlet
+MIDlet-Name: Background1
 Nokia-MIDlet-Dual-SIM-Compliant: true
 MIDlet-Version: 2.12.25
 MicroEdition-Configuration: CLDC-1.1

--- a/tests/midlets/background/background2.jad
+++ b/tests/midlets/background/background2.jad
@@ -7,7 +7,7 @@ Nokia-MIDlet-bg-memory-size: 350
 Nokia-MIDlet-Background-Exit-Confirm-en: DO NOT EXIT!
 Nokia-MIDlet-Save-Location: Root
 Nokia-MIDlet-bg-server: 2
-MIDlet-Name: BackgroundMIDlet
+MIDlet-Name: Background2
 Nokia-MIDlet-Dual-SIM-Compliant: true
 MIDlet-Version: 2.12.25
 MicroEdition-Configuration: CLDC-1.1

--- a/tests/midlets/background/background3.jad
+++ b/tests/midlets/background/background3.jad
@@ -6,8 +6,7 @@ MIDlet-Vendor: Mozilla
 Nokia-MIDlet-bg-memory-size: 350
 Nokia-MIDlet-Background-Exit-Confirm-en: DO NOT EXIT!
 Nokia-MIDlet-Save-Location: Root
-Nokia-MIDlet-bg-server: 2
-MIDlet-Name: BackgroundMIDlet
+MIDlet-Name: Background3
 Nokia-MIDlet-Dual-SIM-Compliant: true
 MIDlet-Version: 2.12.25
 MicroEdition-Configuration: CLDC-1.1

--- a/tests/native.js
+++ b/tests/native.js
@@ -237,12 +237,17 @@ Native["tests/recordstore/ReaderMIDlet.waitWriterWrote.()V"] = function() {
 
 Native["tests/background/DestroyMIDlet.sendDestroyMIDletEvent.()V"] = function() {
   MIDP.setDestroyedForRestart(true);
-  MIDP.sendDestroyMIDletEvent(J2ME.newString("tests.background.DestroyMIDlet"));
+  MIDP.sendDestroyMIDletEvent(1, "tests.background.DestroyMIDlet");
 };
 
 Native["tests/background/DestroyMIDlet.sendExecuteMIDletEvent.()V"] = function() {
   setTimeout(function() {
-    MIDP.sendExecuteMIDletEvent();
+    MIDP.sendExecuteMIDletEvent(1,
+                                "tests.background.DestroyMIDlet",
+                                "",
+                                "",
+                                "",
+                                "");
   }, 0);
 };
 


### PR DESCRIPTION
Up to now, we've been telling the `MIDletSuiteLoader` class to launch
whatever user `MIDlet` we're trying to launch. We've been targeting the
background MIDlet of each suite we're running and then expecting the BG
MIDlet to call `BGUtils.setBGMIDletResident`. At that point, we've been
launching our best guess at what the FG MIDlet is (we currently assume
that there are only ever a max of 2 MIDlets in a suite).

This has a few important implications.

Because we launch the FG MIDlet when the BG MIDlet calls
`BGUtils.setBGMIDletResident`, and because that is frequently during the
BG MIDlet's `startApp` or constructor, the BG MIDlet does not get a
chance to fully initialize before the FG MIDlet starts up and takes the
foreground. This means that certain registrations that should be present
in the system by the time the FG MIDlet launches will not be present if
they were supposed to have been made by the BG MIDlet. It also means
that we cannot pause the BG MIDlet because the system will believe that
it is in a pre-startup state and will terminate it instead.

The MIDlet launched by `MIDletSuiteLoader` is supposed to be a special
"AMS" MIDlet that is responsible for managing user MIDlets
(launching/pausing/destroying, etc). The Isolate of the MIDlet launched
by `MIDletSuiteLoader` gets special privileges and is treated
specially by the MIDP system.

This patch implements an AMS MIDlet to be loaded into the special AMS
isolate. As a result of this patch we no longer load user MIDlets into
the AMS isolate. The AMS MIDlet implemented by this patch launches the
BG MIDlet if there is one specified in the JAD we are loading, then it
launches the FG MIDlet specified in the j2me.js configuration, or it
guesses like we've currently been doing if the configuration targets the
BG MIDlet.

The AMS MIDlet is now the handler for `NATIVE_MIDLET_EXECUTE_REQUEST`
events which we send to request MIDlet launches, and for
`NATIVE_MIDLET_DESTROY_REQUEST` which we now send to request MIDlet
destruction. These are implemented in terms of the `AmsUtil` and
`MIDletProxyList` classes which make certain methods available
only to the AMS MIDlet.

I ran the startup benchmarks on device and found that this patch makes startup slower by an amount that is probably not acceptable. WIP while I see if I can bring the startup hit down. Also the "bgStartupTime" and "fgStartupTime" values don't work because the functions that they rely on have been eliminated. I'll fix that in another push to this branch.

|         Test         | Baseline Mean |    Mean    |    +/-    |    %    |     P    |     Min    |     Max     | 
|:---------------------|--------------:|-----------:|----------:|--------:|---------:|-----------:|------------:|
| startupTime          |      16,618ms |   19,494ms |   2,876ms |   17.31 |    WORSE |   17,221ms |    22,608ms | 
| vmStartupTime        |       2,662ms |    2,702ms |      39ms |    1.47 |    WORSE |    2,397ms |     2,987ms | 
| bgStartupTime        |         906ms |      NaNms |     NaNms |     NaN |     SAME | Infinityms | -Infinityms | 
| fgStartupTime        |      11,476ms |      NaNms |     NaNms |     NaN |     SAME |      NaNms |       NaNms | 
| fgRefreshStartupTime |       1,573ms |    1,126ms |    -447ms |  -28.43 |   BETTER |      782ms |     1,909ms | 
| *totalSize*          |    *26,506kb* | *26,731kb* |   *224kb* |  *0.85* |  *WORSE* | *26,017kb* |  *27,282kb* | 
| *domSize*            |        *74kb* |     *74kb* |     *0kb* | *-0.02* |   *SAME* |     *74kb* |      *74kb* | 
| *styleSize*          |       *311kb* |    *311kb* |     *0kb* |  *0.00* |   *SAME* |    *304kb* |     *316kb* | 
| *jsObjectsSize*      |    *18,122kb* | *18,412kb* |   *290kb* |  *1.60* |  *WORSE* | *18,389kb* |  *18,435kb* | 
| *jsStringsSize*      |     *1,016kb* |    *928kb* |   *-88kb* | *-8.69* | *BETTER* |    *927kb* |     *928kb* | 
| *jsOtherSize*        |     *6,719kb* |  *6,731kb* |    *12kb* |  *0.18* |   *SAME* |  *6,093kb* |   *7,209kb* | 
| *otherSize*          |       *264kb* |    *275kb* |    *10kb* |  *3.88* |   *SAME* |    *213kb* |     *343kb* | 
| *USS*                |    *58,046kb* | *59,174kb* | *1,128kb* |  *1.94* |  *WORSE* | *57,416kb* |  *60,848kb* | 
| *peakRSS*            |         *0kb* |    *NaNkb* |   *NaNkb* |   *NaN* |   *SAME* |    *NaNkb* |     *NaNkb* | 