### PR TITLE
use the default SSL version (SSLv23) in Python test servers

### DIFF
--- a/tests/httpsServer.py
+++ b/tests/httpsServer.py
@@ -7,6 +7,5 @@ httpd = BaseHTTPServer.HTTPServer(('localhost', 4443), SimpleHTTPServer.SimpleHT
 httpd.socket = ssl.wrap_socket(httpd.socket,
                                server_side=True,
                                certfile='cert.pem',
-                               keyfile='cert.pem',
-                               ssl_version=ssl.PROTOCOL_SSLv3)
+                               keyfile='cert.pem')
 httpd.serve_forever()

--- a/tests/sslEchoServer.py
+++ b/tests/sslEchoServer.py
@@ -14,8 +14,7 @@ while True:
         connstream = ssl.wrap_socket(newsocket,
                                      server_side=True,
                                      certfile="cert.pem",
-                                     keyfile="cert.pem",
-                                     ssl_version=ssl.PROTOCOL_SSLv3)
+                                     keyfile="cert.pem")
     except ssl.SSLError as e:
         # Catch occurrences of:
         #   ssl.SSLEOFError: EOF occurred in violation of protocol (_ssl.c:581)


### PR DESCRIPTION
I don't recall why we specified SSLv3 in sslEchoServer.py and httpsServer.py, but tests all pass with the default SSL version (SSLv23), on Python <= 2.7.9 anyway, so it seems unnecessary to specify a different version. Here's what the [ssl.wrap_socket docs](https://docs.python.org/2/library/ssl.html#ssl.wrap_socket) have to say about it:

> The parameter ssl_version specifies which version of the SSL protocol to use. Typically, the server chooses a particular protocol version, and the client must adapt to the server’s choice. Most of the versions are not interoperable with the other versions. If not specified, the default is PROTOCOL_SSLv23; it provides the most compatibility with other versions.

Where "most compatibility" is with all SSL versions on the client, according to the chart in those docs.

(This doesn't fix #1662, which happens anyway on Python 2.7.10.)
