### PR TITLE
explicitly specify RC4 cipher for Python 2.7.10+ (fixes #1662)

### DIFF
--- a/tests/httpsServer.py
+++ b/tests/httpsServer.py
@@ -8,5 +8,6 @@ httpd.socket = ssl.wrap_socket(httpd.socket,
                                server_side=True,
                                certfile='cert.pem',
                                keyfile='cert.pem',
+                               ciphers='RC4',
                                ssl_version=ssl.PROTOCOL_SSLv3)
 httpd.serve_forever()

--- a/tests/httpsServer.py
+++ b/tests/httpsServer.py
@@ -3,10 +3,20 @@
 import BaseHTTPServer, SimpleHTTPServer
 import ssl
 
+# This is a copy of _RESTRICTED_SERVER_CIPHERS from the current tip of ssl.py
+# <https://hg.python.org/cpython/file/af793c7580f1/Lib/ssl.py#l174> except that
+# RC4 has been added back in, since it was removed in Python 2.7.10,
+# but SSLStreamConnection only supports RC4 ciphers.
+CIPHERS = (
+  'ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:ECDH+HIGH:'
+  'DH+HIGH:ECDH+3DES:DH+3DES:RSA+AESGCM:RSA+AES:RSA+HIGH:RSA+3DES:!aNULL:'
+  '!eNULL:!MD5:!DSS:RC4'
+)
+
 httpd = BaseHTTPServer.HTTPServer(('localhost', 4443), SimpleHTTPServer.SimpleHTTPRequestHandler)
 httpd.socket = ssl.wrap_socket(httpd.socket,
                                server_side=True,
                                certfile='cert.pem',
                                keyfile='cert.pem',
-                               ciphers='RC4')
+                               ciphers=CIPHERS)
 httpd.serve_forever()

--- a/tests/sslEchoServer.py
+++ b/tests/sslEchoServer.py
@@ -2,6 +2,16 @@
 
 import socket, ssl
 
+# This is a copy of _RESTRICTED_SERVER_CIPHERS from the current tip of ssl.py
+# <https://hg.python.org/cpython/file/af793c7580f1/Lib/ssl.py#l174> except that
+# RC4 has been added back in, since it was removed in Python 2.7.10,
+# but SSLStreamConnection only supports RC4 ciphers.
+CIPHERS = (
+  'ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:ECDH+HIGH:'
+  'DH+HIGH:ECDH+3DES:DH+3DES:RSA+AESGCM:RSA+AES:RSA+HIGH:RSA+3DES:!aNULL:'
+  '!eNULL:!MD5:!DSS:RC4'
+)
+
 s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
 s.bind(('localhost', 54443))
@@ -15,7 +25,7 @@ while True:
                                      server_side=True,
                                      certfile="cert.pem",
                                      keyfile="cert.pem",
-                                     ciphers="RC4")
+                                     ciphers=CIPHERS)
     except ssl.SSLError as e:
         # Catch occurrences of:
         #   ssl.SSLEOFError: EOF occurred in violation of protocol (_ssl.c:581)

--- a/tests/sslEchoServer.py
+++ b/tests/sslEchoServer.py
@@ -15,6 +15,7 @@ while True:
                                      server_side=True,
                                      certfile="cert.pem",
                                      keyfile="cert.pem",
+                                     ciphers="RC4",
                                      ssl_version=ssl.PROTOCOL_SSLv3)
     except ssl.SSLError as e:
         # Catch occurrences of:


### PR DESCRIPTION
Python 2.7.10 removed *RC4* from the list of SSL ciphers, but *SSLStreamConnection* only supports *SSL_RSA_WITH_RC4_128_MD5* and *SSL_RSA_EXPORT_WITH_RC4_40_MD5*, so we have to specify it explicitly in order for that class to connect to the test servers.

This does "fix #1662" ;-), but it breaks loading pages from the test servers in Firefox, which reports "An error occurred during a connection to localhost:4443. Cannot communicate securely with peer: no common encryption algorithm(s). (Error code: ssl_error_no_cypher_overlap)." So I'll probably have to expand this list, perhaps copying the default from Python (since I doesn't look like I can modify individual ciphers within it).
