### PR TITLE
shift isolate ID by minimum bits necessary to ensure native player ID uniqueness

### DIFF
--- a/midp/media.js
+++ b/midp/media.js
@@ -1016,7 +1016,7 @@ AudioRecorder.prototype.close = function() {
 
 Native["com/sun/mmedia/PlayerImpl.nInit.(IILjava/lang/String;)I"] = function(appId, pId, jURI) {
     var url = J2ME.fromJavaString(jURI);
-    var id = pId + (appId << 32);
+    var id = pId + (appId << 15);
     Media.PlayerCache[id] = new PlayerContainer(url, pId);
     return id;
 };


### PR DESCRIPTION
Per https://github.com/mozilla/pluotsorbet/blob/4c1ef19c3f4ddfe6092516bc3dc77bb630a97785/java/midp/com/sun/mmedia/PlayerImpl.java#L118, Java player IDs can range from 0 to 32767, so it isn't necessary to shift the isolate ID more than 15 bits in PlayerImpl.nInit to ensure native player IDs are unique.

(Nor is it useful to shift by 32 bits, since http://es5.github.io/#x11.7.1 says, "Let shiftCount be the result of masking out all but the least significant 5 bits of rnum, that is, compute rnum & 0x1F," and `32 & 0x1F` is `0`, so `n << 32 === n << 0`.)
