### PR TITLE
pass addr to native methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ If you need implement a native method with async JS calls, the following steps a
 
 e.g:
 
-    Native["java/lang/Thread.sleep.(J)V"] = function(delayL, delayH) {
+    Native["java/lang/Thread.sleep.(J)V"] = function(addr, delayL, delayH) {
         asyncImpl("V", new Promise(function(resolve, reject) {
             window.setTimeout(resolve, J2ME.longToNumber(delayL, delayH));
         }));
@@ -300,7 +300,7 @@ The `asyncImpl` call is optional if part of the code doesn't make async calls. T
 
 e.g:
 
-    Native["java/lang/Thread.newSleep.(J)Z"] = function(delayL, delayH) {
+    Native["java/lang/Thread.newSleep.(J)Z"] = function(addr, delayL, delayH) {
         var delay = J2ME.longToNumber(delayL, delayH);
         if (delay < 0) {
           // Return false synchronously. Note: we use 1 and 0 in JavaScript to

--- a/benchmark.js
+++ b/benchmark.js
@@ -465,7 +465,7 @@ var Benchmark = (function() {
         var vmImplKey = "com/sun/midp/main/MIDletSuiteUtils.vmEndStartUp.(I)V";
         var vmOriginalFn = Native[vmImplKey];
         var vmCalled = false;
-        Native[vmImplKey] = function() {
+        Native[vmImplKey] = function(addr) {
           if (!vmCalled) {
             vmCalled = true;
             var now = performance.now();
@@ -477,7 +477,7 @@ var Benchmark = (function() {
 
         var bgImplKey = "com/nokia/mid/s40/bg/BGUtils.getFGMIDletClass.()Ljava/lang/String;";
         var bgOriginalFn = Native[bgImplKey];
-        Native[bgImplKey] = function() {
+        Native[bgImplKey] = function(addr) {
           var now = performance.now();
           startup.stopTimer("bgStartupTime", now);
           startup.startTimer("fgStartupTime", now);
@@ -504,7 +504,7 @@ var Benchmark = (function() {
         // First refresh0 call: the first FG MIDlet startup
         // Second refresh0 call: the BG MIDlet temporarily goes to the foreground
         // Third refresh0 call: the FG MIDlet is restarted
-        Native[fgImplKey] = function() {
+        Native[fgImplKey] = function(addr) {
           if (storage.warmBench) {
             if (!restartCalled) {
               restartCalled = true;
@@ -528,7 +528,7 @@ var Benchmark = (function() {
         var refreshImplKey = "com/sun/midp/lcdui/DisplayDevice.refresh0.(IIIIII)V";
         var refreshOriginalFn = Native[refreshImplKey];
         var refreshCalled = false;
-        Native[refreshImplKey] = function() {
+        Native[refreshImplKey] = function(addr) {
           if (!refreshCalled) {
             refreshCalled = true;
             var now = performance.now();

--- a/int.ts
+++ b/int.ts
@@ -1768,7 +1768,7 @@ module J2ME {
 
                 thread.set(fp, sp, opPC);
 
-                returnValue = callee.call(object, object ? object._address : 0);
+                returnValue = callee.call(object, object ? object._address : Constants.NULL);
               } else {
                 args.length = 0;
 
@@ -1822,7 +1822,7 @@ module J2ME {
                   // assert(callee.length === args.length, "Function " + callee + " (" + calleeTargetMethodInfo.implKey + "), should have " + args.length + " arguments.");
                 }
 
-                args.unshift(object ? object._address : 0);
+                args.unshift(object ? object._address : Constants.NULL);
                 returnValue = callee.apply(object, args);
               }
 

--- a/int.ts
+++ b/int.ts
@@ -1756,7 +1756,7 @@ module J2ME {
 
                 thread.set(fp, sp, opPC);
 
-                returnValue = callee.call(object);
+                returnValue = callee.call(object, object ? object._address : 0);
               } else {
                 args.length = 0;
 
@@ -1806,6 +1806,7 @@ module J2ME {
                   // assert(callee.length === args.length, "Function " + callee + " (" + calleeTargetMethodInfo.implKey + "), should have " + args.length + " arguments.");
                 }
 
+                args.unshift(object ? object._address : 0);
                 returnValue = callee.apply(object, args);
               }
 

--- a/midp/background.js
+++ b/midp/background.js
@@ -57,17 +57,17 @@ function backgroundCheck() {
   DumbPipe.close(DumbPipe.open("backgroundCheck", {}));
 }
 
-Native["com/nokia/mid/s40/bg/BGUtils.getFGMIDletClass.()Ljava/lang/String;"] = function() {
+Native["com/nokia/mid/s40/bg/BGUtils.getFGMIDletClass.()Ljava/lang/String;"] = function(addr) {
   return J2ME.newString(fgMidletClass);
 };
 
-Native["com/nokia/mid/s40/bg/BGUtils.getFGMIDletNumber.()I"] = function() {
+Native["com/nokia/mid/s40/bg/BGUtils.getFGMIDletNumber.()I"] = function(addr) {
   return fgMidletNumber;
 };
 
 MIDP.additionalProperties = {};
 
-Native["com/nokia/mid/s40/bg/BGUtils.launchIEMIDlet.(Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;)Z"] = function(midletSuiteVendor, midletName, midletNumber, startupNoteText, args) {
+Native["com/nokia/mid/s40/bg/BGUtils.launchIEMIDlet.(Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;)Z"] = function(addr, midletSuiteVendor, midletName, midletNumber, startupNoteText, args) {
   J2ME.fromJavaString(args).split(";").splice(1).forEach(function(arg) {
     var elems = arg.split("=");
     MIDP.additionalProperties[elems[0]] = elems[1];

--- a/midp/codec.js
+++ b/midp/codec.js
@@ -135,37 +135,37 @@ DataDecoder.prototype.getType = function() {
   return this.data[0].type || -1;
 }
 
-Native["com/nokia/mid/s40/codec/DataEncoder.init.()V"] = function() {
+Native["com/nokia/mid/s40/codec/DataEncoder.init.()V"] = function(addr) {
   setNative(this, new DataEncoder());
 };
 
-Native["com/nokia/mid/s40/codec/DataEncoder.putStart.(ILjava/lang/String;)V"] = function(tag, name) {
+Native["com/nokia/mid/s40/codec/DataEncoder.putStart.(ILjava/lang/String;)V"] = function(addr, tag, name) {
   getNative(this).putStart(tag, J2ME.fromJavaString(name));
 };
 
-Native["com/nokia/mid/s40/codec/DataEncoder.put.(ILjava/lang/String;Ljava/lang/String;)V"] = function(tag, name, value) {
+Native["com/nokia/mid/s40/codec/DataEncoder.put.(ILjava/lang/String;Ljava/lang/String;)V"] = function(addr, tag, name, value) {
   getNative(this).put(tag, J2ME.fromJavaString(name), J2ME.fromJavaString(value));
 };
 
-Native["com/nokia/mid/s40/codec/DataEncoder.put.(ILjava/lang/String;J)V"] = function(tag, name, valueLow, valueHigh) {
+Native["com/nokia/mid/s40/codec/DataEncoder.put.(ILjava/lang/String;J)V"] = function(addr, tag, name, valueLow, valueHigh) {
   getNative(this).put(tag, J2ME.fromJavaString(name), J2ME.longToNumber(valueLow, valueHigh));
 };
 
-Native["com/nokia/mid/s40/codec/DataEncoder.put.(ILjava/lang/String;Z)V"] = function(tag, name, value) {
+Native["com/nokia/mid/s40/codec/DataEncoder.put.(ILjava/lang/String;Z)V"] = function(addr, tag, name, value) {
   getNative(this).put(tag, J2ME.fromJavaString(name), value);
 };
 
-Native["com/nokia/mid/s40/codec/DataEncoder.put.(Ljava/lang/String;[BI)V"] = function(name, data, length) {
+Native["com/nokia/mid/s40/codec/DataEncoder.put.(Ljava/lang/String;[BI)V"] = function(addr, name, data, length) {
   var array = Array.prototype.slice.call(data.subarray(0, length));
   array.constructor = Array;
   getNative(this).putNoTag(J2ME.fromJavaString(name), array);
 };
 
-Native["com/nokia/mid/s40/codec/DataEncoder.putEnd.(ILjava/lang/String;)V"] = function(tag, name) {
+Native["com/nokia/mid/s40/codec/DataEncoder.putEnd.(ILjava/lang/String;)V"] = function(addr, tag, name) {
   getNative(this).putEnd(tag, J2ME.fromJavaString(name));
 };
 
-Native["com/nokia/mid/s40/codec/DataEncoder.getData.()[B"] = function() {
+Native["com/nokia/mid/s40/codec/DataEncoder.getData.()[B"] = function(addr) {
   var data = getNative(this).getData();
 
   var array = J2ME.newByteArray(data.length);
@@ -176,23 +176,23 @@ Native["com/nokia/mid/s40/codec/DataEncoder.getData.()[B"] = function() {
   return array;
 };
 
-Native["com/nokia/mid/s40/codec/DataDecoder.init.([BII)V"] = function(data, offset, length) {
+Native["com/nokia/mid/s40/codec/DataDecoder.init.([BII)V"] = function(addr, data, offset, length) {
   setNative(this, new DataDecoder(data, offset, length));
 };
 
-Native["com/nokia/mid/s40/codec/DataDecoder.getStart.(I)V"] = function(tag) {
+Native["com/nokia/mid/s40/codec/DataDecoder.getStart.(I)V"] = function(addr, tag) {
   if (!getNative(this).getStart(tag)) {
     throw $.newIOException("no start found " + tag);
   }
 };
 
-Native["com/nokia/mid/s40/codec/DataDecoder.getEnd.(I)V"] = function(tag) {
+Native["com/nokia/mid/s40/codec/DataDecoder.getEnd.(I)V"] = function(addr, tag) {
   if (!getNative(this).getEnd(tag)) {
     throw $.newIOException("no end found " + tag);
   }
 };
 
-Native["com/nokia/mid/s40/codec/DataDecoder.getString.(I)Ljava/lang/String;"] = function(tag) {
+Native["com/nokia/mid/s40/codec/DataDecoder.getString.(I)Ljava/lang/String;"] = function(addr, tag) {
   var str = getNative(this).getValue(tag);
   if (str === undefined) {
     throw $.newIOException("tag (" + tag + ") invalid");
@@ -200,7 +200,7 @@ Native["com/nokia/mid/s40/codec/DataDecoder.getString.(I)Ljava/lang/String;"] = 
   return J2ME.newString(str);
 };
 
-Native["com/nokia/mid/s40/codec/DataDecoder.getInteger.(I)J"] = function(tag) {
+Native["com/nokia/mid/s40/codec/DataDecoder.getInteger.(I)J"] = function(addr, tag) {
   var num = getNative(this).getValue(tag);
   if (num === undefined) {
     throw $.newIOException("tag (" + tag + ") invalid");
@@ -208,7 +208,7 @@ Native["com/nokia/mid/s40/codec/DataDecoder.getInteger.(I)J"] = function(tag) {
   return J2ME.returnLongValue(num);
 };
 
-Native["com/nokia/mid/s40/codec/DataDecoder.getBoolean.()Z"] = function() {
+Native["com/nokia/mid/s40/codec/DataDecoder.getBoolean.()Z"] = function(addr) {
   var val = getNative(this).getNextValue();
   if (val === undefined) {
     throw $.newIOException();
@@ -216,7 +216,7 @@ Native["com/nokia/mid/s40/codec/DataDecoder.getBoolean.()Z"] = function() {
   return val === 1 ? 1 : 0;
 };
 
-Native["com/nokia/mid/s40/codec/DataDecoder.getName.()Ljava/lang/String;"] = function() {
+Native["com/nokia/mid/s40/codec/DataDecoder.getName.()Ljava/lang/String;"] = function(addr) {
   var name = getNative(this).getName();
   if (name === undefined) {
     throw $.newIOException();
@@ -224,7 +224,7 @@ Native["com/nokia/mid/s40/codec/DataDecoder.getName.()Ljava/lang/String;"] = fun
   return J2ME.newString(name);
 };
 
-Native["com/nokia/mid/s40/codec/DataDecoder.getType.()I"] = function() {
+Native["com/nokia/mid/s40/codec/DataDecoder.getType.()I"] = function(addr) {
   var tag = getNative(this).getTag();
   if (tag === undefined) {
     throw $.newIOException();
@@ -232,6 +232,6 @@ Native["com/nokia/mid/s40/codec/DataDecoder.getType.()I"] = function() {
   return tag;
 };
 
-Native["com/nokia/mid/s40/codec/DataDecoder.listHasMoreItems.()Z"] = function() {
+Native["com/nokia/mid/s40/codec/DataDecoder.listHasMoreItems.()Z"] = function(addr) {
   return getNative(this).getType() != DataEncoder.END ? 1 : 0;
 };

--- a/midp/content.js
+++ b/midp/content.js
@@ -19,7 +19,7 @@ var Content = (function() {
 
   addUnimplementedNative("com/sun/j2me/content/RegistryStore.init.()Z", 1);
 
-  Native["com/sun/j2me/content/RegistryStore.forSuite0.(I)Ljava/lang/String;"] = function(suiteID) {
+  Native["com/sun/j2me/content/RegistryStore.forSuite0.(I)Ljava/lang/String;"] = function(addr, suiteID) {
     if (!chRegisteredClassName) {
       return null;
     }
@@ -36,7 +36,7 @@ var Content = (function() {
 
   addUnimplementedNative("com/sun/j2me/content/RegistryStore.findHandler0.(Ljava/lang/String;ILjava/lang/String;)Ljava/lang/String;", null);
 
-  Native["com/sun/j2me/content/RegistryStore.register0.(ILjava/lang/String;Lcom/sun/j2me/content/ContentHandlerRegData;)Z"] = function(storageId, className, handlerData) {
+  Native["com/sun/j2me/content/RegistryStore.register0.(ILjava/lang/String;Lcom/sun/j2me/content/ContentHandlerRegData;)Z"] = function(addr, storageId, className, handlerData) {
     var registerID = J2ME.fromJavaString(getHandle(handlerData.ID));
     if (chRegisteredID && chRegisteredID != registerID) {
       console.warn("Dynamic registration ID doesn't match the configuration");
@@ -69,7 +69,7 @@ var Content = (function() {
   // registered and unregisters it.
   addUnimplementedNative("com/sun/j2me/content/RegistryStore.unregister0.(Ljava/lang/String;)Z", 1);
 
-  Native["com/sun/j2me/content/RegistryStore.getHandler0.(Ljava/lang/String;Ljava/lang/String;I)Ljava/lang/String;"] = function(callerId, id, mode) {
+  Native["com/sun/j2me/content/RegistryStore.getHandler0.(Ljava/lang/String;Ljava/lang/String;I)Ljava/lang/String;"] = function(addr, callerId, id, mode) {
     if (!chRegisteredClassName) {
       return null;
     }
@@ -90,7 +90,7 @@ var Content = (function() {
                                           ]));
   };
 
-  Native["com/sun/j2me/content/AppProxy.isInSvmMode.()Z"] = function() {
+  Native["com/sun/j2me/content/AppProxy.isInSvmMode.()Z"] = function(addr) {
     // We are in MVM mode (multiple MIDlets running concurrently)
     return 0;
   };
@@ -127,7 +127,7 @@ var Content = (function() {
     }
   });
 
-  Native["com/sun/j2me/content/InvocationStore.get0.(Lcom/sun/j2me/content/InvocationImpl;ILjava/lang/String;IZ)I"] = function(invoc, suiteId, className, mode, shouldBlock) {
+  Native["com/sun/j2me/content/InvocationStore.get0.(Lcom/sun/j2me/content/InvocationImpl;ILjava/lang/String;IZ)I"] = function(addr, invoc, suiteId, className, mode, shouldBlock) {
     getInvocationCalled = true;
 
     if (!invocation) {

--- a/midp/crypto.js
+++ b/midp/crypto.js
@@ -3,7 +3,7 @@
 
 'use strict';
 
-Native["com/sun/midp/crypto/PRand.getRandomBytes.([BI)Z"] = function(b, nbytes) {
+Native["com/sun/midp/crypto/PRand.getRandomBytes.([BI)Z"] = function(addr, b, nbytes) {
     window.crypto.getRandomValues(b.subarray(0, nbytes));
     return 1;
 };
@@ -38,11 +38,11 @@ MIDP.bin2String = function(array) {
   return bin2StringResult.join("");
 };
 
-Native["com/sun/midp/crypto/MD5.nativeUpdate.([BII[I[I[I[I)V"] = function(inBuf, inOff, inLen, state, num, count, data) {
+Native["com/sun/midp/crypto/MD5.nativeUpdate.([BII[I[I[I[I)V"] = function(addr, inBuf, inOff, inLen, state, num, count, data) {
     MIDP.getMD5Hasher(data).update(MIDP.bin2String(new Int8Array(inBuf.subarray(inOff, inOff + inLen))));
 };
 
-Native["com/sun/midp/crypto/MD5.nativeFinal.([BII[BI[I[I[I[I)V"] = function(inBuf, inOff, inLen, outBuf, outOff, state, num, count, data) {
+Native["com/sun/midp/crypto/MD5.nativeFinal.([BII[BI[I[I[I[I)V"] = function(addr, inBuf, inOff, inLen, outBuf, outOff, state, num, count, data) {
     var hasher = MIDP.getMD5Hasher(data);
 
     if (inBuf) {
@@ -64,7 +64,7 @@ Native["com/sun/midp/crypto/MD5.nativeFinal.([BII[BI[I[I[I[I)V"] = function(inBu
     MIDP.hashers.delete(data);
 };
 
-Native["com/sun/midp/crypto/MD5.nativeClone.([I)V"] = function(data) {
+Native["com/sun/midp/crypto/MD5.nativeClone.([I)V"] = function(addr, data) {
     for (var key of MIDP.hashers.keys()) {
         if (util.compareTypedArrays(key, data)) {
             var value = MIDP.hashers.get(key);
@@ -107,7 +107,7 @@ function hexStringToBytes(hex) {
     return bytes;
 }
 
-Native["com/sun/midp/crypto/RSA.modExp.([B[B[B[B)I"] = function(data, exponent, modulus, result) {
+Native["com/sun/midp/crypto/RSA.modExp.([B[B[B[B)I"] = function(addr, data, exponent, modulus, result) {
     // The jsbn library doesn't work well with typed arrays, so we're using this
     // hack of translating the numbers to hexadecimal strings before handing
     // them to jsbn (and we're getting the result back in a hex string).
@@ -122,7 +122,7 @@ Native["com/sun/midp/crypto/RSA.modExp.([B[B[B[B)I"] = function(data, exponent, 
     return remainder.length;
 };
 
-Native["com/sun/midp/crypto/ARC4.nativetx.([B[I[I[BII[BI)V"] = function(S, X, Y, inbuf, inoff, inlen, outbuf, outoff) {
+Native["com/sun/midp/crypto/ARC4.nativetx.([B[I[I[BII[BI)V"] = function(addr, S, X, Y, inbuf, inoff, inlen, outbuf, outoff) {
     var x = X[0];
     var y = Y[0];
 

--- a/midp/device_control.js
+++ b/midp/device_control.js
@@ -3,7 +3,7 @@
 
 'use strict';
 
-Native["com/nokia/mid/ui/DeviceControl.startVibra.(IJ)V"] = function(freq, longDurationLow, longDurationHigh) {
+Native["com/nokia/mid/ui/DeviceControl.startVibra.(IJ)V"] = function(addr, freq, longDurationLow, longDurationHigh) {
   // If method is called during a previously called vibration that has been
   // activated from this method, the previous vibration is stopped and the new
   // one is activated using the new set of parameters.
@@ -23,6 +23,6 @@ Native["com/nokia/mid/ui/DeviceControl.startVibra.(IJ)V"] = function(freq, longD
   navigator.vibrate(duration);
 };
 
-Native["com/nokia/mid/ui/DeviceControl.stopVibra.()V"] = function() {
+Native["com/nokia/mid/ui/DeviceControl.stopVibra.()V"] = function(addr) {
   navigator.vibrate(0);
 };

--- a/midp/frameanimator.js
+++ b/midp/frameanimator.js
@@ -33,11 +33,11 @@ FrameAnimator.prototype.isRegistered = function() {
   return this._isRegistered;
 };
 
-Native["com/nokia/mid/ui/frameanimator/FrameAnimator.init.()V"] = function() {
+Native["com/nokia/mid/ui/frameanimator/FrameAnimator.init.()V"] = function(addr) {
   setNative(this, new FrameAnimator());
 };
 
-Native["com/nokia/mid/ui/frameanimator/FrameAnimator.register.(IISSLcom/nokia/mid/ui/frameanimator/FrameAnimatorListener;)Z"] = function(x, y, maxFps, maxPps, listener) {
+Native["com/nokia/mid/ui/frameanimator/FrameAnimator.register.(IISSLcom/nokia/mid/ui/frameanimator/FrameAnimatorListener;)Z"] = function(addr, x, y, maxFps, maxPps, listener) {
   var nativeObject = getNative(this);
   if (nativeObject.isRegistered()) {
     throw $.newIllegalStateException("FrameAnimator already registered");
@@ -57,7 +57,7 @@ Native["com/nokia/mid/ui/frameanimator/FrameAnimator.register.(IISSLcom/nokia/mi
   return 1;
 };
 
-Native["com/nokia/mid/ui/frameanimator/FrameAnimator.unregister.()V"] = function() {
+Native["com/nokia/mid/ui/frameanimator/FrameAnimator.unregister.()V"] = function(addr) {
   var nativeObject = getNative(this);
   if (!nativeObject.isRegistered()) {
     throw $.newIllegalStateException("FrameAnimator not registered");
@@ -71,10 +71,10 @@ addUnimplementedNative("com/nokia/mid/ui/frameanimator/FrameAnimator.kineticScro
 addUnimplementedNative("com/nokia/mid/ui/frameanimator/FrameAnimator.limitedKineticScroll.(IIIFII)V");
 addUnimplementedNative("com/nokia/mid/ui/frameanimator/FrameAnimator.stop.()V");
 
-Native["com/nokia/mid/ui/frameanimator/FrameAnimator.isRegistered.()Z"] = function() {
+Native["com/nokia/mid/ui/frameanimator/FrameAnimator.isRegistered.()Z"] = function(addr) {
   return getNative(this).isRegistered() ? 1 : 0;
 };
 
-Native["com/nokia/mid/ui/frameanimator/FrameAnimator.getNumRegisteredFrameAnimators.()I"] = function() {
+Native["com/nokia/mid/ui/frameanimator/FrameAnimator.getNumRegisteredFrameAnimators.()I"] = function(addr) {
   return FrameAnimator.numRegistered;
 };

--- a/midp/fs.js
+++ b/midp/fs.js
@@ -22,38 +22,38 @@ MIDP.fsRootNames = [
     "Private",
 ];
 
-Native["com/sun/midp/io/j2me/storage/File.initConfigRoot.(I)Ljava/lang/String;"] = function(storageId) {
+Native["com/sun/midp/io/j2me/storage/File.initConfigRoot.(I)Ljava/lang/String;"] = function(addr, storageId) {
     return J2ME.newString("assets/" + storageId + "/");
 };
 
-Native["com/sun/midp/io/j2me/storage/File.initStorageRoot.(I)Ljava/lang/String;"] = function(storageId) {
+Native["com/sun/midp/io/j2me/storage/File.initStorageRoot.(I)Ljava/lang/String;"] = function(addr, storageId) {
     return J2ME.newString("assets/" + storageId + "/");
 };
 
-Native["com/sun/midp/midletsuite/MIDletSuiteStorage.getSecureFilenameBase.(I)Ljava/lang/String;"] = function(id) {
+Native["com/sun/midp/midletsuite/MIDletSuiteStorage.getSecureFilenameBase.(I)Ljava/lang/String;"] = function(addr, id) {
     return J2ME.newString("");
 };
 
 Native["com/sun/midp/rms/RecordStoreUtil.exists.(Ljava/lang/String;Ljava/lang/String;I)Z"] =
-function(filenameBase, name, ext) {
+function(addr, filenameBase, name, ext) {
     var path = RECORD_STORE_BASE + "/" + J2ME.fromJavaString(filenameBase) + "/" + J2ME.fromJavaString(name) + "." + ext;
     return fs.exists(path) ? 1 : 0;
 };
 
 Native["com/sun/midp/rms/RecordStoreUtil.deleteFile.(Ljava/lang/String;Ljava/lang/String;I)V"] =
-function(filenameBase, name, ext) {
+function(addr, filenameBase, name, ext) {
     var path = RECORD_STORE_BASE + "/" + J2ME.fromJavaString(filenameBase) + "/" + J2ME.fromJavaString(name) + "." + ext;
     fs.remove(path);
 };
 
 Native["com/sun/midp/rms/RecordStoreFile.getNumberOfStores.(Ljava/lang/String;)I"] =
-function(filenameBase) {
+function(addr, filenameBase) {
     var path = RECORD_STORE_BASE + "/" + J2ME.fromJavaString(filenameBase);
     return fs.list(path).length;
 };
 
 Native["com/sun/midp/rms/RecordStoreFile.getRecordStoreList.(Ljava/lang/String;[Ljava/lang/String;)V"] =
-function (filenameBase, names) {
+function(addr, filenameBase, names) {
     var path = RECORD_STORE_BASE + "/" + J2ME.fromJavaString(filenameBase);
     var files = fs.list(path);
     for (var i = 0; i < files.length; i++) {
@@ -61,7 +61,7 @@ function (filenameBase, names) {
     }
 };
 
-Native["com/sun/midp/rms/RecordStoreFile.spaceAvailableNewRecordStore0.(Ljava/lang/String;I)I"] = function(filenameBase, storageId) {
+Native["com/sun/midp/rms/RecordStoreFile.spaceAvailableNewRecordStore0.(Ljava/lang/String;I)I"] = function(addr, filenameBase, storageId) {
     // Pretend there is 50MiB available.  Our implementation is backed
     // by IndexedDB, which has no actual limit beyond space available on device,
     // which I don't think we can determine.  But this should be sufficient
@@ -69,7 +69,7 @@ Native["com/sun/midp/rms/RecordStoreFile.spaceAvailableNewRecordStore0.(Ljava/la
     return 50 * 1024 * 1024;
 };
 
-Native["com/sun/midp/rms/RecordStoreFile.spaceAvailableRecordStore.(ILjava/lang/String;I)I"] = function(handle, filenameBase, storageId) {
+Native["com/sun/midp/rms/RecordStoreFile.spaceAvailableRecordStore.(ILjava/lang/String;I)I"] = function(addr, handle, filenameBase, storageId) {
     // Pretend there is 50MiB available.  Our implementation is backed
     // by IndexedDB, which has no actual limit beyond space available on device,
     // which I don't think we can determine.  But this should be sufficient
@@ -78,7 +78,7 @@ Native["com/sun/midp/rms/RecordStoreFile.spaceAvailableRecordStore.(ILjava/lang/
 };
 
 Native["com/sun/midp/rms/RecordStoreFile.openRecordStoreFile.(Ljava/lang/String;Ljava/lang/String;I)I"] =
-function(filenameBase, name, ext) {
+function(addr, filenameBase, name, ext) {
     var ctx = $.ctx;
 
     var path = RECORD_STORE_BASE + "/" + J2ME.fromJavaString(filenameBase) + "/" + J2ME.fromJavaString(name) + "." + ext;
@@ -113,11 +113,11 @@ function(filenameBase, name, ext) {
     }
 };
 
-Native["com/sun/midp/rms/RecordStoreFile.setPosition.(II)V"] = function(handle, pos) {
+Native["com/sun/midp/rms/RecordStoreFile.setPosition.(II)V"] = function(addr, handle, pos) {
     fs.setpos(handle, pos);
 };
 
-Native["com/sun/midp/rms/RecordStoreFile.readBytes.(I[BII)I"] = function(handle, buf, offset, numBytes) {
+Native["com/sun/midp/rms/RecordStoreFile.readBytes.(I[BII)I"] = function(addr, handle, buf, offset, numBytes) {
     var from = fs.getpos(handle);
     var to = from + numBytes;
     var readBytes = fs.read(handle, from, to);
@@ -133,19 +133,19 @@ Native["com/sun/midp/rms/RecordStoreFile.readBytes.(I[BII)I"] = function(handle,
     return readBytes.byteLength;
 };
 
-Native["com/sun/midp/rms/RecordStoreFile.writeBytes.(I[BII)V"] = function(handle, buf, offset, numBytes) {
+Native["com/sun/midp/rms/RecordStoreFile.writeBytes.(I[BII)V"] = function(addr, handle, buf, offset, numBytes) {
     fs.write(handle, buf, offset, numBytes);
 };
 
-Native["com/sun/midp/rms/RecordStoreFile.commitWrite.(I)V"] = function(handle) {
+Native["com/sun/midp/rms/RecordStoreFile.commitWrite.(I)V"] = function(addr, handle) {
     fs.flush(handle);
 };
 
-Native["com/sun/midp/rms/RecordStoreFile.closeFile.(I)V"] = function(handle) {
+Native["com/sun/midp/rms/RecordStoreFile.closeFile.(I)V"] = function(addr, handle) {
     fs.close(handle);
 };
 
-Native["com/sun/midp/rms/RecordStoreFile.truncateFile.(II)V"] = function(handle, size) {
+Native["com/sun/midp/rms/RecordStoreFile.truncateFile.(II)V"] = function(addr, handle, size) {
     fs.flush(handle);
     fs.ftruncate(handle, size);
 };
@@ -153,7 +153,7 @@ Native["com/sun/midp/rms/RecordStoreFile.truncateFile.(II)V"] = function(handle,
 MIDP.RecordStoreCache = [];
 
 Native["com/sun/midp/rms/RecordStoreSharedDBHeader.getLookupId0.(ILjava/lang/String;I)I"] =
-function(suiteId, jStoreName, headerDataSize) {
+function(addr, suiteId, jStoreName, headerDataSize) {
     var storeName = J2ME.fromJavaString(jStoreName);
 
     var sharedHeader =
@@ -176,7 +176,7 @@ function(suiteId, jStoreName, headerDataSize) {
     return sharedHeader.lookupId;
 };
 
-Native["com/sun/midp/rms/RecordStoreSharedDBHeader.shareCachedData0.(I[BI)I"] = function(lookupId, headerData, headerDataSize) {
+Native["com/sun/midp/rms/RecordStoreSharedDBHeader.shareCachedData0.(I[BI)I"] = function(addr, lookupId, headerData, headerDataSize) {
     var sharedHeader = MIDP.RecordStoreCache[lookupId];
     if (!sharedHeader) {
         throw $.newIllegalStateException("invalid header lookup ID");
@@ -197,7 +197,7 @@ Native["com/sun/midp/rms/RecordStoreSharedDBHeader.shareCachedData0.(I[BI)I"] = 
 };
 
 Native["com/sun/midp/rms/RecordStoreSharedDBHeader.updateCachedData0.(I[BII)I"] =
-function(lookupId, headerData, headerDataSize, headerVersion) {
+function(addr, lookupId, headerData, headerDataSize, headerVersion) {
     var sharedHeader = MIDP.RecordStoreCache[lookupId];
     if (!sharedHeader) {
         throw $.newIllegalStateException("invalid header lookup ID");
@@ -222,7 +222,7 @@ function(lookupId, headerData, headerDataSize, headerVersion) {
     return headerVersion;
 };
 
-Native["com/sun/midp/rms/RecordStoreSharedDBHeader.getHeaderRefCount0.(I)I"] = function(lookupId) {
+Native["com/sun/midp/rms/RecordStoreSharedDBHeader.getHeaderRefCount0.(I)I"] = function(addr, lookupId) {
     var sharedHeader = MIDP.RecordStoreCache[lookupId];
     if (!sharedHeader) {
         throw $.newIllegalStateException("invalid header lookup ID");
@@ -231,7 +231,7 @@ Native["com/sun/midp/rms/RecordStoreSharedDBHeader.getHeaderRefCount0.(I)I"] = f
     return sharedHeader.refCount;
 };
 
-Native["com/sun/midp/rms/RecordStoreSharedDBHeader.cleanup0.()V"] = function() {
+Native["com/sun/midp/rms/RecordStoreSharedDBHeader.cleanup0.()V"] = function(addr) {
     var lookupId = this.lookupId;
     if (MIDP.RecordStoreCache[lookupId] &&
         --MIDP.RecordStoreCache[lookupId].refCount <= 0) {
@@ -246,35 +246,35 @@ Native["com/sun/midp/rms/RecordStoreSharedDBHeader.finalize.()V"] =
     Native["com/sun/midp/rms/RecordStoreSharedDBHeader.cleanup0.()V"];
 
 Native["com/sun/midp/rms/RecordStoreRegistry.getRecordStoreListeners.(ILjava/lang/String;)[I"] =
-function(suiteId, storeName) {
+function(addr, suiteId, storeName) {
     console.warn("RecordStoreRegistry.getRecordStoreListeners.(IL...String;)[I not implemented (" +
                  suiteId + ", " + J2ME.fromJavaString(storeName) + ")");
     return null;
 };
 
 Native["com/sun/midp/rms/RecordStoreRegistry.sendRecordStoreChangeEvent.(ILjava/lang/String;II)V"] =
-function(suiteId, storeName, changeType, recordId) {
+function(addr, suiteId, storeName, changeType, recordId) {
     console.warn("RecordStoreRegistry.sendRecordStoreChangeEvent.(IL...String;II)V not implemented (" +
                  suiteId + ", " + J2ME.fromJavaString(storeName) + ", " + changeType + ", " + recordId + ")");
 };
 
 Native["com/sun/midp/rms/RecordStoreRegistry.startRecordStoreListening.(ILjava/lang/String;)V"] =
-function(suiteId, storeName) {
+function(addr, suiteId, storeName) {
     console.warn("RecordStoreRegistry.startRecordStoreListening.(IL...String;)V not implemented (" +
                  suiteId + ", " + J2ME.fromJavaString(storeName) + ")");
 };
 
 Native["com/sun/midp/rms/RecordStoreRegistry.stopRecordStoreListening.(ILjava/lang/String;)V"] =
-function(suiteId, storeName) {
+function(addr, suiteId, storeName) {
     console.warn("RecordStoreRegistry.stopRecordStoreListening.(IL...String;)V not implemented (" +
                  suiteId + ", " + J2ME.fromJavaString(storeName) + ")");
 };
 
-Native["com/sun/midp/rms/RecordStoreRegistry.stopAllRecordStoreListeners.(I)V"] = function(taskId) {
+Native["com/sun/midp/rms/RecordStoreRegistry.stopAllRecordStoreListeners.(I)V"] = function(addr, taskId) {
     console.warn("RecordStoreRegistry.stopAllRecordStoreListeners.(I)V not implemented (" + taskId + ")");
 };
 
-Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.create.()V"] = function() {
+Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.create.()V"] = function(addr) {
     var pathname = J2ME.fromJavaString(getHandle(this.nativePath));
     DEBUG_FS && console.log("DefaultFileHandler.create: " + pathname);
     if (config.ignoredFiles.has(pathname)) {
@@ -289,7 +289,7 @@ Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.create.()V"] = function() {
     }
 };
 
-Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.exists.()Z"] = function() {
+Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.exists.()Z"] = function(addr) {
     var pathname = J2ME.fromJavaString(getHandle(this.nativePath));
     DEBUG_FS && console.log("DefaultFileHandler.exists: " + pathname);
     if (config.ignoredFiles.has(pathname)) {
@@ -302,7 +302,7 @@ Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.exists.()Z"] = function() {
     return exists ? 1 : 0;
 };
 
-Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.isDirectory.()Z"] = function() {
+Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.isDirectory.()Z"] = function(addr) {
     var pathname = J2ME.fromJavaString(getHandle(this.nativePath));
     DEBUG_FS && console.log("DefaultFileHandler.isDirectory: " + pathname);
     if (config.ignoredFiles.has(pathname)) {
@@ -316,7 +316,7 @@ Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.isDirectory.()Z"] = function
     return isDirectory ? 1 : 0;
 }
 
-Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.delete.()V"] = function() {
+Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.delete.()V"] = function(addr) {
     var pathname = J2ME.fromJavaString(getHandle(this.nativePath));
     DEBUG_FS && console.log("DefaultFileHandler.delete: " + pathname);
     if (config.ignoredFiles.has(pathname)) {
@@ -330,7 +330,7 @@ Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.delete.()V"] = function() {
 };
 
 
-Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.rename0.(Ljava/lang/String;)V"] = function(newName) {
+Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.rename0.(Ljava/lang/String;)V"] = function(addr, newName) {
     var pathname = J2ME.fromJavaString(getHandle(this.nativePath));
     var newPathname = J2ME.fromJavaString(newName);
     DEBUG_FS && console.log("DefaultFileHandler.rename0: " + pathname + " to " + newPathname);
@@ -344,7 +344,7 @@ Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.rename0.(Ljava/lang/String;)
     }
 };
 
-Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.truncate.(J)V"] = function(byteOffsetL, byteOffsetH) {
+Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.truncate.(J)V"] = function(addr, byteOffsetL, byteOffsetH) {
     var pathname = J2ME.fromJavaString(getHandle(this.nativePath));
     DEBUG_FS && console.log("DefaultFileHandler.lastModified: " + pathname);
     if (config.ignoredFiles.has(pathname)) {
@@ -367,7 +367,7 @@ Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.truncate.(J)V"] = function(b
     fs.truncate(pathname, J2ME.longToNumber(byteOffsetL, byteOffsetH));
 };
 
-Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.fileSize.()J"] = function() {
+Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.fileSize.()J"] = function(addr) {
     var pathname = J2ME.fromJavaString(getHandle(this.nativePath));
     DEBUG_FS && console.log("DefaultFileHandler.fileSize: " + pathname);
     if (config.ignoredFiles.has(pathname)) {
@@ -381,7 +381,7 @@ Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.fileSize.()J"] = function() 
 addUnimplementedNative("com/sun/cdc/io/j2me/file/DefaultFileHandler.directorySize.(Z)J",
                        function() { return J2ME.returnLongValue(0) });
 
-Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.canRead.()Z"] = function() {
+Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.canRead.()Z"] = function(addr) {
     var pathname = J2ME.fromJavaString(getHandle(this.nativePath));
     DEBUG_FS && console.log("DefaultFileHandler.canRead: " + pathname);
     if (config.ignoredFiles.has(pathname)) {
@@ -392,7 +392,7 @@ Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.canRead.()Z"] = function() {
     return J2ME.returnLongValue(fs.exists(pathname) ? 1 : 0);
 };
 
-Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.canWrite.()Z"] = function() {
+Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.canWrite.()Z"] = function(addr) {
     var pathname = J2ME.fromJavaString(getHandle(this.nativePath));
     DEBUG_FS && console.log("DefaultFileHandler.canWrite: " + pathname);
     if (config.ignoredFiles.has(pathname)) {
@@ -403,13 +403,13 @@ Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.canWrite.()Z"] = function() 
     return fs.exists(pathname) ? 1 : 0;
 };
 
-Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.isHidden0.()Z"] = function() {
+Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.isHidden0.()Z"] = function(addr) {
     // Per the comment in DefaultFileHandler.isHidden, we pretend we're Unix
     // and always return false.
     return 0;
 };
 
-Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.setReadable.(Z)V"] = function() {
+Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.setReadable.(Z)V"] = function(addr) {
     var pathname = J2ME.fromJavaString(getHandle(this.nativePath));
     DEBUG_FS && console.log("DefaultFileHandler.setReadable: " + pathname);
     if (config.ignoredFiles.has(pathname)) {
@@ -424,7 +424,7 @@ Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.setReadable.(Z)V"] = functio
     // Otherwise this is a noop, as files are always readable in our filesystem.
 };
 
-Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.setWritable.(Z)V"] = function() {
+Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.setWritable.(Z)V"] = function(addr) {
     var pathname = J2ME.fromJavaString(getHandle(this.nativePath));
     DEBUG_FS && console.log("DefaultFileHandler.setWritable: " + pathname);
     if (config.ignoredFiles.has(pathname)) {
@@ -441,7 +441,7 @@ Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.setWritable.(Z)V"] = functio
 
 addUnimplementedNative("com/sun/cdc/io/j2me/file/DefaultFileHandler.setHidden0.(Z)V");
 
-Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.mkdir.()V"] = function() {
+Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.mkdir.()V"] = function(addr) {
     var pathname = J2ME.fromJavaString(getHandle(this.nativePath));
     DEBUG_FS && console.log("DefaultFileHandler.mkdir: " + pathname);
 
@@ -456,7 +456,7 @@ addUnimplementedNative("com/sun/cdc/io/j2me/file/DefaultFileHandler.availableSiz
 addUnimplementedNative("com/sun/cdc/io/j2me/file/DefaultFileHandler.totalSize.()J",
                        function() { return J2ME.returnLongValue(1024 * 1024 * 1024) });
 
-Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.lastModified.()J"] = function() {
+Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.lastModified.()J"] = function(addr) {
     var pathname = J2ME.fromJavaString(getHandle(this.nativePath));
     DEBUG_FS && console.log("DefaultFileHandler.lastModified: " + pathname);
     if (config.ignoredFiles.has(pathname)) {
@@ -550,28 +550,28 @@ MIDP.closeFileHandler = function(fileHandler, mode) {
     }
 };
 
-Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.openForRead.()V"] = function() {
+Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.openForRead.()V"] = function(addr) {
     MIDP.openFileHandler(this, "read");
 };
 
-Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.closeForRead.()V"] = function() {
+Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.closeForRead.()V"] = function(addr) {
     MIDP.closeFileHandler(this, "read");
 };
 
-Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.openForWrite.()V"] = function() {
+Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.openForWrite.()V"] = function(addr) {
     MIDP.openFileHandler(this, "write");
 };
 
-Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.closeForWrite.()V"] = function() {
+Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.closeForWrite.()V"] = function(addr) {
     MIDP.closeFileHandler(this, "write");
 };
 
-Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.closeForReadWrite.()V"] = function() {
+Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.closeForReadWrite.()V"] = function(addr) {
     MIDP.closeFileHandler(this, "read");
     MIDP.closeFileHandler(this, "write");
 };
 
-Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.read.([BII)I"] = function(b, off, len) {
+Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.read.([BII)I"] = function(addr, b, off, len) {
     DEBUG_FS && console.log("DefaultFileHandler.read: " + J2ME.fromJavaString(getHandle(this.nativePath)) + " " + len);
     if (this.nativeDescriptor === -1) {
         DEBUG_FS && console.log("DefaultFileHandler.read: ignored file");
@@ -595,7 +595,7 @@ Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.read.([BII)I"] = function(b,
     return (data.byteLength > 0) ? data.byteLength : -1;
 };
 
-Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.skip.(J)J"] = function(l, h) {
+Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.skip.(J)J"] = function(addr, l, h) {
     DEBUG_FS && console.log("DefaultFileHandler.skip: " + J2ME.fromJavaString(getHandle(this.nativePath)));
     if (this.nativeDescriptor === -1) {
         DEBUG_FS && console.log("DefaultFileHandler.skip: ignored file");
@@ -620,7 +620,7 @@ Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.skip.(J)J"] = function(l, h)
     }
 };
 
-Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.write.([BII)I"] = function(b, off, len) {
+Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.write.([BII)I"] = function(addr, b, off, len) {
     DEBUG_FS && console.log("DefaultFileHandler.write: " + J2ME.fromJavaString(getHandle(this.nativePath)) + " " + off + "+" + len);
     if (this.nativeDescriptor === -1) {
         DEBUG_FS && console.log("DefaultFileHandler.write: ignored file");
@@ -634,7 +634,7 @@ Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.write.([BII)I"] = function(b
     return preemptingImpl("I", len);
 };
 
-Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.positionForWrite.(J)V"] = function(offsetLow, offsetHigh) {
+Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.positionForWrite.(J)V"] = function(addr, offsetLow, offsetHigh) {
     DEBUG_FS && console.log("DefaultFileHandler.positionForWrite: " + J2ME.fromJavaString(getHandle(this.nativePath)));
     if (this.nativeDescriptor === -1) {
         DEBUG_FS && console.log("DefaultFileHandler.positionForWrite: ignored file");
@@ -645,7 +645,7 @@ Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.positionForWrite.(J)V"] = fu
     fs.setpos(fd, J2ME.longToNumber(offsetLow, offsetHigh));
 };
 
-Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.flush.()V"] = function() {
+Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.flush.()V"] = function(addr) {
     DEBUG_FS && console.log("DefaultFileHandler.flush: " + J2ME.fromJavaString(getHandle(this.nativePath)));
     if (this.nativeDescriptor === -1) {
         DEBUG_FS && console.log("DefaultFileHandler.flush: ignored file");
@@ -656,7 +656,7 @@ Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.flush.()V"] = function() {
     fs.flush(fd);
 };
 
-Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.close.()V"] = function() {
+Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.close.()V"] = function(addr) {
     DEBUG_FS && console.log("DefaultFileHandler.close: " + J2ME.fromJavaString(getHandle(this.nativePath)));
 
     MIDP.closeFileHandler(this, "read");
@@ -668,14 +668,14 @@ Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.close.()V"] = function() {
 addUnimplementedNative("com/sun/cdc/io/j2me/file/DefaultFileHandler.getNativeName.(Ljava/lang/String;J)J",
                        function() { return J2ME.returnLongValue(0) });
 
-Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.getFileSeparator.()C"] = function() {
+Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.getFileSeparator.()C"] = function(addr) {
     return "/".charCodeAt(0);
 }
 
 MIDP.openDirs = new Map();
 MIDP.openDirHandle = 0;
 
-Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.openDir.()J"] = function() {
+Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.openDir.()J"] = function(addr) {
     var pathname = J2ME.fromJavaString(getHandle(this.nativePath));
     DEBUG_FS && console.log("DefaultFileHandler.openDir: " + pathname);
 
@@ -700,12 +700,12 @@ Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.openDir.()J"] = function() {
     return J2ME.returnLongValue(openDirHandle);
 };
 
-Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.closeDir.(J)V"] = function(dirHandleLow, dirHandleHigh) {
+Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.closeDir.(J)V"] = function(addr, dirHandleLow, dirHandleHigh) {
     MIDP.openDirs.delete(J2ME.longToNumber(dirHandleLow, dirHandleHigh));
 };
 
 Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.dirGetNextFile.(JZ)Ljava/lang/String;"] =
-function(dirHandleLow, dirHandleHigh, includeHidden) {
+function(addr, dirHandleLow, dirHandleHigh, includeHidden) {
     var iterator = MIDP.openDirs.get(J2ME.longToNumber(dirHandleLow, dirHandleHigh));
     var nextFile = iterator.files[++iterator.index];
 DEBUG_FS && console.log(iterator.index + " " + nextFile);
@@ -713,20 +713,20 @@ DEBUG_FS && console.log(iterator.index + " " + nextFile);
 };
 
 Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.getNativePathForRoot.(Ljava/lang/String;)Ljava/lang/String;"] =
-function(root) {
+function(addr, root) {
 // XXX Ensure root is in MIDP.fsRoots?
 DEBUG_FS && console.log("getNativePathForRoot: " + J2ME.fromJavaString(root));
     var nativePath = J2ME.newString("/" + J2ME.fromJavaString(root));
     return nativePath;
 };
 
-Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.illegalFileNameChars0.()Ljava/lang/String;"] = function() {
+Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.illegalFileNameChars0.()Ljava/lang/String;"] = function(addr) {
     return J2ME.newString('<>:"\\|?');
 };
 
 addUnimplementedNative("com/sun/cdc/io/j2me/file/DefaultFileHandler.initialize.()V");
 
-Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.getSuiteIdString.(I)Ljava/lang/String;"] = function(id) {
+Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.getSuiteIdString.(I)Ljava/lang/String;"] = function(addr, id) {
 DEBUG_FS && console.log("getSuiteIdString: " + id);
     // return J2ME.newString(id.toString());
     // The implementation adds this to the path of the file, presumably
@@ -735,7 +735,7 @@ DEBUG_FS && console.log("getSuiteIdString: " + id);
     return J2ME.newString("");
 };
 
-Native["com/sun/cdc/io/j2me/file/Protocol.available.()I"] = function() {
+Native["com/sun/cdc/io/j2me/file/Protocol.available.()I"] = function(addr) {
     var fileHandler = getHandle(this.fileHandler);
     var fd = fileHandler.nativeDescriptor;
     var available = fs.getsize(fd) - fs.getpos(fd);
@@ -743,7 +743,7 @@ Native["com/sun/cdc/io/j2me/file/Protocol.available.()I"] = function() {
     return available;
 };
 
-Native["com/sun/midp/io/j2me/storage/RandomAccessStream.open.(Ljava/lang/String;I)I"] = function(fileName, mode) {
+Native["com/sun/midp/io/j2me/storage/RandomAccessStream.open.(Ljava/lang/String;I)I"] = function(addr, fileName, mode) {
     var path = "/" + J2ME.fromJavaString(fileName);
 
     var ctx = $.ctx;
@@ -773,7 +773,7 @@ Native["com/sun/midp/io/j2me/storage/RandomAccessStream.open.(Ljava/lang/String;
 };
 
 Native["com/sun/midp/io/j2me/storage/RandomAccessStream.read.(I[BII)I"] =
-function(handle, buffer, offset, length) {
+function(addr, handle, buffer, offset, length) {
     var from = fs.getpos(handle);
     var to = from + length;
     var readBytes = fs.read(handle, from, to);
@@ -790,19 +790,19 @@ function(handle, buffer, offset, length) {
 };
 
 Native["com/sun/midp/io/j2me/storage/RandomAccessStream.write.(I[BII)V"] =
-function(handle, buffer, offset, length) {
+function(addr, handle, buffer, offset, length) {
     fs.write(handle, buffer, offset, length);
 };
 
-Native["com/sun/midp/io/j2me/storage/RandomAccessStream.commitWrite.(I)V"] = function(handle) {
+Native["com/sun/midp/io/j2me/storage/RandomAccessStream.commitWrite.(I)V"] = function(addr, handle) {
     fs.flush(handle);
 };
 
-Native["com/sun/midp/io/j2me/storage/RandomAccessStream.position.(II)V"] = function(handle, position) {
+Native["com/sun/midp/io/j2me/storage/RandomAccessStream.position.(II)V"] = function(addr, handle, position) {
     fs.setpos(handle, position);
 };
 
-Native["com/sun/midp/io/j2me/storage/RandomAccessStream.sizeOf.(I)I"] = function(handle) {
+Native["com/sun/midp/io/j2me/storage/RandomAccessStream.sizeOf.(I)I"] = function(addr, handle) {
     var size = fs.getsize(handle);
 
     if (size == -1) {
@@ -812,11 +812,11 @@ Native["com/sun/midp/io/j2me/storage/RandomAccessStream.sizeOf.(I)I"] = function
     return size;
 };
 
-Native["com/sun/midp/io/j2me/storage/RandomAccessStream.close.(I)V"] = function(handle) {
+Native["com/sun/midp/io/j2me/storage/RandomAccessStream.close.(I)V"] = function(addr, handle) {
     fs.close(handle);
 };
 
-Native["javax/microedition/io/file/FileSystemRegistry.getRoots.()[Ljava/lang/String;"] = function() {
+Native["javax/microedition/io/file/FileSystemRegistry.getRoots.()[Ljava/lang/String;"] = function(addr) {
     var array = J2ME.newStringArray(MIDP.fsRoots.length);
 
     for (var i = 0; i < MIDP.fsRoots.length; i++) {

--- a/midp/gfx.js
+++ b/midp/gfx.js
@@ -22,58 +22,58 @@ var currentlyFocusedTextEditor;
     tempContext.canvas.width = 0;
     tempContext.canvas.height = 0;
 
-    Native["com/sun/midp/lcdui/DisplayDeviceContainer.getDisplayDevicesIds0.()[I"] = function() {
+    Native["com/sun/midp/lcdui/DisplayDeviceContainer.getDisplayDevicesIds0.()[I"] = function(addr) {
         var ids = J2ME.newIntArray( 1);
         ids[0] = 1;
         return ids;
     };
 
-    Native["com/sun/midp/lcdui/DisplayDevice.getDisplayName0.(I)Ljava/lang/String;"] = function(id) {
+    Native["com/sun/midp/lcdui/DisplayDevice.getDisplayName0.(I)Ljava/lang/String;"] = function(addr, id) {
         return null;
     };
 
-    Native["com/sun/midp/lcdui/DisplayDevice.isDisplayPrimary0.(I)Z"] = function(id) {
+    Native["com/sun/midp/lcdui/DisplayDevice.isDisplayPrimary0.(I)Z"] = function(addr, id) {
         console.warn("DisplayDevice.isDisplayPrimary0.(I)Z not implemented (" + id + ")");
         return 1;
     };
 
-    Native["com/sun/midp/lcdui/DisplayDevice.isbuildInDisplay0.(I)Z"] = function(id) {
+    Native["com/sun/midp/lcdui/DisplayDevice.isbuildInDisplay0.(I)Z"] = function(addr, id) {
         return 1;
     };
 
-    Native["com/sun/midp/lcdui/DisplayDevice.getDisplayCapabilities0.(I)I"] = function(id) {
+    Native["com/sun/midp/lcdui/DisplayDevice.getDisplayCapabilities0.(I)I"] = function(addr, id) {
         return 0x3ff;
     };
 
-    Native["com/sun/midp/lcdui/DisplayDevice.isDisplayPenSupported0.(I)Z"] = function(id) {
+    Native["com/sun/midp/lcdui/DisplayDevice.isDisplayPenSupported0.(I)Z"] = function(addr, id) {
         return 1;
     };
 
-    Native["com/sun/midp/lcdui/DisplayDevice.isDisplayPenMotionSupported0.(I)Z"] = function(id) {
+    Native["com/sun/midp/lcdui/DisplayDevice.isDisplayPenMotionSupported0.(I)Z"] = function(addr, id) {
         return 1;
     };
 
-    Native["com/sun/midp/lcdui/DisplayDevice.reverseOrientation0.(I)Z"] = function(id) {
+    Native["com/sun/midp/lcdui/DisplayDevice.reverseOrientation0.(I)Z"] = function(addr, id) {
         return 0;
     };
 
-    Native["com/sun/midp/lcdui/DisplayDevice.getReverseOrientation0.(I)Z"] = function(id) {
+    Native["com/sun/midp/lcdui/DisplayDevice.getReverseOrientation0.(I)Z"] = function(addr, id) {
         return 0;
     };
 
-    Native["com/sun/midp/lcdui/DisplayDevice.getScreenWidth0.(I)I"] = function(id) {
+    Native["com/sun/midp/lcdui/DisplayDevice.getScreenWidth0.(I)I"] = function(addr, id) {
         return offscreenCanvas.width;
     };
 
-    Native["com/sun/midp/lcdui/DisplayDevice.getScreenHeight0.(I)I"] = function(id) {
+    Native["com/sun/midp/lcdui/DisplayDevice.getScreenHeight0.(I)I"] = function(addr, id) {
         return offscreenCanvas.height;
     };
 
-    Native["com/sun/midp/lcdui/DisplayDevice.displayStateChanged0.(II)V"] = function(hardwareId, state) {
+    Native["com/sun/midp/lcdui/DisplayDevice.displayStateChanged0.(II)V"] = function(addr, hardwareId, state) {
         console.warn("DisplayDevice.displayStateChanged0.(II)V not implemented (" + hardwareId + ", " + state + ")");
     };
 
-    Native["com/sun/midp/lcdui/DisplayDevice.gainedForeground0.(II)V"] = function(hardwareId, displayId) {
+    Native["com/sun/midp/lcdui/DisplayDevice.gainedForeground0.(II)V"] = function(addr, hardwareId, displayId) {
         hideSplashScreen();
 
         if (!emoji.loaded) {
@@ -88,11 +88,11 @@ var currentlyFocusedTextEditor;
         }
     };
 
-    Native["com/sun/midp/lcdui/DisplayDeviceAccess.vibrate0.(IZ)Z"] = function(displayId, on) {
+    Native["com/sun/midp/lcdui/DisplayDeviceAccess.vibrate0.(IZ)Z"] = function(addr, displayId, on) {
         return 1;
     };
 
-    Native["com/sun/midp/lcdui/DisplayDeviceAccess.isBacklightSupported0.(I)Z"] = function(displayId) {
+    Native["com/sun/midp/lcdui/DisplayDeviceAccess.isBacklightSupported0.(I)Z"] = function(addr, displayId) {
         return 1;
     };
 
@@ -111,7 +111,7 @@ var currentlyFocusedTextEditor;
         }
     }
 
-    Native["com/sun/midp/lcdui/RepaintEventProducer.waitForAnimationFrame.()V"] = function() {
+    Native["com/sun/midp/lcdui/RepaintEventProducer.waitForAnimationFrame.()V"] = function(addr) {
         if (hasNewFrame) {
             hasNewFrame = false;
             window.requestAnimationFrame(gotNewFrame);
@@ -121,7 +121,7 @@ var currentlyFocusedTextEditor;
         }
     }
 
-    Native["com/sun/midp/lcdui/DisplayDevice.refresh0.(IIIIII)V"] = function(hardwareId, displayId, x1, y1, x2, y2) {
+    Native["com/sun/midp/lcdui/DisplayDevice.refresh0.(IIIIII)V"] = function(addr, hardwareId, displayId, x1, y1, x2, y2) {
         x1 = Math.max(0, x1);
         y1 = Math.max(0, y1);
         x2 = Math.max(0, x2);
@@ -244,7 +244,7 @@ var currentlyFocusedTextEditor;
     }
 
     Native["javax/microedition/lcdui/ImageDataFactory.createImmutableImageDecodeImage.(Ljavax/microedition/lcdui/ImageData;[BII)V"] =
-    function(imageData, bytes, offset, length) {
+    function(addr, imageData, bytes, offset, length) {
         var ctx = $.ctx;
         asyncImpl("V", new Promise(function(resolve, reject) {
             var blob = new Blob([bytes.subarray(offset, offset + length)], { type: "image/png" });
@@ -266,27 +266,27 @@ var currentlyFocusedTextEditor;
     };
 
     Native["javax/microedition/lcdui/ImageDataFactory.createImmutableImageDataRegion.(Ljavax/microedition/lcdui/ImageData;Ljavax/microedition/lcdui/ImageData;IIIIIZ)V"] =
-    function(dataDest, dataSource, x, y, width, height, transform, isMutable) {
+    function(addr, dataDest, dataSource, x, y, width, height, transform, isMutable) {
         var context = initImageData(dataDest, width, height, isMutable);
         renderRegion(context, getNative(dataSource).context.canvas, x, y, width, height, transform, 0, 0, TOP|LEFT);
     };
 
     Native["javax/microedition/lcdui/ImageDataFactory.createImmutableImageDataCopy.(Ljavax/microedition/lcdui/ImageData;Ljavax/microedition/lcdui/ImageData;)V"] =
-    function(dest, source) {
+    function(addr, dest, source) {
         var srcCanvas = getNative(source).context.canvas;
         var context = initImageData(dest, srcCanvas.width, srcCanvas.height, 0);
         context.drawImage(srcCanvas, 0, 0);
     };
 
     Native["javax/microedition/lcdui/ImageDataFactory.createMutableImageData.(Ljavax/microedition/lcdui/ImageData;II)V"] =
-    function(imageData, width, height) {
+    function(addr, imageData, width, height) {
         var context = initImageData(imageData, width, height, 1);
         context.fillStyle = "rgb(255,255,255)"; // white
         context.fillRect(0, 0, width, height);
     };
 
     Native["javax/microedition/lcdui/ImageDataFactory.createImmutableImageDecodeRGBImage.(Ljavax/microedition/lcdui/ImageData;[IIIZ)V"] =
-    function(imageData, rgbData, width, height, processAlpha) {
+    function(addr, imageData, rgbData, width, height, processAlpha) {
         var context = initImageData(imageData, width, height, 0);
         var ctxImageData = context.createImageData(width, height);
         var abgrData = new Int32Array(ctxImageData.data.buffer);
@@ -300,17 +300,17 @@ var currentlyFocusedTextEditor;
         context.putImageData(ctxImageData, 0, 0);
     };
 
-    Native["javax/microedition/lcdui/ImageData.getRGB.([IIIIIII)V"] = function(rgbData, offset, scanlength, x, y, width, height) {
+    Native["javax/microedition/lcdui/ImageData.getRGB.([IIIIIII)V"] = function(addr, rgbData, offset, scanlength, x, y, width, height) {
         var abgrData = new Int32Array(getNative(this).context.getImageData(x, y, width, height).data.buffer);
         ABGRToARGB(abgrData, rgbData, width, height, offset, scanlength);
     };
 
-    Native["com/nokia/mid/ui/DirectUtils.makeMutable.(Ljavax/microedition/lcdui/Image;)V"] = function(image) {
+    Native["com/nokia/mid/ui/DirectUtils.makeMutable.(Ljavax/microedition/lcdui/Image;)V"] = function(addr, image) {
         var imageData = getHandle(image.imageData);
         imageData.isMutable = 1;
     };
 
-    Native["com/nokia/mid/ui/DirectUtils.setPixels.(Ljavax/microedition/lcdui/Image;I)V"] = function(image, argb) {
+    Native["com/nokia/mid/ui/DirectUtils.setPixels.(Ljavax/microedition/lcdui/Image;I)V"] = function(addr, image, argb) {
         var width = image.width;
         var height = image.height;
         var imageData = getHandle(image.imageData);
@@ -348,7 +348,7 @@ var currentlyFocusedTextEditor;
     var SIZE_MEDIUM = 0;
     var SIZE_LARGE = 16;
 
-    Native["javax/microedition/lcdui/Font.init.(III)V"] = function(face, style, size) {
+    Native["javax/microedition/lcdui/Font.init.(III)V"] = function(addr, face, style, size) {
         var defaultSize = config.fontSize ? config.fontSize : Math.max(19, (offscreenCanvas.height / 35) | 0);
         if (size & SIZE_SMALL)
             size = defaultSize / 1.25;
@@ -414,23 +414,23 @@ var currentlyFocusedTextEditor;
         return defaultFont;
     }
 
-    Native["javax/microedition/lcdui/Font.getDefaultFont.()Ljavax/microedition/lcdui/Font;"] = function() {
+    Native["javax/microedition/lcdui/Font.getDefaultFont.()Ljavax/microedition/lcdui/Font;"] = function(addr) {
         return getDefaultFont();
     };
 
-    Native["javax/microedition/lcdui/Font.stringWidth.(Ljava/lang/String;)I"] = function(str) {
+    Native["javax/microedition/lcdui/Font.stringWidth.(Ljava/lang/String;)I"] = function(addr, str) {
         return calcStringWidth(this, J2ME.fromJavaString(str));
     };
 
-    Native["javax/microedition/lcdui/Font.charWidth.(C)I"] = function(char) {
+    Native["javax/microedition/lcdui/Font.charWidth.(C)I"] = function(addr, char) {
         return getNative(this).measureText(String.fromCharCode(char)).width | 0;
     };
 
-    Native["javax/microedition/lcdui/Font.charsWidth.([CII)I"] = function(str, offset, len) {
+    Native["javax/microedition/lcdui/Font.charsWidth.([CII)I"] = function(addr, str, offset, len) {
         return calcStringWidth(this, util.fromJavaChars(str).slice(offset, offset + len));
     };
 
-    Native["javax/microedition/lcdui/Font.substringWidth.(Ljava/lang/String;II)I"] = function(str, offset, len) {
+    Native["javax/microedition/lcdui/Font.substringWidth.(Ljava/lang/String;II)I"] = function(addr, str, offset, len) {
         return calcStringWidth(this, J2ME.fromJavaString(str).slice(offset, offset + len));
     };
 
@@ -515,87 +515,87 @@ var currentlyFocusedTextEditor;
         createEllipticalArc(c, x + rw, y + rh, rw, rh, Math.PI, 1.5 * Math.PI, false);
     }
 
-    Native["javax/microedition/lcdui/Graphics.getDisplayColor.(I)I"] = function(color) {
+    Native["javax/microedition/lcdui/Graphics.getDisplayColor.(I)I"] = function(addr, color) {
         return color & 0x00FFFFFF;
     };
 
-    Native["javax/microedition/lcdui/Graphics.resetGC.()V"] = function() {
+    Native["javax/microedition/lcdui/Graphics.resetGC.()V"] = function(addr) {
         getNative(this).resetGC();
     };
 
-    Native["javax/microedition/lcdui/Graphics.reset.(IIII)V"] = function(x1, y1, x2, y2) {
+    Native["javax/microedition/lcdui/Graphics.reset.(IIII)V"] = function(addr, x1, y1, x2, y2) {
         getNative(this).reset(x1, y1, x2, y2);
     };
 
-    Native["javax/microedition/lcdui/Graphics.reset.()V"] = function() {
+    Native["javax/microedition/lcdui/Graphics.reset.()V"] = function(addr) {
         var info = getNative(this);
         info.reset(0, 0, info.contextInfo.context.canvas.width, info.contextInfo.context.canvas.height);
     };
 
-    Native["javax/microedition/lcdui/Graphics.copyArea.(IIIIIII)V"] = function(x_src, y_src, width, height, x_dest, y_dest, anchor) {
+    Native["javax/microedition/lcdui/Graphics.copyArea.(IIIIIII)V"] = function(addr, x_src, y_src, width, height, x_dest, y_dest, anchor) {
         if (isScreenGraphics(this)) {
             throw $.newIllegalStateException();
         }
         console.warn("javax/microedition/lcdui/Graphics.copyArea.(IIIIIII)V not implemented");
     };
 
-    Native["javax/microedition/lcdui/Graphics.setDimensions.(II)V"] = function(w, h) {
+    Native["javax/microedition/lcdui/Graphics.setDimensions.(II)V"] = function(addr, w, h) {
         getNative(this).resetNonGC(0, 0, w, h);
     };
 
-    Native["javax/microedition/lcdui/Graphics.translate.(II)V"] = function(x, y) {
+    Native["javax/microedition/lcdui/Graphics.translate.(II)V"] = function(addr, x, y) {
         getNative(this).translate(x, y);
     };
 
-    Native["javax/microedition/lcdui/Graphics.getTranslateX.()I"] = function() {
+    Native["javax/microedition/lcdui/Graphics.getTranslateX.()I"] = function(addr) {
         return getNative(this).transX;
     };
 
-    Native["javax/microedition/lcdui/Graphics.getTranslateY.()I"] = function() {
+    Native["javax/microedition/lcdui/Graphics.getTranslateY.()I"] = function(addr) {
         return getNative(this).transY;
     };
 
-    Native["javax/microedition/lcdui/Graphics.getMaxWidth.()S"] = function() {
+    Native["javax/microedition/lcdui/Graphics.getMaxWidth.()S"] = function(addr) {
         return getNative(this).contextInfo.context.canvas.width;
     };
 
-    Native["javax/microedition/lcdui/Graphics.getMaxHeight.()S"] = function() {
+    Native["javax/microedition/lcdui/Graphics.getMaxHeight.()S"] = function(addr) {
         return getNative(this).contextInfo.context.canvas.height;
     };
 
-    Native["javax/microedition/lcdui/Graphics.getCreator.()Ljava/lang/Object;"] = function() {
+    Native["javax/microedition/lcdui/Graphics.getCreator.()Ljava/lang/Object;"] = function(addr) {
         return this.creator;
     };
 
-    Native["javax/microedition/lcdui/Graphics.setCreator.(Ljava/lang/Object;)V"] = function(creator) {
+    Native["javax/microedition/lcdui/Graphics.setCreator.(Ljava/lang/Object;)V"] = function(addr, creator) {
         if (!this.creator) {
             this.creator = creator;
         }
     };
 
-    Native["javax/microedition/lcdui/Graphics.getColor.()I"] = function() {
+    Native["javax/microedition/lcdui/Graphics.getColor.()I"] = function(addr) {
         var info = getNative(this);
         return (info.red << 16) | (info.green << 8) | info.blue;
     };
 
-    Native["javax/microedition/lcdui/Graphics.getRedComponent.()I"] = function() {
+    Native["javax/microedition/lcdui/Graphics.getRedComponent.()I"] = function(addr) {
         return getNative(this).red;
     };
 
-    Native["javax/microedition/lcdui/Graphics.getGreenComponent.()I"] = function() {
+    Native["javax/microedition/lcdui/Graphics.getGreenComponent.()I"] = function(addr) {
         return getNative(this).green;
     };
 
-    Native["javax/microedition/lcdui/Graphics.getBlueComponent.()I"] = function() {
+    Native["javax/microedition/lcdui/Graphics.getBlueComponent.()I"] = function(addr) {
         return getNative(this).blue;
     };
 
-    Native["javax/microedition/lcdui/Graphics.getGrayScale.()I"] = function() {
+    Native["javax/microedition/lcdui/Graphics.getGrayScale.()I"] = function(addr) {
         var info = getNative(this);
         return (info.red*76 + info.green*150 + info.blue*29) >>> 8;
     };
 
-    Native["javax/microedition/lcdui/Graphics.setColor.(III)V"] = function(red, green, blue) {
+    Native["javax/microedition/lcdui/Graphics.setColor.(III)V"] = function(addr, red, green, blue) {
         if ((red < 0)   || (red > 255)
             || (green < 0) || (green > 255)
             || (blue < 0)  || (blue > 255)) {
@@ -605,7 +605,7 @@ var currentlyFocusedTextEditor;
         getNative(this).setPixel(0xFF, red, green, blue);
     };
 
-    Native["javax/microedition/lcdui/Graphics.setColor.(I)V"] = function(rgb) {
+    Native["javax/microedition/lcdui/Graphics.setColor.(I)V"] = function(addr, rgb) {
         var red = (rgb >>> 16) & 0xFF;
         var green = (rgb >>> 8) & 0xFF;
         var blue = rgb & 0xFF;
@@ -622,7 +622,7 @@ var currentlyFocusedTextEditor;
         }
     };
 
-    Native["javax/microedition/lcdui/Graphics.setGrayScale.(I)V"] = function(value) {
+    Native["javax/microedition/lcdui/Graphics.setGrayScale.(I)V"] = function(addr, value) {
         if ((value < 0) || (value > 255)) {
             throw $.newIllegalArgumentException("Gray value out of range");
         }
@@ -639,17 +639,17 @@ var currentlyFocusedTextEditor;
         }
     };
 
-    Native["javax/microedition/lcdui/Graphics.getFont.()Ljavax/microedition/lcdui/Font;"] = function() {
+    Native["javax/microedition/lcdui/Graphics.getFont.()Ljavax/microedition/lcdui/Font;"] = function(addr) {
         return getNative(this).currentFont;
     };
 
-    Native["javax/microedition/lcdui/Graphics.setFont.(Ljavax/microedition/lcdui/Font;)V"] = function(font) {
+    Native["javax/microedition/lcdui/Graphics.setFont.(Ljavax/microedition/lcdui/Font;)V"] = function(addr, font) {
         getNative(this).setFont(font);
     };
 
     var SOLID = 0;
     var DOTTED = 1;
-    Native["javax/microedition/lcdui/Graphics.setStrokeStyle.(I)V"] = function(style) {
+    Native["javax/microedition/lcdui/Graphics.setStrokeStyle.(I)V"] = function(addr, style) {
         if ((style !== SOLID) && (style !== DOTTED)) {
             throw $.newIllegalArgumentException("Invalid stroke style");
         }
@@ -657,31 +657,31 @@ var currentlyFocusedTextEditor;
         // We don't actually implement DOTTED style so this is a no-op
     };
 
-    Native["javax/microedition/lcdui/Graphics.getStrokeStyle.()I"] = function() {
+    Native["javax/microedition/lcdui/Graphics.getStrokeStyle.()I"] = function(addr) {
         return SOLID;
     };
 
-    Native["javax/microedition/lcdui/Graphics.getClipX.()I"] = function() {
+    Native["javax/microedition/lcdui/Graphics.getClipX.()I"] = function(addr) {
         var info = getNative(this);
         return info.clipX1 - info.transX;
     };
 
-    Native["javax/microedition/lcdui/Graphics.getClipY.()I"] = function() {
+    Native["javax/microedition/lcdui/Graphics.getClipY.()I"] = function(addr) {
         var info = getNative(this);
         return info.clipY1 - info.transY;
     };
 
-    Native["javax/microedition/lcdui/Graphics.getClipWidth.()I"] = function() {
+    Native["javax/microedition/lcdui/Graphics.getClipWidth.()I"] = function(addr) {
         var info = getNative(this);
         return info.clipX2 - info.clipX1;
     };
 
-    Native["javax/microedition/lcdui/Graphics.getClipHeight.()I"] = function() {
+    Native["javax/microedition/lcdui/Graphics.getClipHeight.()I"] = function(addr) {
         var info = getNative(this);
         return info.clipY2 - info.clipY1;
     };
 
-    Native["javax/microedition/lcdui/Graphics.getClip.([I)V"] = function(region) {
+    Native["javax/microedition/lcdui/Graphics.getClip.([I)V"] = function(addr, region) {
         var info = getNative(this);
         region[0] = info.clipX1 - info.transX;
         region[1] = info.clipY1 - info.transY;
@@ -689,7 +689,7 @@ var currentlyFocusedTextEditor;
         region[3] = info.clipY2 - info.transY;
     };
 
-    Native["javax/microedition/lcdui/Graphics.clipRect.(IIII)V"] = function(x, y, width, height) {
+    Native["javax/microedition/lcdui/Graphics.clipRect.(IIII)V"] = function(addr, x, y, width, height) {
         var info = getNative(this);
         info.setClip(x, y, width, height, info.clipX1, info.clipY1, info.clipX2, info.clipY2);
     };
@@ -698,7 +698,7 @@ var currentlyFocusedTextEditor;
     var TYPE_USHORT_4444_ARGB = 4444;
     var TYPE_USHORT_565_RGB = 565;
 
-    Native["com/nokia/mid/ui/DirectGraphicsImp.setARGBColor.(I)V"] = function(argb) {
+    Native["com/nokia/mid/ui/DirectGraphicsImp.setARGBColor.(I)V"] = function(addr, argb) {
         var alpha = (argb >>> 24);
         var red = (argb >>> 16) & 0xFF;
         var green = (argb >>> 8) & 0xFF;
@@ -706,12 +706,12 @@ var currentlyFocusedTextEditor;
         getNative(getHandle(this.graphics)).setPixel(alpha, red, green, blue);
     };
 
-    Native["com/nokia/mid/ui/DirectGraphicsImp.getAlphaComponent.()I"] = function() {
+    Native["com/nokia/mid/ui/DirectGraphicsImp.getAlphaComponent.()I"] = function(addr) {
         return getNative(getHandle(this.graphics)).alpha;
     };
 
     Native["com/nokia/mid/ui/DirectGraphicsImp.getPixels.([SIIIIIII)V"] =
-    function(pixels, offset, scanlength, x, y, width, height, format) {
+    function(addr, pixels, offset, scanlength, x, y, width, height, format) {
         if (pixels === null) {
             throw $.newNullPointerException("Pixels array is null");
         }
@@ -731,7 +731,7 @@ var currentlyFocusedTextEditor;
     };
 
     Native["com/nokia/mid/ui/DirectGraphicsImp.drawPixels.([SZIIIIIIII)V"] =
-    function(pixels, transparency, offset, scanlength, x, y, width, height, manipulation, format) {
+    function(addr, pixels, transparency, offset, scanlength, x, y, width, height, manipulation, format) {
         if (pixels === null) {
             throw $.newNullPointerException("Pixels array is null");
         }
@@ -759,13 +759,13 @@ var currentlyFocusedTextEditor;
         tempContext.canvas.height = 0;
     };
 
-    Native["javax/microedition/lcdui/Graphics.render.(Ljavax/microedition/lcdui/Image;III)Z"] = function(image, x, y, anchor) {
+    Native["javax/microedition/lcdui/Graphics.render.(Ljavax/microedition/lcdui/Image;III)Z"] = function(addr, image, x, y, anchor) {
         renderRegion(getNative(this).getGraphicsContext(), getNative(getHandle(image.imageData)).context.canvas,
                      0, 0, image.width, image.height, TRANS_NONE, x, y, anchor);
         return 1;
     };
 
-    Native["javax/microedition/lcdui/Graphics.drawRegion.(Ljavax/microedition/lcdui/Image;IIIIIIII)V"] = function(src, x_src, y_src, width, height, transform, x_dest, y_dest, anchor) {
+    Native["javax/microedition/lcdui/Graphics.drawRegion.(Ljavax/microedition/lcdui/Image;IIIIIIII)V"] = function(addr, src, x_src, y_src, width, height, transform, x_dest, y_dest, anchor) {
         if (null === src) {
             throw $.newNullPointerException("src image is null");
         }
@@ -774,7 +774,7 @@ var currentlyFocusedTextEditor;
                      x_src, y_src, width, height, transform, x_dest, y_dest, anchor);
     };
 
-    Native["javax/microedition/lcdui/Graphics.drawImage.(Ljavax/microedition/lcdui/Image;III)V"] = function(image, x, y, anchor) {
+    Native["javax/microedition/lcdui/Graphics.drawImage.(Ljavax/microedition/lcdui/Image;III)V"] = function(addr, image, x, y, anchor) {
         if (image === null) {
             throw $.newNullPointerException("image is null");
         }
@@ -917,13 +917,13 @@ var currentlyFocusedTextEditor;
         this.currentlyAppliedGraphicsInfo = graphicsInfo;
     };
 
-    Native["javax/microedition/lcdui/Graphics.initScreen0.(I)V"] = function(displayId) {
+    Native["javax/microedition/lcdui/Graphics.initScreen0.(I)V"] = function(addr, displayId) {
         this.displayId = displayId;
         setNative(this, new GraphicsInfo(screenContextInfo));
         this.creator = null;
     };
 
-    Native["javax/microedition/lcdui/Graphics.initImage0.(Ljavax/microedition/lcdui/Image;)V"] = function(img) {
+    Native["javax/microedition/lcdui/Graphics.initImage0.(Ljavax/microedition/lcdui/Image;)V"] = function(addr, img) {
         this.displayId = -1;
         setNative(this, new GraphicsInfo(getNative(getHandle(img.imageData))));
         this.creator = null;
@@ -933,7 +933,7 @@ var currentlyFocusedTextEditor;
         return g.displayId !== -1;
     }
 
-    Native["javax/microedition/lcdui/Graphics.setClip.(IIII)V"] = function(x, y, w, h) {
+    Native["javax/microedition/lcdui/Graphics.setClip.(IIII)V"] = function(addr, x, y, w, h) {
         var info = getNative(this);
         info.setClip(x, y, w, h, 0, 0, info.contextInfo.context.canvas.width, info.contextInfo.context.canvas.height);
     };
@@ -979,20 +979,20 @@ var currentlyFocusedTextEditor;
         }
     }
 
-    Native["javax/microedition/lcdui/Graphics.drawString.(Ljava/lang/String;III)V"] = function(str, x, y, anchor) {
+    Native["javax/microedition/lcdui/Graphics.drawString.(Ljava/lang/String;III)V"] = function(addr, str, x, y, anchor) {
         drawString(getNative(this), J2ME.fromJavaString(str), x, y, anchor);
     };
 
-    Native["javax/microedition/lcdui/Graphics.drawSubstring.(Ljava/lang/String;IIIII)V"] = 
-    function(str, offset, len, x, y, anchor) {
+    Native["javax/microedition/lcdui/Graphics.drawSubstring.(Ljava/lang/String;IIIII)V"] =
+    function(addr, str, offset, len, x, y, anchor) {
         drawString(getNative(this), J2ME.fromJavaString(str).substr(offset, len), x, y, anchor);
     };
 
-    Native["javax/microedition/lcdui/Graphics.drawChars.([CIIIII)V"] = function(data, offset, len, x, y, anchor) {
+    Native["javax/microedition/lcdui/Graphics.drawChars.([CIIIII)V"] = function(addr, data, offset, len, x, y, anchor) {
         drawString(getNative(this), util.fromJavaChars(data, offset, len), x, y, anchor);
     };
 
-    Native["javax/microedition/lcdui/Graphics.drawChar.(CIII)V"] = function(jChr, x, y, anchor) {
+    Native["javax/microedition/lcdui/Graphics.drawChar.(CIII)V"] = function(addr, jChr, x, y, anchor) {
         var chr = String.fromCharCode(jChr);
         var info = getNative(this);
 
@@ -1003,7 +1003,7 @@ var currentlyFocusedTextEditor;
         c.fillText(chr, x, y);
     };
 
-    Native["javax/microedition/lcdui/Graphics.fillTriangle.(IIIIII)V"] = function(x1, y1, x2, y2, x3, y3) {
+    Native["javax/microedition/lcdui/Graphics.fillTriangle.(IIIIII)V"] = function(addr, x1, y1, x2, y2, x3, y3) {
         var c = getNative(this).getGraphicsContext();
 
         var dx1 = (x2 - x1) || 1;
@@ -1019,7 +1019,7 @@ var currentlyFocusedTextEditor;
         c.fill();
     };
 
-    Native["javax/microedition/lcdui/Graphics.drawRect.(IIII)V"] = function(x, y, w, h) {
+    Native["javax/microedition/lcdui/Graphics.drawRect.(IIII)V"] = function(addr, x, y, w, h) {
         if (w < 0 || h < 0) {
             return;
         }
@@ -1032,7 +1032,7 @@ var currentlyFocusedTextEditor;
         c.strokeRect(x, y, w, h);
     };
 
-    Native["javax/microedition/lcdui/Graphics.drawRoundRect.(IIIIII)V"] = function(x, y, w, h, arcWidth, arcHeight) {
+    Native["javax/microedition/lcdui/Graphics.drawRoundRect.(IIIIII)V"] = function(addr, x, y, w, h, arcWidth, arcHeight) {
         if (w < 0 || h < 0) {
             return;
         }
@@ -1047,7 +1047,7 @@ var currentlyFocusedTextEditor;
         c.stroke();
     };
 
-    Native["javax/microedition/lcdui/Graphics.fillRect.(IIII)V"] = function(x, y, w, h) {
+    Native["javax/microedition/lcdui/Graphics.fillRect.(IIII)V"] = function(addr, x, y, w, h) {
         if (w <= 0 || h <= 0) {
             return;
         }
@@ -1060,7 +1060,7 @@ var currentlyFocusedTextEditor;
         c.fillRect(x, y, w, h);
     };
 
-    Native["javax/microedition/lcdui/Graphics.fillRoundRect.(IIIIII)V"] = function(x, y, w, h, arcWidth, arcHeight) {
+    Native["javax/microedition/lcdui/Graphics.fillRoundRect.(IIIIII)V"] = function(addr, x, y, w, h, arcWidth, arcHeight) {
         if (w <= 0 || h <= 0) {
             return;
         }
@@ -1075,7 +1075,7 @@ var currentlyFocusedTextEditor;
         c.fill();
     };
 
-    Native["javax/microedition/lcdui/Graphics.drawArc.(IIIIII)V"] = function(x, y, width, height, startAngle, arcAngle) {
+    Native["javax/microedition/lcdui/Graphics.drawArc.(IIIIII)V"] = function(addr, x, y, width, height, startAngle, arcAngle) {
         if (width < 0 || height < 0) {
             return;
         }
@@ -1089,7 +1089,7 @@ var currentlyFocusedTextEditor;
         c.stroke();
     };
 
-    Native["javax/microedition/lcdui/Graphics.fillArc.(IIIIII)V"] = function(x, y, width, height, startAngle, arcAngle) {
+    Native["javax/microedition/lcdui/Graphics.fillArc.(IIIIII)V"] = function(addr, x, y, width, height, startAngle, arcAngle) {
         if (width <= 0 || height <= 0) {
             return;
         }
@@ -1222,7 +1222,7 @@ var currentlyFocusedTextEditor;
         }
     };
 
-    Native["javax/microedition/lcdui/Graphics.drawLine.(IIII)V"] = function(x1, y1, x2, y2) {
+    Native["javax/microedition/lcdui/Graphics.drawLine.(IIII)V"] = function(addr, x1, y1, x2, y2) {
         var c = getNative(this).getGraphicsContext();
 
         // If we're drawing a completely vertical line that is
@@ -1251,7 +1251,7 @@ var currentlyFocusedTextEditor;
     };
 
     Native["javax/microedition/lcdui/Graphics.drawRGB.([IIIIIIIZ)V"] =
-    function(rgbData, offset, scanlength, x, y, width, height, processAlpha) {
+    function(addr, rgbData, offset, scanlength, x, y, width, height, processAlpha) {
         tempContext.canvas.height = height;
         tempContext.canvas.width = width;
         var imageData = tempContext.createImageData(width, height);
@@ -1305,7 +1305,7 @@ var currentlyFocusedTextEditor;
     };
 
     Native["com/nokia/mid/ui/TextEditor.init.(Ljava/lang/String;IIII)V"] =
-    function(text, maxSize, constraints, width, height) {
+    function(addr, text, maxSize, constraints, width, height) {
         if (constraints !== 0) {
             console.warn("TextEditor.constraints not implemented");
         }
@@ -1328,7 +1328,7 @@ var currentlyFocusedTextEditor;
         }.bind(this));
     };
 
-    Native["com/nokia/mid/ui/CanvasItem.attachNativeImpl.()V"] = function() {
+    Native["com/nokia/mid/ui/CanvasItem.attachNativeImpl.()V"] = function(addr) {
         var textEditor = getNative(this);
         if (textEditor) {
             textEditor.attach();
@@ -1339,7 +1339,7 @@ var currentlyFocusedTextEditor;
         }
     };
 
-    Native["com/nokia/mid/ui/CanvasItem.detachNativeImpl.()V"] = function() {
+    Native["com/nokia/mid/ui/CanvasItem.detachNativeImpl.()V"] = function(addr) {
         var textEditor = getNative(this);
         if (textEditor) {
             this.caretPosition = textEditor.getSelectionStart();
@@ -1347,52 +1347,52 @@ var currentlyFocusedTextEditor;
         }
     };
 
-    Native["javax/microedition/lcdui/Display.setTitle.(Ljava/lang/String;)V"] = function(title) {
+    Native["javax/microedition/lcdui/Display.setTitle.(Ljava/lang/String;)V"] = function(addr, title) {
         document.getElementById("display_title").textContent = J2ME.fromJavaString(title);
     };
 
-    Native["com/nokia/mid/ui/CanvasItem.setSize.(II)V"] = function(width, height) {
+    Native["com/nokia/mid/ui/CanvasItem.setSize.(II)V"] = function(addr, width, height) {
         getNative(this).setSize(width, height);
     };
 
-    Native["com/nokia/mid/ui/CanvasItem.setVisible.(Z)V"] = function(visible) {
+    Native["com/nokia/mid/ui/CanvasItem.setVisible.(Z)V"] = function(addr, visible) {
         getNative(this).setVisible(visible ? true : false);
     };
 
-    Native["com/nokia/mid/ui/CanvasItem.getWidth.()I"] = function() {
+    Native["com/nokia/mid/ui/CanvasItem.getWidth.()I"] = function(addr) {
         return getNative(this).getWidth();
     };
 
-    Native["com/nokia/mid/ui/CanvasItem.getHeight.()I"] = function() {
+    Native["com/nokia/mid/ui/CanvasItem.getHeight.()I"] = function(addr) {
         return getNative(this).getHeight();
     };
 
-    Native["com/nokia/mid/ui/CanvasItem.setPosition0.(II)V"] = function(x, y) {
+    Native["com/nokia/mid/ui/CanvasItem.setPosition0.(II)V"] = function(addr, x, y) {
         getNative(this).setPosition(x, y);
     };
 
-    Native["com/nokia/mid/ui/CanvasItem.getPositionX.()I"] = function() {
+    Native["com/nokia/mid/ui/CanvasItem.getPositionX.()I"] = function(addr) {
         return getNative(this).getLeft();
     };
 
-    Native["com/nokia/mid/ui/CanvasItem.getPositionY.()I"] = function() {
+    Native["com/nokia/mid/ui/CanvasItem.getPositionY.()I"] = function(addr) {
         return getNative(this).getTop();
     };
 
-    Native["com/nokia/mid/ui/CanvasItem.isVisible.()Z"] = function() {
+    Native["com/nokia/mid/ui/CanvasItem.isVisible.()Z"] = function(addr) {
         return getNative(this).visible ? 1 : 0;
     };
 
-    Native["com/nokia/mid/ui/TextEditor.setConstraints.(I)V"] = function(constraints) {
+    Native["com/nokia/mid/ui/TextEditor.setConstraints.(I)V"] = function(addr, constraints) {
         var textEditor = getNative(this);
         setNative(this, TextEditorProvider.getEditor(constraints, textEditor, textEditor.id));
     };
 
-    Native["com/nokia/mid/ui/TextEditor.getConstraints.()I"] = function() {
+    Native["com/nokia/mid/ui/TextEditor.getConstraints.()I"] = function(addr) {
         return getNative(this).constraints;
     };
 
-    Native["com/nokia/mid/ui/TextEditor.setFocus.(Z)V"] = function(shouldFocus) {
+    Native["com/nokia/mid/ui/TextEditor.setFocus.(Z)V"] = function(addr, shouldFocus) {
         var textEditor = getNative(this);
         var promise;
         if (shouldFocus && (currentlyFocusedTextEditor !== textEditor)) {
@@ -1407,11 +1407,11 @@ var currentlyFocusedTextEditor;
         asyncImpl("V", promise);
     };
 
-    Native["com/nokia/mid/ui/TextEditor.hasFocus.()Z"] = function() {
+    Native["com/nokia/mid/ui/TextEditor.hasFocus.()Z"] = function(addr) {
         return (getNative(this) === currentlyFocusedTextEditor) ? 1 : 0;
     };
 
-    Native["com/nokia/mid/ui/TextEditor.setCaret.(I)V"] = function(index) {
+    Native["com/nokia/mid/ui/TextEditor.setCaret.(I)V"] = function(addr, index) {
         var textEditor = getNative(this);
 
         if (index < 0 || index > textEditor.getContentSize()) {
@@ -1421,28 +1421,28 @@ var currentlyFocusedTextEditor;
         setTextEditorCaretPosition(this, index);
     };
 
-    Native["com/nokia/mid/ui/TextEditor.getCaretPosition.()I"] = function() {
+    Native["com/nokia/mid/ui/TextEditor.getCaretPosition.()I"] = function(addr) {
         return getTextEditorCaretPosition(this);
     };
 
-    Native["com/nokia/mid/ui/TextEditor.getBackgroundColor.()I"] = function() {
+    Native["com/nokia/mid/ui/TextEditor.getBackgroundColor.()I"] = function(addr) {
         return getNative(this).getBackgroundColor();
     };
-    Native["com/nokia/mid/ui/TextEditor.getForegroundColor.()I"] = function() {
+    Native["com/nokia/mid/ui/TextEditor.getForegroundColor.()I"] = function(addr) {
         return getNative(this).getForegroundColor();
     };
-    Native["com/nokia/mid/ui/TextEditor.setBackgroundColor.(I)V"] = function(backgroundColor) {
+    Native["com/nokia/mid/ui/TextEditor.setBackgroundColor.(I)V"] = function(addr, backgroundColor) {
         getNative(this).setBackgroundColor(backgroundColor);
     };
-    Native["com/nokia/mid/ui/TextEditor.setForegroundColor.(I)V"] = function(foregroundColor) {
+    Native["com/nokia/mid/ui/TextEditor.setForegroundColor.(I)V"] = function(addr, foregroundColor) {
         getNative(this).setForegroundColor(foregroundColor);
     };
 
-    Native["com/nokia/mid/ui/TextEditor.getContent.()Ljava/lang/String;"] = function() {
+    Native["com/nokia/mid/ui/TextEditor.getContent.()Ljava/lang/String;"] = function(addr) {
         return J2ME.newString(getNative(this).getContent());
     };
 
-    Native["com/nokia/mid/ui/TextEditor.setContent.(Ljava/lang/String;)V"] = function(jStr) {
+    Native["com/nokia/mid/ui/TextEditor.setContent.(Ljava/lang/String;)V"] = function(addr, jStr) {
         var textEditor = getNative(this);
         var str = J2ME.fromJavaString(jStr);
         textEditor.setContent(str);
@@ -1452,11 +1452,11 @@ var currentlyFocusedTextEditor;
     addUnimplementedNative("com/nokia/mid/ui/TextEditor.getLineMarginHeight.()I", 0);
     addUnimplementedNative("com/nokia/mid/ui/TextEditor.getVisibleContentPosition.()I", 0);
 
-    Native["com/nokia/mid/ui/TextEditor.getContentHeight.()I"] = function() {
+    Native["com/nokia/mid/ui/TextEditor.getContentHeight.()I"] = function(addr) {
         return getNative(this).getContentHeight();
     };
 
-    Native["com/nokia/mid/ui/TextEditor.insert.(Ljava/lang/String;I)V"] = function(jStr, pos) {
+    Native["com/nokia/mid/ui/TextEditor.insert.(Ljava/lang/String;I)V"] = function(addr, jStr, pos) {
         var textEditor = getNative(this);
         var str = J2ME.fromJavaString(jStr);
         var len = util.toCodePointArray(str).length;
@@ -1467,7 +1467,7 @@ var currentlyFocusedTextEditor;
         setTextEditorCaretPosition(this, pos + len);
     };
 
-    Native["com/nokia/mid/ui/TextEditor.delete.(II)V"] = function(offset, length) {
+    Native["com/nokia/mid/ui/TextEditor.delete.(II)V"] = function(addr, offset, length) {
         var textEditor = getNative(this);
         var old = textEditor.getContent();
 
@@ -1480,11 +1480,11 @@ var currentlyFocusedTextEditor;
         setTextEditorCaretPosition(this, offset);
     };
 
-    Native["com/nokia/mid/ui/TextEditor.getMaxSize.()I"] = function() {
+    Native["com/nokia/mid/ui/TextEditor.getMaxSize.()I"] = function(addr) {
         return parseInt(getNative(this).getAttribute("maxlength"));
     };
 
-    Native["com/nokia/mid/ui/TextEditor.setMaxSize.(I)I"] = function(maxSize) {
+    Native["com/nokia/mid/ui/TextEditor.setMaxSize.(I)I"] = function(addr, maxSize) {
         var textEditor = getNative(this);
         if (textEditor.getContentSize() > maxSize) {
             var oldCaretPosition = getTextEditorCaretPosition(this);
@@ -1504,17 +1504,17 @@ var currentlyFocusedTextEditor;
         return maxSize;
     };
 
-    Native["com/nokia/mid/ui/TextEditor.size.()I"] = function() {
+    Native["com/nokia/mid/ui/TextEditor.size.()I"] = function(addr) {
         return getNative(this).getContentSize();
     };
 
-    Native["com/nokia/mid/ui/TextEditor.setFont.(Ljavax/microedition/lcdui/Font;)V"] = function(font) {
+    Native["com/nokia/mid/ui/TextEditor.setFont.(Ljavax/microedition/lcdui/Font;)V"] = function(addr, font) {
         this.font = font._address;
         var textEditor = getNative(this);
         textEditor.setFont(font);
     };
 
-    Native["com/nokia/mid/ui/TextEditorThread.getNextDirtyEditor.()Lcom/nokia/mid/ui/TextEditor;"] = function() {
+    Native["com/nokia/mid/ui/TextEditorThread.getNextDirtyEditor.()Lcom/nokia/mid/ui/TextEditor;"] = function(addr) {
         if (dirtyEditors.length) {
             return dirtyEditors.shift();
         }
@@ -1530,10 +1530,10 @@ var currentlyFocusedTextEditor;
     var nextMidpDisplayableId = 1;
     var PLAIN = 0;
 
-    Native["javax/microedition/lcdui/DisplayableLFImpl.initialize0.()V"] = function() {
+    Native["javax/microedition/lcdui/DisplayableLFImpl.initialize0.()V"] = function(addr) {
     };
 
-    Native["javax/microedition/lcdui/DisplayableLFImpl.deleteNativeResource0.(I)V"] = function(nativeId) {
+    Native["javax/microedition/lcdui/DisplayableLFImpl.deleteNativeResource0.(I)V"] = function(addr, nativeId) {
         var el = document.getElementById("displayable-" + nativeId);
         if (el) {
             el.parentElement.removeChild(el);
@@ -1545,17 +1545,17 @@ var currentlyFocusedTextEditor;
         }
     };
 
-    Native["javax/microedition/lcdui/DisplayableLFImpl.setTitle0.(ILjava/lang/String;)V"] = function(nativeId, title) {
+    Native["javax/microedition/lcdui/DisplayableLFImpl.setTitle0.(ILjava/lang/String;)V"] = function(addr, nativeId, title) {
         document.getElementById("display_title").textContent = J2ME.fromJavaString(title);
     };
 
-    Native["javax/microedition/lcdui/CanvasLFImpl.createNativeResource0.(Ljava/lang/String;Ljava/lang/String;)I"] = function(title, ticker) {
+    Native["javax/microedition/lcdui/CanvasLFImpl.createNativeResource0.(Ljava/lang/String;Ljava/lang/String;)I"] = function(addr, title, ticker) {
         console.warn("javax/microedition/lcdui/CanvasLFImpl.createNativeResource0.(Ljava/lang/String;Ljava/lang/String;)I not implemented");
         curDisplayableId = nextMidpDisplayableId++;
         return curDisplayableId;
     };
 
-    Native["javax/microedition/lcdui/AlertLFImpl.createNativeResource0.(Ljava/lang/String;Ljava/lang/String;I)I"] = function(title, ticker, type) {
+    Native["javax/microedition/lcdui/AlertLFImpl.createNativeResource0.(Ljava/lang/String;Ljava/lang/String;I)I"] = function(addr, title, ticker, type) {
         var nativeId = nextMidpDisplayableId++;
         var alertTemplateNode = document.getElementById("lcdui-alert");
         var el = alertTemplateNode.cloneNode(true);
@@ -1567,14 +1567,14 @@ var currentlyFocusedTextEditor;
     };
 
     Native["javax/microedition/lcdui/AlertLFImpl.setNativeContents0.(ILjavax/microedition/lcdui/ImageData;[ILjava/lang/String;)Z"] =
-    function(nativeId, imgId, indicatorBounds, text) {
+    function(addr, nativeId, imgId, indicatorBounds, text) {
         var el = document.getElementById("displayable-" + nativeId);
         el.querySelector('p.text').textContent = J2ME.fromJavaString(text);
 
         return 0;
     };
 
-    Native["javax/microedition/lcdui/AlertLFImpl.showNativeResource0.(I)V"] = function(nativeId) {
+    Native["javax/microedition/lcdui/AlertLFImpl.showNativeResource0.(I)V"] = function(addr, nativeId) {
         var el = document.getElementById("displayable-" + nativeId);
         el.style.display = 'block';
         el.classList.add('visible');
@@ -1589,7 +1589,7 @@ var currentlyFocusedTextEditor;
     var CONTINUOUS_RUNNING = 2;
 
     Native["javax/microedition/lcdui/GaugeLFImpl.createNativeResource0.(ILjava/lang/String;IZII)I"] =
-    function(ownerId, label, layout, interactive, maxValue, initialValue) {
+    function(addr, ownerId, label, layout, interactive, maxValue, initialValue) {
         if (label !== null) {
             console.error("Expected null label");
         }
@@ -1617,13 +1617,13 @@ var currentlyFocusedTextEditor;
     };
 
     Native["javax/microedition/lcdui/TextFieldLFImpl.createNativeResource0.(ILjava/lang/String;ILcom/sun/midp/lcdui/DynamicCharacterArray;ILjava/lang/String;)I"] =
-    function(ownerId, label, layout, buffer, constraints, initialInputMode) {
+    function(addr, ownerId, label, layout, buffer, constraints, initialInputMode) {
         console.warn("javax/microedition/lcdui/TextFieldLFImpl.createNativeResource0.(ILjava/lang/String;ILcom/sun/midp/lcdui/DynamicCharacterArray;ILjava/lang/String;)I not implemented");
         return nextMidpDisplayableId++;
     };
 
     Native["javax/microedition/lcdui/ImageItemLFImpl.createNativeResource0.(ILjava/lang/String;ILjavax/microedition/lcdui/ImageData;Ljava/lang/String;I)I"] =
-    function(ownerId, label, layout, imageData, altText, appearanceMode) {
+    function(addr, ownerId, label, layout, imageData, altText, appearanceMode) {
         console.warn("javax/microedition/lcdui/ImageItemLFImpl.createNativeResource0.(ILjava/lang/String;ILjavax/microedition/lcdui/ImageData;Ljava/lang/String;I)I not implemented");
         return nextMidpDisplayableId++;
     };
@@ -1644,19 +1644,19 @@ var currentlyFocusedTextEditor;
         function() { return nextMidpDisplayableId++ }
     );
 
-    Native["javax/microedition/lcdui/ItemLFImpl.setSize0.(III)V"] = function(nativeId, w, h) {
+    Native["javax/microedition/lcdui/ItemLFImpl.setSize0.(III)V"] = function(addr, nativeId, w, h) {
         console.warn("javax/microedition/lcdui/ItemLFImpl.setSize0.(III)V not implemented");
     };
 
-    Native["javax/microedition/lcdui/ItemLFImpl.setLocation0.(III)V"] = function(nativeId, x, y) {
+    Native["javax/microedition/lcdui/ItemLFImpl.setLocation0.(III)V"] = function(addr, nativeId, x, y) {
         console.warn("javax/microedition/lcdui/ItemLFImpl.setLocation0.(III)V not implemented");
     };
 
-    Native["javax/microedition/lcdui/ItemLFImpl.show0.(I)V"] = function(nativeId) {
+    Native["javax/microedition/lcdui/ItemLFImpl.show0.(I)V"] = function(addr, nativeId) {
         console.warn("javax/microedition/lcdui/ItemLFImpl.show0.(I)V not implemented");
     };
 
-    Native["javax/microedition/lcdui/ItemLFImpl.hide0.(I)V"] = function(nativeId) {
+    Native["javax/microedition/lcdui/ItemLFImpl.hide0.(I)V"] = function(addr, nativeId) {
         console.warn("javax/microedition/lcdui/ItemLFImpl.hide0.(I)V not implemented");
     };
 
@@ -1672,7 +1672,7 @@ var currentlyFocusedTextEditor;
     var STOP = 6;
 
     Native["javax/microedition/lcdui/NativeMenu.updateCommands.([Ljavax/microedition/lcdui/Command;I[Ljavax/microedition/lcdui/Command;I)V"] =
-    function(itemCommands, numItemCommands, commands, numCommands) {
+    function(addr, itemCommands, numItemCommands, commands, numCommands) {
         if (numItemCommands !== 0) {
             console.error("NativeMenu.updateCommands: item commands not yet supported");
         }

--- a/midp/localmsg.js
+++ b/midp/localmsg.js
@@ -1004,7 +1004,7 @@ NokiaActiveStandbyLocalMsgConnection.prototype.sendMessageToServer = function(da
   }
 }
 
-Native["com/nokia/mid/ui/lcdui/Indicator.setActive.(Z)V"] = function(active) {
+Native["com/nokia/mid/ui/lcdui/Indicator.setActive.(Z)V"] = function(addr, active) {
   NokiaActiveStandbyLocalMsgConnection.indicatorActive = active;
 
   if (!active && NokiaActiveStandbyLocalMsgConnection.pipeSender) {
@@ -1040,7 +1040,7 @@ function getNativeConnection(obj) {
     return nativeConnectionMap[obj._address];
 }
 
-Native["org/mozilla/io/LocalMsgConnection.init.(Ljava/lang/String;)V"] = function(jName) {
+Native["org/mozilla/io/LocalMsgConnection.init.(Ljava/lang/String;)V"] = function(addr, jName) {
     var name = J2ME.fromJavaString(jName);
 
     var info = {
@@ -1093,7 +1093,7 @@ Native["org/mozilla/io/LocalMsgConnection.init.(Ljava/lang/String;)V"] = functio
     connection.notifyConnection();
 };
 
-Native["org/mozilla/io/LocalMsgConnection.waitConnection.()V"] = function() {
+Native["org/mozilla/io/LocalMsgConnection.waitConnection.()V"] = function(addr) {
     var connection = getNativeConnection(this);
 
     if (connection.clientConnected) {
@@ -1103,7 +1103,7 @@ Native["org/mozilla/io/LocalMsgConnection.waitConnection.()V"] = function() {
     asyncImpl("V", connection.waitConnection());
 };
 
-Native["org/mozilla/io/LocalMsgConnection.sendData.([BII)V"] = function(data, offset, length) {
+Native["org/mozilla/io/LocalMsgConnection.sendData.([BII)V"] = function(addr, data, offset, length) {
     var connection = getNativeConnection(this);
     var info = getNative(this);
 
@@ -1119,7 +1119,7 @@ Native["org/mozilla/io/LocalMsgConnection.sendData.([BII)V"] = function(data, of
     }
 };
 
-Native["org/mozilla/io/LocalMsgConnection.receiveData.([B)I"] = function(data) {
+Native["org/mozilla/io/LocalMsgConnection.receiveData.([B)I"] = function(addr, data) {
     var connection = getNativeConnection(this);
     var info = getNative(this);
 

--- a/midp/location.js
+++ b/midp/location.js
@@ -63,14 +63,14 @@ LocationProvider.prototype.requestData = function() {
     }.bind(this));
 };
 
-Native["com/sun/j2me/location/PlatformLocationProvider.getListOfLocationProviders.()Ljava/lang/String;"] = function() {
+Native["com/sun/j2me/location/PlatformLocationProvider.getListOfLocationProviders.()Ljava/lang/String;"] = function(addr) {
     // If there are more than one providers, separate them by comma.
     return J2ME.newString(Location.PROVIDER_NAME);
 };
 
 addUnimplementedNative("com/sun/j2me/location/CriteriaImpl.initNativeClass.()V");
 
-Native["com/sun/j2me/location/PlatformLocationProvider.getBestProviderByCriteriaImpl.(Lcom/sun/j2me/location/CriteriaImpl;)Z"] = function(criteria) {
+Native["com/sun/j2me/location/PlatformLocationProvider.getBestProviderByCriteriaImpl.(Lcom/sun/j2me/location/CriteriaImpl;)Z"] = function(addr, criteria) {
     criteria.providerName = J2ME.newString(Location.PROVIDER_NAME);
     return 1;
 };
@@ -78,7 +78,7 @@ Native["com/sun/j2me/location/PlatformLocationProvider.getBestProviderByCriteria
 addUnimplementedNative("com/sun/j2me/location/LocationProviderInfo.initNativeClass.()V");
 addUnimplementedNative("com/sun/j2me/location/LocationInfo.initNativeClass.()V");
 
-Native["com/sun/j2me/location/PlatformLocationProvider.open.(Ljava/lang/String;)I"] = function(name) {
+Native["com/sun/j2me/location/PlatformLocationProvider.open.(Ljava/lang/String;)I"] = function(addr, name) {
     var provider = new LocationProvider();
     provider.start();
     var id = Location.Providers.nextId;
@@ -87,24 +87,24 @@ Native["com/sun/j2me/location/PlatformLocationProvider.open.(Ljava/lang/String;)
     return id;
 };
 
-Native["com/sun/j2me/location/PlatformLocationProvider.resetImpl.(I)V"] = function(providerId) {
+Native["com/sun/j2me/location/PlatformLocationProvider.resetImpl.(I)V"] = function(addr, providerId) {
     var provider = Location.Providers[providerId];
     provider.stop();
     Location.Providers[providerId] = null;
 };
 
-Native["com/sun/j2me/location/PlatformLocationProvider.getCriteria.(Ljava/lang/String;Lcom/sun/j2me/location/LocationProviderInfo;)Z"] = function(name, criteria) {
+Native["com/sun/j2me/location/PlatformLocationProvider.getCriteria.(Ljava/lang/String;Lcom/sun/j2me/location/LocationProviderInfo;)Z"] = function(addr, name, criteria) {
     criteria.canReportAltitude = 1;
     criteria.canReportSpeedCource = 1;
     criteria.averageResponseTime = 10000;
     return 1;
 };
 
-Native["com/sun/j2me/location/PlatformLocationProvider.setUpdateIntervalImpl.(II)V"] = function(providerId, interval) {
+Native["com/sun/j2me/location/PlatformLocationProvider.setUpdateIntervalImpl.(II)V"] = function(addr, providerId, interval) {
     console.warn("com/sun/j2me/location/PlatformLocationProvider.setUpdateIntervalImpl.(II)V not implemented");
 };
 
-Native["com/sun/j2me/location/PlatformLocationProvider.getLastLocationImpl.(ILcom/sun/j2me/location/LocationInfo;)Z"] = function(providerId, locationInfo) {
+Native["com/sun/j2me/location/PlatformLocationProvider.getLastLocationImpl.(ILcom/sun/j2me/location/LocationInfo;)Z"] = function(addr, providerId, locationInfo) {
     var provider = Location.Providers[providerId];
     var pos = provider.position;
     locationInfo.isValid = 1;
@@ -120,12 +120,12 @@ Native["com/sun/j2me/location/PlatformLocationProvider.getLastLocationImpl.(ILco
     return 1;
 };
 
-Native["com/sun/j2me/location/PlatformLocationProvider.getStateImpl.(I)I"] = function(providerId) {
+Native["com/sun/j2me/location/PlatformLocationProvider.getStateImpl.(I)I"] = function(addr, providerId) {
     var provider = Location.Providers[providerId];
     return provider.state;
 };
 
-Native["com/sun/j2me/location/PlatformLocationProvider.waitForNewLocation.(IJ)Z"] = function(providerId, timeoutLow, timeoutHigh) {
+Native["com/sun/j2me/location/PlatformLocationProvider.waitForNewLocation.(IJ)Z"] = function(addr, providerId, timeoutLow, timeoutHigh) {
     asyncImpl("Z", new Promise(function(resolve, reject) {
         var provider = Location.Providers[providerId];
         provider.requestData().then(resolve.bind(null, 1));
@@ -133,7 +133,7 @@ Native["com/sun/j2me/location/PlatformLocationProvider.waitForNewLocation.(IJ)Z"
     }));
 };
 
-Native["com/sun/j2me/location/PlatformLocationProvider.receiveNewLocationImpl.(IJ)Z"] = function(providerId, timestampLow, timestampHigh) {
+Native["com/sun/j2me/location/PlatformLocationProvider.receiveNewLocationImpl.(IJ)Z"] = function(addr, providerId, timestampLow, timestampHigh) {
     var provider = Location.Providers[providerId];
     var result = Math.abs(J2ME.longToNumber(timestampLow, timestampHigh) - provider.position.timestamp) < 10000;
     return result ? 1 : 0;

--- a/midp/media.js
+++ b/midp/media.js
@@ -133,7 +133,7 @@ Media.convert3gpToAmr = function(inBuffer) {
     return outBuffer.subarray(0, outOffset);
 };
 
-Native["com/sun/mmedia/DefaultConfiguration.nListContentTypesOpen.(Ljava/lang/String;)I"] = function(jProtocol) {
+Native["com/sun/mmedia/DefaultConfiguration.nListContentTypesOpen.(Ljava/lang/String;)I"] = function(addr, jProtocol) {
     var protocol = J2ME.fromJavaString(jProtocol);
     var types = [];
     if (protocol) {
@@ -157,7 +157,7 @@ Native["com/sun/mmedia/DefaultConfiguration.nListContentTypesOpen.(Ljava/lang/St
     return Media.ListCache.create(types);
 };
 
-Native["com/sun/mmedia/DefaultConfiguration.nListContentTypesNext.(I)Ljava/lang/String;"] = function(hdlr) {
+Native["com/sun/mmedia/DefaultConfiguration.nListContentTypesNext.(I)Ljava/lang/String;"] = function(addr, hdlr) {
     var cached = Media.ListCache.get(hdlr);
     if (!cached) {
         console.error("Invalid hdlr: " + hdlr);
@@ -167,11 +167,11 @@ Native["com/sun/mmedia/DefaultConfiguration.nListContentTypesNext.(I)Ljava/lang/
     return s ? J2ME.newString(s) : null;
 };
 
-Native["com/sun/mmedia/DefaultConfiguration.nListContentTypesClose.(I)V"] = function(hdlr) {
+Native["com/sun/mmedia/DefaultConfiguration.nListContentTypesClose.(I)V"] = function(addr, hdlr) {
     Media.ListCache.remove(hdlr);
 };
 
-Native["com/sun/mmedia/DefaultConfiguration.nListProtocolsOpen.(Ljava/lang/String;)I"] = function(jMime) {
+Native["com/sun/mmedia/DefaultConfiguration.nListProtocolsOpen.(Ljava/lang/String;)I"] = function(addr, jMime) {
     var mime = J2ME.fromJavaString(jMime);
     var protocols = [];
     for (var protocol in Media.ContentTypes) {
@@ -185,7 +185,7 @@ Native["com/sun/mmedia/DefaultConfiguration.nListProtocolsOpen.(Ljava/lang/Strin
     return Media.ListCache.create(protocols);
 };
 
-Native["com/sun/mmedia/DefaultConfiguration.nListProtocolsNext.(I)Ljava/lang/String;"] = function(hdlr) {
+Native["com/sun/mmedia/DefaultConfiguration.nListProtocolsNext.(I)Ljava/lang/String;"] = function(addr, hdlr) {
     var cached = Media.ListCache.get(hdlr);
     if (!cached) {
         console.error("Invalid hdlr: " + hdlr);
@@ -195,7 +195,7 @@ Native["com/sun/mmedia/DefaultConfiguration.nListProtocolsNext.(I)Ljava/lang/Str
     return s ? J2ME.newString(s) : null;
 };
 
-Native["com/sun/mmedia/DefaultConfiguration.nListProtocolsClose.(I)V"] = function(hdlr) {
+Native["com/sun/mmedia/DefaultConfiguration.nListProtocolsClose.(I)V"] = function(addr, hdlr) {
     Media.ListCache.remove(hdlr);
 };
 
@@ -1014,7 +1014,7 @@ AudioRecorder.prototype.close = function() {
     }.bind(this));
 };
 
-Native["com/sun/mmedia/PlayerImpl.nInit.(IILjava/lang/String;)I"] = function(appId, pId, jURI) {
+Native["com/sun/mmedia/PlayerImpl.nInit.(IILjava/lang/String;)I"] = function(addr, appId, pId, jURI) {
     var url = J2ME.fromJavaString(jURI);
     var id = pId + (appId << 15);
     Media.PlayerCache[id] = new PlayerContainer(url, pId);
@@ -1024,7 +1024,7 @@ Native["com/sun/mmedia/PlayerImpl.nInit.(IILjava/lang/String;)I"] = function(app
 /**
  * @return 0 - failed; 1 - succeeded.
  */
-Native["com/sun/mmedia/PlayerImpl.nTerm.(I)I"] = function(handle) {
+Native["com/sun/mmedia/PlayerImpl.nTerm.(I)I"] = function(addr, handle) {
     var player = Media.PlayerCache[handle];
     if (!player) {
         return 1;
@@ -1034,37 +1034,37 @@ Native["com/sun/mmedia/PlayerImpl.nTerm.(I)I"] = function(handle) {
     return 1;
 };
 
-Native["com/sun/mmedia/PlayerImpl.nGetMediaFormat.(I)Ljava/lang/String;"] = function(handle) {
+Native["com/sun/mmedia/PlayerImpl.nGetMediaFormat.(I)Ljava/lang/String;"] = function(addr, handle) {
     var player = Media.PlayerCache[handle];
     player.mediaFormat = player.getMediaFormat();
     return J2ME.newString(player.mediaFormat);
 };
 
-Native["com/sun/mmedia/DirectPlayer.nGetContentType.(I)Ljava/lang/String;"] = function(handle) {
+Native["com/sun/mmedia/DirectPlayer.nGetContentType.(I)Ljava/lang/String;"] = function(addr, handle) {
     return J2ME.newString(Media.PlayerCache[handle].getContentType());
 };
 
-Native["com/sun/mmedia/PlayerImpl.nIsHandledByDevice.(I)Z"] = function(handle) {
+Native["com/sun/mmedia/PlayerImpl.nIsHandledByDevice.(I)Z"] = function(addr, handle) {
     return Media.PlayerCache[handle].isHandledByDevice() ? 1 : 0;
 };
 
-Native["com/sun/mmedia/PlayerImpl.nRealize.(ILjava/lang/String;)Z"] = function(handle, jMime) {
+Native["com/sun/mmedia/PlayerImpl.nRealize.(ILjava/lang/String;)Z"] = function(addr, handle, jMime) {
     var mime = J2ME.fromJavaString(jMime);
     var player = Media.PlayerCache[handle];
     asyncImpl("Z", player.realize(mime));
 };
 
-Native["com/sun/mmedia/MediaDownload.nGetJavaBufferSize.(I)I"] = function(handle) {
+Native["com/sun/mmedia/MediaDownload.nGetJavaBufferSize.(I)I"] = function(addr, handle) {
     var player = Media.PlayerCache[handle];
     return player.getBufferSize();
 };
 
-Native["com/sun/mmedia/MediaDownload.nGetFirstPacketSize.(I)I"] = function(handle) {
+Native["com/sun/mmedia/MediaDownload.nGetFirstPacketSize.(I)I"] = function(addr, handle) {
     var player = Media.PlayerCache[handle];
     return player.getBufferSize() >>> 1;
 };
 
-Native["com/sun/mmedia/MediaDownload.nBuffering.(I[BII)I"] = function(handle, buffer, offset, size) {
+Native["com/sun/mmedia/MediaDownload.nBuffering.(I[BII)I"] = function(addr, handle, buffer, offset, size) {
     var player = Media.PlayerCache[handle];
     var bufferSize = player.getBufferSize();
 
@@ -1079,80 +1079,80 @@ Native["com/sun/mmedia/MediaDownload.nBuffering.(I[BII)I"] = function(handle, bu
     return bufferSize >>> 1;
 };
 
-Native["com/sun/mmedia/MediaDownload.nNeedMoreDataImmediatelly.(I)Z"] = function(handle) {
+Native["com/sun/mmedia/MediaDownload.nNeedMoreDataImmediatelly.(I)Z"] = function(addr, handle) {
     console.warn("com/sun/mmedia/MediaDownload.nNeedMoreDataImmediatelly.(I)Z not implemented");
     return 1;
 };
 
-Native["com/sun/mmedia/MediaDownload.nSetWholeContentSize.(IJ)V"] = function(handle, contentSizeLow, contentSizeHigh) {
+Native["com/sun/mmedia/MediaDownload.nSetWholeContentSize.(IJ)V"] = function(addr, handle, contentSizeLow, contentSizeHigh) {
     var player = Media.PlayerCache[handle];
     player.wholeContentSize = J2ME.longToNumber(contentSizeLow, contentSizeHigh);
 };
 
-Native["com/sun/mmedia/DirectPlayer.nIsToneControlSupported.(I)Z"] = function(handle) {
+Native["com/sun/mmedia/DirectPlayer.nIsToneControlSupported.(I)Z"] = function(addr, handle) {
     console.info("To support ToneControl, implement com.sun.mmedia.DirectTone.");
     return 0;
 };
 
-Native["com/sun/mmedia/DirectPlayer.nIsMIDIControlSupported.(I)Z"] = function(handle) {
+Native["com/sun/mmedia/DirectPlayer.nIsMIDIControlSupported.(I)Z"] = function(addr, handle) {
     console.info("To support MIDIControl, implement com.sun.mmedia.DirectMIDI.");
     return 0;
 };
 
-Native["com/sun/mmedia/DirectPlayer.nIsVideoControlSupported.(I)Z"] = function(handle) {
+Native["com/sun/mmedia/DirectPlayer.nIsVideoControlSupported.(I)Z"] = function(addr, handle) {
     return Media.PlayerCache[handle].isVideoControlSupported() ? 1 : 0;
 };
 
-Native["com/sun/mmedia/DirectPlayer.nIsVolumeControlSupported.(I)Z"] = function(handle) {
+Native["com/sun/mmedia/DirectPlayer.nIsVolumeControlSupported.(I)Z"] = function(addr, handle) {
     var player = Media.PlayerCache[handle];
     return player.isVolumeControlSupported() ? 1 : 0;
 };
 
-Native["com/sun/mmedia/DirectPlayer.nIsNeedBuffering.(I)Z"] = function(handle) {
+Native["com/sun/mmedia/DirectPlayer.nIsNeedBuffering.(I)Z"] = function(addr, handle) {
     var player = Media.PlayerCache[handle];
     console.warn("com/sun/mmedia/DirectPlayer.nIsNeedBuffering.(I)Z not implemented.");
     return 0;
 };
 
-Native["com/sun/mmedia/DirectPlayer.nPcmAudioPlayback.(I)Z"] = function(handle) {
+Native["com/sun/mmedia/DirectPlayer.nPcmAudioPlayback.(I)Z"] = function(addr, handle) {
     var player = Media.PlayerCache[handle];
     console.warn("com/sun/mmedia/DirectPlayer.nPcmAudioPlayback.(I)Z not implemented.");
     return 0;
 };
 
 // Device is available?
-Native["com/sun/mmedia/DirectPlayer.nAcquireDevice.(I)Z"] = function(handle) {
+Native["com/sun/mmedia/DirectPlayer.nAcquireDevice.(I)Z"] = function(addr, handle) {
     var player = Media.PlayerCache[handle];
     console.warn("com/sun/mmedia/DirectPlayer.nAcquireDevice.(I)Z not implemented.");
     return 1;
 };
 
 // Relase device reference
-Native["com/sun/mmedia/DirectPlayer.nReleaseDevice.(I)V"] = function(handle) {
+Native["com/sun/mmedia/DirectPlayer.nReleaseDevice.(I)V"] = function(addr, handle) {
     var player = Media.PlayerCache[handle];
     console.warn("com/sun/mmedia/DirectPlayer.nReleaseDevice.(I)V not implemented.");
 };
 
-Native["com/sun/mmedia/DirectPlayer.nSwitchToForeground.(II)Z"] = function(handle, options) {
+Native["com/sun/mmedia/DirectPlayer.nSwitchToForeground.(II)Z"] = function(addr, handle, options) {
     var player = Media.PlayerCache[handle];
     console.warn("com/sun/mmedia/DirectPlayer.nSwitchToForeground.(II)Z not implemented. ");
     return 1;
 };
 
-Native["com/sun/mmedia/DirectPlayer.nSwitchToBackground.(II)Z"] = function(handle, options) {
+Native["com/sun/mmedia/DirectPlayer.nSwitchToBackground.(II)Z"] = function(addr, handle, options) {
     var player = Media.PlayerCache[handle];
     console.warn("com/sun/mmedia/DirectPlayer.nSwitchToBackground.(II)Z not implemented. ");
     return 1;
 };
 
 // Start Prefetch of Native Player
-Native["com/sun/mmedia/DirectPlayer.nPrefetch.(I)Z"] = function(handle) {
+Native["com/sun/mmedia/DirectPlayer.nPrefetch.(I)Z"] = function(addr, handle) {
     var player = Media.PlayerCache[handle];
     console.warn("com/sun/mmedia/DirectPlayer.nPrefetch.(I)Z not implemented.");
     return 1;
 };
 
-Native["com/sun/mmedia/DirectPlayer.nGetMediaTime.(I)I"] = function(handle) {
+Native["com/sun/mmedia/DirectPlayer.nGetMediaTime.(I)I"] = function(addr, handle) {
     var player = Media.PlayerCache[handle];
     var mediaTime = player.getMediaTime();
     if (mediaTime instanceof Promise) {
@@ -1162,65 +1162,65 @@ Native["com/sun/mmedia/DirectPlayer.nGetMediaTime.(I)I"] = function(handle) {
     }
 };
 
-Native["com/sun/mmedia/DirectPlayer.nSetMediaTime.(IJ)I"] = function(handle, msLow, msHigh) {
+Native["com/sun/mmedia/DirectPlayer.nSetMediaTime.(IJ)I"] = function(addr, handle, msLow, msHigh) {
     var container = Media.PlayerCache[handle];
     return container.player.setMediaTime(J2ME.longToNumber(msLow, msHigh));
 };
 
-Native["com/sun/mmedia/DirectPlayer.nStart.(I)Z"] = function(handle) {
+Native["com/sun/mmedia/DirectPlayer.nStart.(I)Z"] = function(addr, handle) {
     var player = Media.PlayerCache[handle];
     player.start();
     return 1;
 };
 
-Native["com/sun/mmedia/DirectPlayer.nStop.(I)Z"] = function(handle) {
+Native["com/sun/mmedia/DirectPlayer.nStop.(I)Z"] = function(addr, handle) {
     var player = Media.PlayerCache[handle];
     player.close();
     return 1;
 };
 
-Native["com/sun/mmedia/DirectPlayer.nTerm.(I)I"] = function(handle) {
+Native["com/sun/mmedia/DirectPlayer.nTerm.(I)I"] = function(addr, handle) {
     var player = Media.PlayerCache[handle];
     player.close();
     delete Media.PlayerCache[handle];
     return 1;
 };
 
-Native["com/sun/mmedia/DirectPlayer.nPause.(I)Z"] = function(handle) {
+Native["com/sun/mmedia/DirectPlayer.nPause.(I)Z"] = function(addr, handle) {
     var player = Media.PlayerCache[handle];
     player.pause();
     return 1;
 };
 
-Native["com/sun/mmedia/DirectPlayer.nResume.(I)Z"] = function(handle) {
+Native["com/sun/mmedia/DirectPlayer.nResume.(I)Z"] = function(addr, handle) {
     var player = Media.PlayerCache[handle];
     player.resume();
     return 1;
 };
 
-Native["com/sun/mmedia/DirectPlayer.nGetWidth.(I)I"] = function(handle) {
+Native["com/sun/mmedia/DirectPlayer.nGetWidth.(I)I"] = function(addr, handle) {
     return Media.PlayerCache[handle].getWidth();
 };
 
-Native["com/sun/mmedia/DirectPlayer.nGetHeight.(I)I"] = function(handle) {
+Native["com/sun/mmedia/DirectPlayer.nGetHeight.(I)I"] = function(addr, handle) {
     return Media.PlayerCache[handle].getHeight();
 };
 
-Native["com/sun/mmedia/DirectPlayer.nSetLocation.(IIIII)Z"] = function(handle, x, y, w, h) {
+Native["com/sun/mmedia/DirectPlayer.nSetLocation.(IIIII)Z"] = function(addr, handle, x, y, w, h) {
     Media.PlayerCache[handle].setLocation(x, y, w, h);
     return 1;
 };
 
-Native["com/sun/mmedia/DirectPlayer.nSetVisible.(IZ)Z"] = function(handle, visible) {
+Native["com/sun/mmedia/DirectPlayer.nSetVisible.(IZ)Z"] = function(addr, handle, visible) {
     Media.PlayerCache[handle].setVisible(visible);
     return 1;
 };
 
-Native["com/sun/mmedia/DirectPlayer.nIsRecordControlSupported.(I)Z"] = function(handle) {
+Native["com/sun/mmedia/DirectPlayer.nIsRecordControlSupported.(I)Z"] = function(addr, handle) {
     return !!(Media.PlayerCache[handle] && Media.PlayerCache[handle].audioRecorder) ? 1 : 0;
 };
 
-Native["com/sun/mmedia/DirectPlayer.nGetDuration.(I)I"] = function(handle) {
+Native["com/sun/mmedia/DirectPlayer.nGetDuration.(I)I"] = function(addr, handle) {
     var duration = Media.PlayerCache[handle].getDuration();
     if (duration instanceof Promise) {
         asyncImpl("I", duration);
@@ -1229,35 +1229,35 @@ Native["com/sun/mmedia/DirectPlayer.nGetDuration.(I)I"] = function(handle) {
     }
 };
 
-Native["com/sun/mmedia/DirectRecord.nSetLocator.(ILjava/lang/String;)I"] = function(handle, locator) {
+Native["com/sun/mmedia/DirectRecord.nSetLocator.(ILjava/lang/String;)I"] = function(addr, handle, locator) {
     // Let the DirectRecord class handle writing to files / uploading via HTTP
     return 0;
 };
 
-Native["com/sun/mmedia/DirectRecord.nGetRecordedSize.(I)I"] = function(handle) {
+Native["com/sun/mmedia/DirectRecord.nGetRecordedSize.(I)I"] = function(addr, handle) {
     return Media.PlayerCache[handle].getRecordedSize();
 };
 
-Native["com/sun/mmedia/DirectRecord.nGetRecordedData.(III[B)I"] = function(handle, offset, size, buffer) {
+Native["com/sun/mmedia/DirectRecord.nGetRecordedData.(III[B)I"] = function(addr, handle, offset, size, buffer) {
     Media.PlayerCache[handle].getRecordedData(offset, size, buffer);
     return 1;
 };
 
-Native["com/sun/mmedia/DirectRecord.nCommit.(I)I"] = function(handle) {
+Native["com/sun/mmedia/DirectRecord.nCommit.(I)I"] = function(addr, handle) {
     // In DirectRecord.java, before nCommit, nPause or nStop is called,
     // which means all the recorded data has been fetched, so do nothing here.
     return 1;
 };
 
-Native["com/sun/mmedia/DirectRecord.nPause.(I)I"] = function(handle) {
+Native["com/sun/mmedia/DirectRecord.nPause.(I)I"] = function(addr, handle) {
     asyncImpl("I", Media.PlayerCache[handle].audioRecorder.pause());
 };
 
-Native["com/sun/mmedia/DirectRecord.nStop.(I)I"] = function(handle) {
+Native["com/sun/mmedia/DirectRecord.nStop.(I)I"] = function(addr, handle) {
     asyncImpl("I", Media.PlayerCache[handle].audioRecorder.stop());
 };
 
-Native["com/sun/mmedia/DirectRecord.nClose.(I)I"] = function(handle) {
+Native["com/sun/mmedia/DirectRecord.nClose.(I)I"] = function(addr, handle) {
     var player = Media.PlayerCache[handle];
 
     if (!player || !player.audioRecorder) {
@@ -1273,20 +1273,20 @@ Native["com/sun/mmedia/DirectRecord.nClose.(I)I"] = function(handle) {
     }));
 };
 
-Native["com/sun/mmedia/DirectRecord.nStart.(I)I"] = function(handle) {
+Native["com/sun/mmedia/DirectRecord.nStart.(I)I"] = function(addr, handle) {
     // In DirectRecord.java, nStart plays two roles: real start and resume.
     // Let's handle this on the other side of the DumbPipe.
     asyncImpl("I", Media.PlayerCache[handle].audioRecorder.start());
 };
 
-Native["com/sun/mmedia/DirectRecord.nGetRecordedType.(I)Ljava/lang/String;"] = function(handle) {
+Native["com/sun/mmedia/DirectRecord.nGetRecordedType.(I)Ljava/lang/String;"] = function(addr, handle) {
     return J2ME.newString(Media.PlayerCache[handle].audioRecorder.getContentType());
 };
 
 /**
  * @return the volume level between 0 and 100 if succeeded. Otherwise -1.
  */
-Native["com/sun/mmedia/DirectVolume.nGetVolume.(I)I"] = function(handle) {
+Native["com/sun/mmedia/DirectVolume.nGetVolume.(I)I"] = function(addr, handle) {
     var player = Media.PlayerCache[handle];
     return player.getVolume();
 };
@@ -1295,18 +1295,18 @@ Native["com/sun/mmedia/DirectVolume.nGetVolume.(I)I"] = function(handle) {
  * @param level The volume level between 0 and 100.
  * @return the volume level set between 0 and 100 if succeeded. Otherwise -1.
  */
-Native["com/sun/mmedia/DirectVolume.nSetVolume.(II)I"] = function(handle, level) {
+Native["com/sun/mmedia/DirectVolume.nSetVolume.(II)I"] = function(addr, handle, level) {
     var player = Media.PlayerCache[handle];
     player.setVolume(level);
     return level;
 };
 
-Native["com/sun/mmedia/DirectVolume.nIsMuted.(I)Z"] = function(handle) {
+Native["com/sun/mmedia/DirectVolume.nIsMuted.(I)Z"] = function(addr, handle) {
     var player = Media.PlayerCache[handle];
     return player.getMute() ? 1 : 0;
 };
 
-Native["com/sun/mmedia/DirectVolume.nSetMute.(IZ)Z"] = function(handle, mute) {
+Native["com/sun/mmedia/DirectVolume.nSetMute.(IZ)Z"] = function(addr, handle, mute) {
     var player = Media.PlayerCache[handle];
     player.setMute(mute);
     return 1;
@@ -1400,7 +1400,7 @@ TonePlayer.prototype.stopTone = function() {
     this.gainNode.gain.linearRampToValueAtTime(0, current + TonePlayer.FADE_TIME);
 };
 
-Native["com/sun/mmedia/NativeTonePlayer.nPlayTone.(IIII)Z"] = function(appId, note, duration, volume) {
+Native["com/sun/mmedia/NativeTonePlayer.nPlayTone.(IIII)Z"] = function(addr, appId, note, duration, volume) {
     if (!Media.TonePlayerCache[appId]) {
         Media.TonePlayerCache[appId] = new TonePlayer();
     }
@@ -1408,34 +1408,34 @@ Native["com/sun/mmedia/NativeTonePlayer.nPlayTone.(IIII)Z"] = function(appId, no
     return 1;
 };
 
-Native["com/sun/mmedia/NativeTonePlayer.nStopTone.(I)Z"] = function(appId) {
+Native["com/sun/mmedia/NativeTonePlayer.nStopTone.(I)Z"] = function(addr, appId) {
     Media.TonePlayerCache[appId].stopTone();
     return 1;
 };
 
-Native["com/sun/mmedia/DirectPlayer.nStartSnapshot.(ILjava/lang/String;)V"] = function(handle, imageType) {
+Native["com/sun/mmedia/DirectPlayer.nStartSnapshot.(ILjava/lang/String;)V"] = function(addr, handle, imageType) {
     Media.PlayerCache[handle].startSnapshot(J2ME.fromJavaString(imageType));
 };
 
-Native["com/sun/mmedia/DirectPlayer.nGetSnapshotData.(I)[B"] = function(handle) {
+Native["com/sun/mmedia/DirectPlayer.nGetSnapshotData.(I)[B"] = function(addr, handle) {
     return Media.PlayerCache[handle].getSnapshotData();
 };
 
-Native["com/sun/amms/GlobalMgrImpl.nCreatePeer.()I"] = function() {
+Native["com/sun/amms/GlobalMgrImpl.nCreatePeer.()I"] = function(addr) {
     console.warn("com/sun/amms/GlobalMgrImpl.nCreatePeer.()I not implemented.");
     return 1;
 };
 
-Native["com/sun/amms/GlobalMgrImpl.nGetControlPeer.([B)I"] = function(typeName) {
+Native["com/sun/amms/GlobalMgrImpl.nGetControlPeer.([B)I"] = function(addr, typeName) {
     console.warn("com/sun/amms/GlobalMgrImpl.nGetControlPeer.([B)I not implemented.");
     return 2;
 };
 
-Native["com/sun/amms/directcontrol/DirectVolumeControl.nSetMute.(Z)V"] = function(mute) {
+Native["com/sun/amms/directcontrol/DirectVolumeControl.nSetMute.(Z)V"] = function(addr, mute) {
     console.warn("com/sun/amms/directcontrol/DirectVolumeControl.nSetMute.(Z)V not implemented.");
 };
 
-Native["com/sun/amms/directcontrol/DirectVolumeControl.nGetLevel.()I"] = function() {
+Native["com/sun/amms/directcontrol/DirectVolumeControl.nGetLevel.()I"] = function(addr) {
     console.warn("com/sun/amms/directcontrol/DirectVolumeControl.nGetLevel.()I not implemented.");
     return 100;
 };

--- a/midp/midp.js
+++ b/midp/midp.js
@@ -123,15 +123,15 @@ var MIDP = (function() {
 
   var manifest = {};
 
-  Native["com/sun/midp/lcdui/DisplayDevice.setFullScreen0.(IIZ)V"] = function(hardwareId, displayId, mode) {
+  Native["com/sun/midp/lcdui/DisplayDevice.setFullScreen0.(IIZ)V"] = function(addr, hardwareId, displayId, mode) {
     FullscreenInfo.set(displayId, mode);
   };
 
-  Native["com/sun/midp/log/LoggingBase.report.(IILjava/lang/String;)V"] = function(severity, channelID, message) {
+  Native["com/sun/midp/log/LoggingBase.report.(IILjava/lang/String;)V"] = function(addr, severity, channelID, message) {
     console.info(J2ME.fromJavaString(message));
   };
 
-  Native["com/sun/midp/midlet/MIDletPeer.platformRequest.(Ljava/lang/String;)Z"] = function(request) {
+  Native["com/sun/midp/midlet/MIDletPeer.platformRequest.(Ljava/lang/String;)Z"] = function(addr, request) {
     request = J2ME.fromJavaString(request);
     if (request.startsWith("http://") || request.startsWith("https://")) {
       if (request.endsWith(".jad")) {
@@ -166,7 +166,7 @@ var MIDP = (function() {
     return 0;
   };
 
-  Native["com/sun/midp/main/CommandState.restoreCommandState.(Lcom/sun/midp/main/CommandState;)V"] = function(state) {
+  Native["com/sun/midp/main/CommandState.restoreCommandState.(Lcom/sun/midp/main/CommandState;)V"] = function(addr, state) {
     var suiteId = (config.midletClassName === "internal") ? -1 : 1;
     state.suiteId = suiteId;
     state.midletClassName = J2ME.newString(config.midletClassName);
@@ -176,7 +176,7 @@ var MIDP = (function() {
     state.arg2 = J2ME.newString((args.length > 2) ? args[2] : "");
   };
 
-  Native["com/sun/midp/main/MIDletSuiteUtils.getIsolateId.()I"] = function() {
+  Native["com/sun/midp/main/MIDletSuiteUtils.getIsolateId.()I"] = function(addr) {
     return $.ctx.runtime.isolateId;
   };
 
@@ -217,21 +217,21 @@ var MIDP = (function() {
     }
   })();
 
-  Native["com/sun/midp/main/MIDletSuiteUtils.registerAmsIsolateId.()V"] = function() {
+  Native["com/sun/midp/main/MIDletSuiteUtils.registerAmsIsolateId.()V"] = function(addr) {
     AMS.set($.ctx.runtime.isolateId);
   };
 
-  Native["com/sun/midp/main/MIDletSuiteUtils.getAmsIsolateId.()I"] = function() {
+  Native["com/sun/midp/main/MIDletSuiteUtils.getAmsIsolateId.()I"] = function(addr) {
     return AMS.get();
   };
 
-  Native["com/sun/midp/main/MIDletSuiteUtils.isAmsIsolate.()Z"] = function() {
+  Native["com/sun/midp/main/MIDletSuiteUtils.isAmsIsolate.()Z"] = function(addr) {
     return AMS.isAMSIsolate($.ctx.runtime.isolateId) ? 1 : 0;
   };
 
   // This function is called before a MIDlet is created (in MIDletStateListener::midletPreStart).
   var loadingMIDletPromisesResolved = false;
-  Native["com/sun/midp/main/MIDletSuiteUtils.vmBeginStartUp.(I)V"] = function(midletIsolateId) {
+  Native["com/sun/midp/main/MIDletSuiteUtils.vmBeginStartUp.(I)V"] = function(addr, midletIsolateId) {
     if (loadingMIDletPromisesResolved) {
       return;
     }
@@ -241,10 +241,10 @@ var MIDP = (function() {
     asyncImpl("V", Promise.all(loadingMIDletPromises));
   };
 
-  Native["com/sun/midp/main/MIDletSuiteUtils.vmEndStartUp.(I)V"] = function(midletIsolateId) {
+  Native["com/sun/midp/main/MIDletSuiteUtils.vmEndStartUp.(I)V"] = function(addr, midletIsolateId) {
   };
 
-  Native["com/sun/midp/main/Configuration.getProperty0.(Ljava/lang/String;)Ljava/lang/String;"] = function(key) {
+  Native["com/sun/midp/main/Configuration.getProperty0.(Ljava/lang/String;)Ljava/lang/String;"] = function(addr, key) {
     var value;
     switch (J2ME.fromJavaString(key)) {
       case "com.sun.midp.publickeystore.WebPublicKeyStore":
@@ -293,7 +293,7 @@ var MIDP = (function() {
     return J2ME.newString(value);
   };
 
-  Native["com/sun/midp/util/ResourceHandler.loadRomizedResource0.(Ljava/lang/String;)[B"] = function(file) {
+  Native["com/sun/midp/util/ResourceHandler.loadRomizedResource0.(Ljava/lang/String;)[B"] = function(addr, file) {
     var fileName = "assets/0/" + J2ME.fromJavaString(file).replace("_", ".").replace("_png", ".png").replace("_raw", ".raw");
     var data = JARStore.loadFile(fileName);
     if (!data) {
@@ -576,30 +576,30 @@ var MIDP = (function() {
     mouseDownInfo = null; // Clear the way for the next gesture.
   });
 
-  Native["com/sun/midp/midletsuite/MIDletSuiteStorage.suiteIdToString.(I)Ljava/lang/String;"] = function(id) {
+  Native["com/sun/midp/midletsuite/MIDletSuiteStorage.suiteIdToString.(I)Ljava/lang/String;"] = function(addr, id) {
     return J2ME.newString(id.toString());
   };
 
-  Native["com/sun/midp/midletsuite/MIDletSuiteStorage.getMidletSuiteStorageId.(I)I"] = function(suiteId) {
+  Native["com/sun/midp/midletsuite/MIDletSuiteStorage.getMidletSuiteStorageId.(I)I"] = function(addr, suiteId) {
     // We should be able to use the same storage ID for all MIDlet suites.
     return 0; // storageId
   };
 
-  Native["com/sun/midp/midletsuite/MIDletSuiteImpl.lockMIDletSuite.(IZ)V"] = function(id, lock) {
+  Native["com/sun/midp/midletsuite/MIDletSuiteImpl.lockMIDletSuite.(IZ)V"] = function(addr, id, lock) {
     console.warn("MIDletSuiteImpl.lockMIDletSuite.(IZ)V not implemented (" + id + ", " + lock + ")");
   };
 
-  Native["com/sun/midp/midletsuite/MIDletSuiteImpl.unlockMIDletSuite.(I)V"] = function(suiteId) {
+  Native["com/sun/midp/midletsuite/MIDletSuiteImpl.unlockMIDletSuite.(I)V"] = function(addr, suiteId) {
     console.warn("MIDletSuiteImpl.unlockMIDletSuite.(I)V not implemented (" + suiteId + ")");
   };
 
-  Native["com/sun/midp/midletsuite/InstallInfo.load.()V"] = function() {
+  Native["com/sun/midp/midletsuite/InstallInfo.load.()V"] = function(addr) {
     // The MIDlet has to be trusted for opening SSL connections using port 443.
     this.trusted = 1;
     console.warn("com/sun/midp/midletsuite/InstallInfo.load.()V incomplete");
   };
 
-  Native["com/sun/midp/midletsuite/SuiteProperties.load.()[Ljava/lang/String;"] = function() {
+  Native["com/sun/midp/midletsuite/SuiteProperties.load.()[Ljava/lang/String;"] = function(addr) {
     var keys = Object.keys(manifest);
     var arr = J2ME.newStringArray(keys.length * 2);
     var i = 0;
@@ -610,7 +610,7 @@ var MIDP = (function() {
     return arr;
   };
 
-  Native["javax/microedition/lcdui/SuiteImageCacheImpl.loadAndCreateImmutableImageDataFromCache0.(Ljavax/microedition/lcdui/ImageData;ILjava/lang/String;)Z"] = function(imageData, suiteId, fileName) {
+  Native["javax/microedition/lcdui/SuiteImageCacheImpl.loadAndCreateImmutableImageDataFromCache0.(Ljavax/microedition/lcdui/ImageData;ILjava/lang/String;)Z"] = function(addr, imageData, suiteId, fileName) {
     // We're not implementing the cache because looks like it isn't used much.
     // In a MIDlet I've been testing for a few minutes, there's been only one hit.
     return 0;
@@ -619,7 +619,7 @@ var MIDP = (function() {
   var interIsolateMutexes = [];
   var lastInterIsolateMutexID = -1;
 
-  Native["com/sun/midp/util/isolate/InterIsolateMutex.getID0.(Ljava/lang/String;)I"] = function(jName) {
+  Native["com/sun/midp/util/isolate/InterIsolateMutex.getID0.(Ljava/lang/String;)I"] = function(addr, jName) {
     var name = J2ME.fromJavaString(jName);
 
     var mutex;
@@ -642,7 +642,7 @@ var MIDP = (function() {
     return mutex.id;
   };
 
-  Native["com/sun/midp/util/isolate/InterIsolateMutex.lock0.(I)V"] = function(id) {
+  Native["com/sun/midp/util/isolate/InterIsolateMutex.lock0.(I)V"] = function(addr, id) {
     var ctx = $.ctx;
     var isolateId = $.ctx.runtime.isolateId;
 
@@ -677,7 +677,7 @@ var MIDP = (function() {
     }));
   };
 
-  Native["com/sun/midp/util/isolate/InterIsolateMutex.unlock0.(I)V"] = function(id) {
+  Native["com/sun/midp/util/isolate/InterIsolateMutex.unlock0.(I)V"] = function(addr, id) {
     var isolateId = $.ctx.runtime.isolateId;
     var mutex;
     for (var i = 0; i < interIsolateMutexes.length; i++) {
@@ -727,7 +727,7 @@ var MIDP = (function() {
   }
 
   var pendingMIDletUpdate = null;
-  Native["com/sun/cldc/isolate/Isolate.stop.(II)V"] = function(code, reason) {
+  Native["com/sun/cldc/isolate/Isolate.stop.(II)V"] = function(addr, code, reason) {
     // XXX According to Isolate.java, Isolate.id() should return -1 if an
     // isolate has been terminated, so we should set this._id to -1 here.
 
@@ -909,16 +909,16 @@ var MIDP = (function() {
     sendKeyRelease(ev.which);
   });
 
-  Native["com/sun/midp/events/EventQueue.getNativeEventQueueHandle.()I"] = function() {
+  Native["com/sun/midp/events/EventQueue.getNativeEventQueueHandle.()I"] = function(addr) {
     return 0;
   };
 
-  Native["com/sun/midp/events/EventQueue.resetNativeEventQueue.()V"] = function() {
+  Native["com/sun/midp/events/EventQueue.resetNativeEventQueue.()V"] = function(addr) {
     nativeEventQueues[$.ctx.runtime.isolateId] = [];
   };
 
   Native["com/sun/midp/events/EventQueue.sendNativeEventToIsolate.(Lcom/sun/midp/events/NativeEvent;I)V"] =
-    function(obj, isolateId) {
+    function(addr, obj, isolateId) {
       var e = { type: obj.type };
 
       var fields = obj.klass.classInfo.fields;
@@ -931,7 +931,7 @@ var MIDP = (function() {
     };
 
   Native["com/sun/midp/events/NativeEventMonitor.waitForNativeEvent.(Lcom/sun/midp/events/NativeEvent;)I"] =
-    function(nativeEvent) {
+    function(addr, nativeEvent) {
       var isolateId = $.ctx.runtime.isolateId;
       var nativeEventQueue = nativeEventQueues[isolateId];
 
@@ -949,7 +949,7 @@ var MIDP = (function() {
     };
 
   Native["com/sun/midp/events/NativeEventMonitor.readNativeEvent.(Lcom/sun/midp/events/NativeEvent;)Z"] =
-    function(obj) {
+    function(addr, obj) {
       var isolateId = $.ctx.runtime.isolateId;
       var nativeEventQueue = nativeEventQueues[isolateId];
       if (!nativeEventQueue.length) {
@@ -961,7 +961,7 @@ var MIDP = (function() {
 
   var localizedStrings;
 
-  Native["com/sun/midp/l10n/LocalizedStringsBase.getContent.(I)Ljava/lang/String;"] = function(id) {
+  Native["com/sun/midp/l10n/LocalizedStringsBase.getContent.(I)Ljava/lang/String;"] = function(addr, id) {
     if (!MIDP.localizedStrings) {
       var data = JARStore.loadFileFromJAR("java/classes.jar", "l10n/" + (config.language || navigator.language) + ".json");
       if (!data) {
@@ -985,24 +985,24 @@ var MIDP = (function() {
     return J2ME.newString(value);
   };
 
-  Native["javax/microedition/lcdui/Display.drawTrustedIcon0.(IZ)V"] = function(dispId, drawTrusted) {
+  Native["javax/microedition/lcdui/Display.drawTrustedIcon0.(IZ)V"] = function(addr, dispId, drawTrusted) {
     console.warn("Display.drawTrustedIcon0.(IZ)V not implemented (" + dispId + ", " + drawTrusted + ")");
   };
 
-  Native["com/sun/midp/events/EventQueue.sendShutdownEvent.()V"] = function() {
+  Native["com/sun/midp/events/EventQueue.sendShutdownEvent.()V"] = function(addr) {
     sendNativeEvent({ type: EVENT_QUEUE_SHUTDOWN }, $.ctx.runtime.isolateId);
   };
 
-  Native["com/sun/midp/main/CommandState.saveCommandState.(Lcom/sun/midp/main/CommandState;)V"] = function(commandState) {
+  Native["com/sun/midp/main/CommandState.saveCommandState.(Lcom/sun/midp/main/CommandState;)V"] = function(addr, commandState) {
     console.warn("CommandState.saveCommandState.(L...CommandState;)V not implemented (" + commandState + ")");
   };
 
-  Native["com/sun/midp/main/CommandState.exitInternal.(I)V"] = function(status) {
+  Native["com/sun/midp/main/CommandState.exitInternal.(I)V"] = function(addr, status) {
     console.info("Exit: " + status);
     exit();
   };
 
-  Native["com/sun/midp/suspend/SuspendSystem$MIDPSystem.allMidletsKilled.()Z"] = function() {
+  Native["com/sun/midp/suspend/SuspendSystem$MIDPSystem.allMidletsKilled.()Z"] = function(addr) {
     console.warn("SuspendSystem$MIDPSystem.allMidletsKilled.()Z not implemented");
     return 0;
   };
@@ -1024,7 +1024,7 @@ var MIDP = (function() {
     114: SYSTEM_KEY_END, // F3
   };
 
-  Native["javax/microedition/lcdui/KeyConverter.getSystemKey.(I)I"] = function(key) {
+  Native["javax/microedition/lcdui/KeyConverter.getSystemKey.(I)I"] = function(addr, key) {
     return systemKeyMap[key] || 0;
   };
 
@@ -1040,7 +1040,7 @@ var MIDP = (function() {
     12: 99, // GAME_D
   };
 
-  Native["javax/microedition/lcdui/KeyConverter.getKeyCode.(I)I"] = function(key) {
+  Native["javax/microedition/lcdui/KeyConverter.getKeyCode.(I)I"] = function(addr, key) {
     return keyMap[key] || 0;
   };
 
@@ -1056,7 +1056,7 @@ var MIDP = (function() {
     99: "Mail",
   };
 
-  Native["javax/microedition/lcdui/KeyConverter.getKeyName.(I)Ljava/lang/String;"] = function(keyCode) {
+  Native["javax/microedition/lcdui/KeyConverter.getKeyName.(I)Ljava/lang/String;"] = function(addr, keyCode) {
     return J2ME.newString((keyCode in keyNames) ? keyNames[keyCode] : String.fromCharCode(keyCode));
   };
 
@@ -1072,19 +1072,19 @@ var MIDP = (function() {
     99: 12   // GAME_D
   };
 
-  Native["javax/microedition/lcdui/KeyConverter.getGameAction.(I)I"] = function(keyCode) {
+  Native["javax/microedition/lcdui/KeyConverter.getGameAction.(I)I"] = function(addr, keyCode) {
     return gameKeys[keyCode] || 0;
   };
 
-  Native["javax/microedition/lcdui/game/GameCanvas.setSuppressKeyEvents.(Ljavax/microedition/lcdui/Canvas;Z)V"] = function(canvas, shouldSuppress) {
+  Native["javax/microedition/lcdui/game/GameCanvas.setSuppressKeyEvents.(Ljavax/microedition/lcdui/Canvas;Z)V"] = function(addr, canvas, shouldSuppress) {
     suppressKeyEvents = shouldSuppress;
   };
 
-  Native["com/sun/midp/main/MIDletProxyList.resetForegroundInNativeState.()V"] = function() {
+  Native["com/sun/midp/main/MIDletProxyList.resetForegroundInNativeState.()V"] = function(addr) {
     FG.reset();
   };
 
-  Native["com/sun/midp/main/MIDletProxyList.setForegroundInNativeState.(II)V"] = function(isolateId, dispId) {
+  Native["com/sun/midp/main/MIDletProxyList.setForegroundInNativeState.(II)V"] = function(addr, isolateId, dispId) {
     FG.set(isolateId, dispId);
   };
 
@@ -1132,7 +1132,7 @@ var MIDP = (function() {
     }
   };
 
-  Native["com/sun/midp/io/j2me/push/ConnectionRegistry.poll0.(J)I"] = function(time) {
+  Native["com/sun/midp/io/j2me/push/ConnectionRegistry.poll0.(J)I"] = function(addr, time) {
     asyncImpl("I", new Promise(function(resolve, reject) {
       connectionRegistry.waitForRegistration(function(id) {
         resolve(id);
@@ -1140,7 +1140,7 @@ var MIDP = (function() {
     }));
   };
 
-  Native["com/sun/midp/io/j2me/push/ConnectionRegistry.add0.(Ljava/lang/String;)I"] = function(connection) {
+  Native["com/sun/midp/io/j2me/push/ConnectionRegistry.add0.(Ljava/lang/String;)I"] = function(addr, connection) {
     var values = J2ME.fromJavaString(connection).split(',');
 
     console.warn("ConnectionRegistry.add0.(IL...String;)I isn't completely implemented");
@@ -1155,7 +1155,7 @@ var MIDP = (function() {
     return 0;
   };
 
-  Native["com/sun/midp/io/j2me/push/ConnectionRegistry.addAlarm0.([BJ)J"] = function(jMidlet, jTimeLow, jTimeHigh) {
+  Native["com/sun/midp/io/j2me/push/ConnectionRegistry.addAlarm0.([BJ)J"] = function(addr, jMidlet, jTimeLow, jTimeHigh) {
     var time = J2ME.longToNumber(jTimeLow, jTimeHigh), midlet = util.decodeUtf8(jMidlet);
 
     var lastAlarm = 0;
@@ -1196,7 +1196,7 @@ var MIDP = (function() {
     return J2ME.returnLongValue(lastAlarm);
   };
 
-  Native["com/sun/midp/io/j2me/push/ConnectionRegistry.getMIDlet0.(I[BI)I"] = function(handle, regentry, entrysz) {
+  Native["com/sun/midp/io/j2me/push/ConnectionRegistry.getMIDlet0.(I[BI)I"] = function(addr, handle, regentry, entrysz) {
     var reg;
     var alarms = connectionRegistry.alarms;
     for (var i = 0; i < alarms.length; i++) {
@@ -1235,62 +1235,62 @@ var MIDP = (function() {
     return 0;
   };
 
-  Native["com/sun/midp/io/j2me/push/ConnectionRegistry.checkInByMidlet0.(ILjava/lang/String;)V"] = function(suiteId, className) {
+  Native["com/sun/midp/io/j2me/push/ConnectionRegistry.checkInByMidlet0.(ILjava/lang/String;)V"] = function(addr, suiteId, className) {
     console.warn("ConnectionRegistry.checkInByMidlet0.(IL...String;)V not implemented (" + suiteId + ", " + J2ME.fromJavaString(className) + ")");
   };
 
-  Native["com/sun/midp/io/j2me/push/ConnectionRegistry.checkInByName0.([B)I"] = function(name) {
+  Native["com/sun/midp/io/j2me/push/ConnectionRegistry.checkInByName0.([B)I"] = function(addr, name) {
     console.warn("ConnectionRegistry.checkInByName0.([B)V not implemented (" + util.decodeUtf8(name) + ")");
     return 0;
   };
 
-  Native["com/nokia/mid/ui/gestures/GestureInteractiveZone.isSupported.(I)Z"] = function(gestureEventIdentity) {
+  Native["com/nokia/mid/ui/gestures/GestureInteractiveZone.isSupported.(I)Z"] = function(addr, gestureEventIdentity) {
     console.warn("GestureInteractiveZone.isSupported.(I)Z not implemented (" + gestureEventIdentity + ")");
     return 0;
   };
 
   addUnimplementedNative("com/nokia/mid/ui/gestures/GestureInteractiveZone.getGestures.()I", 0);
 
-  Native["com/sun/midp/io/NetworkConnectionBase.initializeInternal.()V"] = function() {
+  Native["com/sun/midp/io/NetworkConnectionBase.initializeInternal.()V"] = function(addr) {
     console.warn("NetworkConnectionBase.initializeInternal.()V not implemented");
   };
 
   addUnimplementedNative("com/nokia/mid/ui/VirtualKeyboard.hideOpenKeypadCommand.(Z)V");
   addUnimplementedNative("com/nokia/mid/ui/VirtualKeyboard.suppressSizeChanged.(Z)V");
 
-  Native["com/nokia/mid/ui/VirtualKeyboard.getCustomKeyboardControl.()Lcom/nokia/mid/ui/CustomKeyboardControl;"] = function() {
+  Native["com/nokia/mid/ui/VirtualKeyboard.getCustomKeyboardControl.()Lcom/nokia/mid/ui/CustomKeyboardControl;"] = function(addr) {
     throw $.newIllegalArgumentException("VirtualKeyboard::getCustomKeyboardControl() not implemented")
   };
 
   var keyboardVisibilityListener = null;
-  Native["com/nokia/mid/ui/VirtualKeyboard.setVisibilityListener.(Lcom/nokia/mid/ui/KeyboardVisibilityListener;)V"] = function(listener) {
+  Native["com/nokia/mid/ui/VirtualKeyboard.setVisibilityListener.(Lcom/nokia/mid/ui/KeyboardVisibilityListener;)V"] = function(addr, listener) {
     keyboardVisibilityListener = listener;
   };
 
-  Native["javax/microedition/lcdui/Display.getKeyboardVisibilityListener.()Lcom/nokia/mid/ui/KeyboardVisibilityListener;"] = function() {
+  Native["javax/microedition/lcdui/Display.getKeyboardVisibilityListener.()Lcom/nokia/mid/ui/KeyboardVisibilityListener;"] = function(addr) {
     return keyboardVisibilityListener;
   };
 
-  Native["com/nokia/mid/ui/VirtualKeyboard.isVisible.()Z"] = function() {
+  Native["com/nokia/mid/ui/VirtualKeyboard.isVisible.()Z"] = function(addr) {
     return MIDP.isVKVisible() ? 1 : 0;
   };
 
-  Native["com/nokia/mid/ui/VirtualKeyboard.getXPosition.()I"] = function() {
+  Native["com/nokia/mid/ui/VirtualKeyboard.getXPosition.()I"] = function(addr) {
     return 0;
   };
 
-  Native["com/nokia/mid/ui/VirtualKeyboard.getYPosition.()I"] = function() {
+  Native["com/nokia/mid/ui/VirtualKeyboard.getYPosition.()I"] = function(addr) {
     // We should return the number of pixels between the top of the
     // screen and the top of the keyboard
     return deviceCanvas.height - getKeyboardHeight();
   };
 
-  Native["com/nokia/mid/ui/VirtualKeyboard.getWidth.()I"] = function() {
+  Native["com/nokia/mid/ui/VirtualKeyboard.getWidth.()I"] = function(addr) {
     // The keyboard is always the same width as our window
     return window.innerWidth;
   };
 
-  Native["com/nokia/mid/ui/VirtualKeyboard.getHeight.()I"] = function() {
+  Native["com/nokia/mid/ui/VirtualKeyboard.getHeight.()I"] = function(addr) {
     return getKeyboardHeight();
   };
 

--- a/midp/pim.js
+++ b/midp/pim.js
@@ -47,7 +47,7 @@ PIM.supportedFields = [
 PIM.lastListHandle = 0;
 PIM.openLists = {};
 
-Native["com/sun/j2me/pim/PIMProxy.getListNamesCount0.(I)I"] = function(listType) {
+Native["com/sun/j2me/pim/PIMProxy.getListNamesCount0.(I)I"] = function(addr, listType) {
   console.warn("PIMProxy.getListNamesCount0.(I)I incomplete");
 
   if (listType === PIM.CONTACT_LIST) {
@@ -57,12 +57,12 @@ Native["com/sun/j2me/pim/PIMProxy.getListNamesCount0.(I)I"] = function(listType)
   return 0;
 };
 
-Native["com/sun/j2me/pim/PIMProxy.getListNames0.([Ljava/lang/String;)V"] = function(names) {
+Native["com/sun/j2me/pim/PIMProxy.getListNames0.([Ljava/lang/String;)V"] = function(addr, names) {
   console.warn("PIMProxy.getListNames0.([Ljava/lang/String;)V incomplete");
   names[0] = J2ME.newString("ContactList");
 };
 
-Native["com/sun/j2me/pim/PIMProxy.listOpen0.(ILjava/lang/String;I)I"] = function(listType, listName, mode) {
+Native["com/sun/j2me/pim/PIMProxy.listOpen0.(ILjava/lang/String;I)I"] = function(addr, listType, listName, mode) {
   console.warn("PIMProxy.listOpen0.(ILjava/lang/String;I)I incomplete");
 
   if (mode !== PIM.READ_ONLY) {
@@ -78,7 +78,7 @@ Native["com/sun/j2me/pim/PIMProxy.listOpen0.(ILjava/lang/String;I)I"] = function
   return 0;
 };
 
-Native["com/sun/j2me/pim/PIMProxy.getNextItemDescription0.(I[I)Z"] = function(listHandle, description) {
+Native["com/sun/j2me/pim/PIMProxy.getNextItemDescription0.(I[I)Z"] = function(addr, listHandle, description) {
   console.warn("PIMProxy.getNextItemDescription0.(I[I)Z incomplete");
 
   asyncImpl("Z", new Promise(function(resolve, reject) {
@@ -105,18 +105,18 @@ Native["com/sun/j2me/pim/PIMProxy.getNextItemDescription0.(I[I)Z"] = function(li
   }));
 };
 
-Native["com/sun/j2me/pim/PIMProxy.getNextItemData0.(I[BI)Z"] = function(itemHandle, data, dataHandle) {
+Native["com/sun/j2me/pim/PIMProxy.getNextItemData0.(I[BI)Z"] = function(addr, itemHandle, data, dataHandle) {
   console.warn("PIMProxy.getNextItemData0.(I[BI)Z incomplete");
   data.set(PIM.curVcard);
   return 1;
 };
 
-Native["com/sun/j2me/pim/PIMProxy.getItemCategories0.(II)Ljava/lang/String;"] = function(itemHandle, dataHandle) {
+Native["com/sun/j2me/pim/PIMProxy.getItemCategories0.(II)Ljava/lang/String;"] = function(addr, itemHandle, dataHandle) {
   console.warn("PIMProxy.getItemCategories0.(II)Ljava/lang/String; not implemented");
   return null;
 };
 
-Native["com/sun/j2me/pim/PIMProxy.listClose0.(I)Z"] = function(listHandle, description) {
+Native["com/sun/j2me/pim/PIMProxy.listClose0.(I)Z"] = function(addr, listHandle, description) {
   if (!(listHandle in PIM.openLists)) {
     return 0;
   }
@@ -125,7 +125,7 @@ Native["com/sun/j2me/pim/PIMProxy.listClose0.(I)Z"] = function(listHandle, descr
   return 1;
 };
 
-Native["com/sun/j2me/pim/PIMProxy.getDefaultListName.(I)Ljava/lang/String;"] = function(listType) {
+Native["com/sun/j2me/pim/PIMProxy.getDefaultListName.(I)Ljava/lang/String;"] = function(addr, listType) {
   if (listType === PIM.CONTACT_LIST) {
     return J2ME.newString("ContactList");
   }
@@ -141,16 +141,16 @@ Native["com/sun/j2me/pim/PIMProxy.getDefaultListName.(I)Ljava/lang/String;"] = f
   return null;
 };
 
-Native["com/sun/j2me/pim/PIMProxy.getFieldsCount0.(I[I)I"] = function(listHandle, dataHandle) {
+Native["com/sun/j2me/pim/PIMProxy.getFieldsCount0.(I[I)I"] = function(addr, listHandle, dataHandle) {
   return PIM.supportedFields.length;
 };
 
-Native["com/sun/j2me/pim/PIMProxy.getFieldLabelsCount0.(III)I"] = function(listHandle, fieldIndex, dataHandle) {
+Native["com/sun/j2me/pim/PIMProxy.getFieldLabelsCount0.(III)I"] = function(addr, listHandle, fieldIndex, dataHandle) {
   console.warn("PIMProxy.getFieldLabelsCount0.(III)I not implemented");
   return 1;
 };
 
-Native["com/sun/j2me/pim/PIMProxy.getFields0.(I[Lcom/sun/j2me/pim/PIMFieldDescriptor;I)V"] = function(listHandle, desc, dataHandle) {
+Native["com/sun/j2me/pim/PIMProxy.getFields0.(I[Lcom/sun/j2me/pim/PIMFieldDescriptor;I)V"] = function(addr, listHandle, desc, dataHandle) {
   console.warn("PIMProxy.getFields0.(I[Lcom/sun/j2me/pim/PIMFieldDescriptor;I)V incomplete");
 
   PIM.supportedFields.forEach(function(field, i) {
@@ -160,11 +160,11 @@ Native["com/sun/j2me/pim/PIMProxy.getFields0.(I[Lcom/sun/j2me/pim/PIMFieldDescri
   });
 };
 
-Native["com/sun/j2me/pim/PIMProxy.getAttributesCount0.(I[I)I"] = function(listHandle, dataHandle) {
+Native["com/sun/j2me/pim/PIMProxy.getAttributesCount0.(I[I)I"] = function(addr, listHandle, dataHandle) {
   console.warn("PIMProxy.getAttributesCount0.(I[I)I not implemented");
   return 0;
 };
 
-Native["com/sun/j2me/pim/PIMProxy.getAttributes0.(I[Lcom/sun/j2me/pim/PIMAttribute;I)V"] = function(listHandle, attr, dataHandle) {
+Native["com/sun/j2me/pim/PIMProxy.getAttributes0.(I[Lcom/sun/j2me/pim/PIMAttribute;I)V"] = function(addr, listHandle, attr, dataHandle) {
   console.warn("PIMProxy.getAttributes0.(I[Lcom/sun/j2me/pim/PIMAttribute;I)V not implemented");
 };

--- a/midp/sensor.js
+++ b/midp/sensor.js
@@ -191,12 +191,12 @@ AccelerometerSensor.handleEvent = function(evt) {
     this.acceleration[2] = a.z;
 };
 
-Native["com/sun/javame/sensor/SensorRegistry.doGetNumberOfSensors.()I"] = function() {
+Native["com/sun/javame/sensor/SensorRegistry.doGetNumberOfSensors.()I"] = function(addr) {
     // Only support the acceleration sensor.
     return 1;
 };
 
-Native["com/sun/javame/sensor/Sensor.doGetSensorModel.(ILcom/sun/javame/sensor/SensorModel;)V"] = function(number, model) {
+Native["com/sun/javame/sensor/Sensor.doGetSensorModel.(ILcom/sun/javame/sensor/SensorModel;)V"] = function(addr, number, model) {
     if (number !== 0) {
         console.error("Invalid sensor number: " + number);
         return;
@@ -222,7 +222,7 @@ Native["com/sun/javame/sensor/Sensor.doGetSensorModel.(ILcom/sun/javame/sensor/S
     model.properties = p;
 };
 
-Native["com/sun/javame/sensor/ChannelImpl.doGetChannelModel.(IILcom/sun/javame/sensor/ChannelModel;)V"] = function(sensorsNumber, number, model) {
+Native["com/sun/javame/sensor/ChannelImpl.doGetChannelModel.(IILcom/sun/javame/sensor/ChannelModel;)V"] = function(addr, sensorsNumber, number, model) {
     if (sensorsNumber !== 0) {
         console.error("Invalid sensor number: " + sensorsNumber);
         return;
@@ -248,12 +248,12 @@ Native["com/sun/javame/sensor/ChannelImpl.doGetChannelModel.(IILcom/sun/javame/s
     model.mrageArray = array;
 };
 
-Native["com/sun/javame/sensor/NativeSensor.doIsAvailable.(I)Z"] = function(number) {
+Native["com/sun/javame/sensor/NativeSensor.doIsAvailable.(I)Z"] = function(addr, number) {
     // Only support the acceleration sensor with number = 0.
     return number === 0 ? 1 : 0;
 };
 
-Native["com/sun/javame/sensor/NativeSensor.doInitSensor.(I)Z"] = function(number) {
+Native["com/sun/javame/sensor/NativeSensor.doInitSensor.(I)Z"] = function(addr, number) {
     if (number !== 0) {
         return 0;
     }
@@ -261,7 +261,7 @@ Native["com/sun/javame/sensor/NativeSensor.doInitSensor.(I)Z"] = function(number
     return 1;
 };
 
-Native["com/sun/javame/sensor/NativeSensor.doFinishSensor.(I)Z"] = function(number) {
+Native["com/sun/javame/sensor/NativeSensor.doFinishSensor.(I)Z"] = function(addr, number) {
     if (number !== 0) {
         return 0;
     }
@@ -269,7 +269,7 @@ Native["com/sun/javame/sensor/NativeSensor.doFinishSensor.(I)Z"] = function(numb
     return 1;
 };
 
-Native["com/sun/javame/sensor/NativeChannel.doMeasureData.(II)[B"] = function(sensorNumber, channelNumber) {
+Native["com/sun/javame/sensor/NativeChannel.doMeasureData.(II)[B"] = function(addr, sensorNumber, channelNumber) {
     if (sensorNumber !== 0 || channelNumber < 0 || channelNumber >= 3) {
         if (sensorNumber !== 0) {
             console.error("Invalid sensor number: " + sensorsNumber);

--- a/midp/sms.js
+++ b/midp/sms.js
@@ -124,7 +124,7 @@ function promptForMessageText() {
     }, MIDlet.SMSDialogTimeout);
 }
 
-Native["com/sun/midp/io/j2me/sms/Protocol.open0.(Ljava/lang/String;II)I"] = function(host, msid, port) {
+Native["com/sun/midp/io/j2me/sms/Protocol.open0.(Ljava/lang/String;II)I"] = function(addr, host, msid, port) {
     MIDP.smsConnections[++MIDP.lastSMSConnection] = {
       port: port,
       msid: msid,
@@ -135,7 +135,7 @@ Native["com/sun/midp/io/j2me/sms/Protocol.open0.(Ljava/lang/String;II)I"] = func
 };
 
 Native["com/sun/midp/io/j2me/sms/Protocol.receive0.(IIILcom/sun/midp/io/j2me/sms/Protocol$SMSPacket;)I"] =
-function(port, msid, handle, smsPacket) {
+function(addr, port, msid, handle, smsPacket) {
     asyncImpl("I", new Promise(function(resolve, reject) {
         function receiveSMS() {
             var sms = MIDP.j2meSMSMessages.shift();
@@ -172,18 +172,18 @@ function(port, msid, handle, smsPacket) {
     }));
 };
 
-Native["com/sun/midp/io/j2me/sms/Protocol.close0.(III)I"] = function(port, handle, deRegister) {
+Native["com/sun/midp/io/j2me/sms/Protocol.close0.(III)I"] = function(addr, port, handle, deRegister) {
     delete MIDP.smsConnections[handle];
     return 0;
 };
 
-Native["com/sun/midp/io/j2me/sms/Protocol.numberOfSegments0.([BIIZ)I"] = function(msgBuffer, msgLen, msgType, hasPort) {
+Native["com/sun/midp/io/j2me/sms/Protocol.numberOfSegments0.([BIIZ)I"] = function(addr, msgBuffer, msgLen, msgType, hasPort) {
     console.warn("com/sun/midp/io/j2me/sms/Protocol.numberOfSegments0.([BIIZ)I not implemented");
     return 1;
 };
 
 Native["com/sun/midp/io/j2me/sms/Protocol.send0.(IILjava/lang/String;II[B)I"] =
-function(handle, type, host, destPort, sourcePort, message) {
+function(addr, handle, type, host, destPort, sourcePort, message) {
     var ctx = $.ctx;
     asyncImpl("I", new Promise(function(resolve, reject) {
         var pipe = DumbPipe.open("mozActivity", {

--- a/midp/socket.js
+++ b/midp/socket.js
@@ -11,7 +11,7 @@ var SOCKET_OPT = {
   SNDBUF: 4,
 };
 
-Native["com/sun/midp/io/j2me/socket/Protocol.getIpNumber0.(Ljava/lang/String;[B)I"] = function(host, ipBytes) {
+Native["com/sun/midp/io/j2me/socket/Protocol.getIpNumber0.(Ljava/lang/String;[B)I"] = function(addr, host, ipBytes) {
     // We're supposed to write the IP address of the host into ipBytes,
     // but we don't actually have to do that, because we can defer resolution
     // until Protocol.open0 (and delegate it to the native socket impl).
@@ -19,7 +19,7 @@ Native["com/sun/midp/io/j2me/socket/Protocol.getIpNumber0.(Ljava/lang/String;[B)
     return 0;
 };
 
-Native["com/sun/midp/io/j2me/socket/Protocol.getHost0.(Z)Ljava/lang/String;"] = function(local) {
+Native["com/sun/midp/io/j2me/socket/Protocol.getHost0.(Z)Ljava/lang/String;"] = function(addr, local) {
     // XXX We should probably retrieve the host directly from the Java object,
     // as Protocol.open0 does.  Then we wouldn't have to get the native socket,
     // and we might avoid an exception if the socket hasn't been opened yet
@@ -99,7 +99,7 @@ Socket.prototype.close = function() {
     this.sender({ type: "close" });
 }
 
-Native["com/sun/midp/io/j2me/socket/Protocol.open0.([BI)V"] = function(ipBytes, port) {
+Native["com/sun/midp/io/j2me/socket/Protocol.open0.([BI)V"] = function(addr, ipBytes, port) {
     var host = J2ME.fromJavaString(getHandle(this.host));
     // console.log("Protocol.open0: " + host + ":" + port);
     asyncImpl("V", new Promise((function(resolve, reject) {
@@ -107,13 +107,13 @@ Native["com/sun/midp/io/j2me/socket/Protocol.open0.([BI)V"] = function(ipBytes, 
     }).bind(this)));
 };
 
-Native["com/sun/midp/io/j2me/socket/Protocol.available0.()I"] = function() {
+Native["com/sun/midp/io/j2me/socket/Protocol.available0.()I"] = function(addr) {
     var socket = getNative(this);
     // console.log("Protocol.available0: " + socket.data.byteLength);
     return socket.dataLen;
 };
 
-Native["com/sun/midp/io/j2me/socket/Protocol.read0.([BII)I"] = function(data, offset, length) {
+Native["com/sun/midp/io/j2me/socket/Protocol.read0.([BII)I"] = function(addr, data, offset, length) {
     var socket = getNative(this);
     // console.log("Protocol.read0: " + socket.isClosed);
 
@@ -162,7 +162,7 @@ Native["com/sun/midp/io/j2me/socket/Protocol.read0.([BII)I"] = function(data, of
     }));
 };
 
-Native["com/sun/midp/io/j2me/socket/Protocol.write0.([BII)I"] = function(data, offset, length) {
+Native["com/sun/midp/io/j2me/socket/Protocol.write0.([BII)I"] = function(addr, data, offset, length) {
     var socket = getNative(this);
     var ctx = $.ctx;
     asyncImpl("I", new Promise(function(resolve, reject) {
@@ -192,7 +192,7 @@ Native["com/sun/midp/io/j2me/socket/Protocol.write0.([BII)I"] = function(data, o
     }));
 };
 
-Native["com/sun/midp/io/j2me/socket/Protocol.setSockOpt0.(II)V"] = function(option, value) {
+Native["com/sun/midp/io/j2me/socket/Protocol.setSockOpt0.(II)V"] = function(addr, option, value) {
     var socket = getNative(this);
     if (!(option in socket.options)) {
         throw $.newIllegalArgumentException("Unsupported socket option");
@@ -201,7 +201,7 @@ Native["com/sun/midp/io/j2me/socket/Protocol.setSockOpt0.(II)V"] = function(opti
     socket.options[option] = value;
 };
 
-Native["com/sun/midp/io/j2me/socket/Protocol.getSockOpt0.(I)I"] = function(option) {
+Native["com/sun/midp/io/j2me/socket/Protocol.getSockOpt0.(I)I"] = function(addr, option) {
     var socket = getNative(this);
     if (!(option in socket.options)) {
         throw new $.newIllegalArgumentException("Unsupported socket option");
@@ -210,7 +210,7 @@ Native["com/sun/midp/io/j2me/socket/Protocol.getSockOpt0.(I)I"] = function(optio
     return socket.options[option];
 };
 
-Native["com/sun/midp/io/j2me/socket/Protocol.close0.()V"] = function() {
+Native["com/sun/midp/io/j2me/socket/Protocol.close0.()V"] = function(addr) {
     var socket = getNative(this);
     // console.log("Protocol.close0: " + socket.isClosed);
 
@@ -230,7 +230,7 @@ Native["com/sun/midp/io/j2me/socket/Protocol.close0.()V"] = function() {
     }));
 };
 
-Native["com/sun/midp/io/j2me/socket/Protocol.shutdownOutput0.()V"] = function() {
+Native["com/sun/midp/io/j2me/socket/Protocol.shutdownOutput0.()V"] = function(addr) {
     // We don't have the ability to close the output stream independently
     // of the connection as a whole.  But we don't seem to have to do anything
     // here, since this has just two call sites: one in Protocol.disconnect,
@@ -239,14 +239,14 @@ Native["com/sun/midp/io/j2me/socket/Protocol.shutdownOutput0.()V"] = function() 
     // I can't find an actual caller.
 };
 
-Native["com/sun/midp/io/j2me/socket/Protocol.notifyClosedInput0.()V"] = function() {
+Native["com/sun/midp/io/j2me/socket/Protocol.notifyClosedInput0.()V"] = function(addr) {
     var socket = getNative(this);
     if (socket.waitingData) {
         console.warn("Protocol.notifyClosedInput0.()V unimplemented while thread is blocked on read0");
     }
 };
 
-Native["com/sun/midp/io/j2me/socket/Protocol.notifyClosedOutput0.()V"] = function() {
+Native["com/sun/midp/io/j2me/socket/Protocol.notifyClosedOutput0.()V"] = function(addr) {
     var socket = getNative(this);
     if (socket.ondrain) {
         console.warn("Protocol.notifyClosedOutput0.()V unimplemented while thread is blocked on write0");

--- a/nat.ts
+++ b/nat.ts
@@ -90,39 +90,43 @@ module J2ME {
     $.pause("Async");
   }
 
-  Native["java/lang/Thread.sleep.(J)V"] = function(delayL: number, delayH: number) {
+  Native["java/lang/Thread.sleep.(J)V"] = function(addr: number, delayL: number, delayH: number) {
     asyncImpl(Kind.Void, new Promise(function(resolve, reject) {
       window.setTimeout(resolve, longToNumber(delayL, delayH));
     }));
   };
 
-  Native["java/lang/Thread.isAlive.()Z"] = function() {
-    return this.nativeAlive ? 1 : 0;
+  Native["java/lang/Thread.isAlive.()Z"] = function(addr: number) {
+    var self = <java.lang.Thread>getHandle(addr);
+    return self.nativeAlive ? 1 : 0;
   };
 
-  Native["java/lang/Thread.yield.()V"] = function() {
+  Native["java/lang/Thread.yield.()V"] = function(addr: number) {
     $.yield("Thread.yield");
     $.ctx.nativeThread.advancePastInvokeBytecode();
   };
 
-  Native["java/lang/Object.wait.(J)V"] = function(timeoutL: number, timeoutH: number) {
-    $.ctx.wait(this, longToNumber(timeoutL, timeoutH));
+  Native["java/lang/Object.wait.(J)V"] = function(addr: number, timeoutL: number, timeoutH: number) {
+    var self = getHandle(addr);
+    $.ctx.wait(self, longToNumber(timeoutL, timeoutH));
     $.ctx.nativeThread.advancePastInvokeBytecode();
   };
 
-  Native["java/lang/Object.notify.()V"] = function() {
-    $.ctx.notify(this, false);
+  Native["java/lang/Object.notify.()V"] = function(addr: number) {
+    var self = getHandle(addr);
+    $.ctx.notify(self, false);
   };
 
-  Native["java/lang/Object.notifyAll.()V"] = function() {
-    $.ctx.notify(this, true);
+  Native["java/lang/Object.notifyAll.()V"] = function(addr: number) {
+    var self = getHandle(addr);
+    $.ctx.notify(self, true);
   };
 
-  Native["org/mozilla/internal/Sys.getUnwindCount.()I"] = function() {
+  Native["org/mozilla/internal/Sys.getUnwindCount.()I"] = function(addr: number) {
     return unwindCount;
   };
 
-  Native["org/mozilla/internal/Sys.constructCurrentThread.()V"] = function() {
+  Native["org/mozilla/internal/Sys.constructCurrentThread.()V"] = function(addr: number) {
     var methodInfo = CLASSES.java_lang_Thread.getMethodByNameString("<init>", "(Ljava/lang/String;)V");
     var thread = <java.lang.Thread>getHandle($.mainThread);
     getLinkedMethod(methodInfo).call(thread, J2ME.newString("main"));
@@ -140,12 +144,12 @@ module J2ME {
     thread.nativeAlive = true;
   };
 
-  Native["org/mozilla/internal/Sys.getIsolateMain.()Ljava/lang/String;"] = function(): java.lang.String {
+  Native["org/mozilla/internal/Sys.getIsolateMain.()Ljava/lang/String;"] = function(addr: number): java.lang.String {
     var isolate = <com.sun.cldc.isolate.Isolate>getHandle($.isolateAddress);
     return <java.lang.String>getHandle(isolate._mainClass);
   };
 
-  Native["org/mozilla/internal/Sys.executeMain.(Ljava/lang/Class;)V"] = function(main: java.lang.Class) {
+  Native["org/mozilla/internal/Sys.executeMain.(Ljava/lang/Class;)V"] = function(addr: number, main: java.lang.Class) {
     var entryPoint = CLASSES.getEntryPoint(main.runtimeKlass.templateKlass.classInfo);
     if (!entryPoint)
       throw new Error("Could not find isolate main.");
@@ -155,7 +159,7 @@ module J2ME {
     getLinkedMethod(entryPoint).call(null, isolate._mainArgs);
   };
 
-  Native["org/mozilla/internal/Sys.forceCollection.()V"] = function() {
+  Native["org/mozilla/internal/Sys.forceCollection.()V"] = function(addr: number) {
     ASM._forceCollection();
   };
 }

--- a/native.js
+++ b/native.js
@@ -43,7 +43,7 @@ function deleteNative(javaObj) {
     NativeMap.delete(javaObj._address);
 }
 
-Native["java/lang/System.arraycopy.(Ljava/lang/Object;ILjava/lang/Object;II)V"] = function(src, srcOffset, dst, dstOffset, length) {
+Native["java/lang/System.arraycopy.(Ljava/lang/Object;ILjava/lang/Object;II)V"] = function(addr, src, srcOffset, dst, dstOffset, length) {
     if (!src || !dst)
         throw $.newNullPointerException("Cannot copy to/from a null array.");
     var srcKlass = src.klass;
@@ -98,7 +98,7 @@ var stubProperties = {
   "com.nokia.mid.imei": "",
 };
 
-Native["java/lang/System.getProperty0.(Ljava/lang/String;)Ljava/lang/String;"] = function(key) {
+Native["java/lang/System.getProperty0.(Ljava/lang/String;)Ljava/lang/String;"] = function(addr, key) {
     key = J2ME.fromJavaString(key);
     var value;
     switch (key) {
@@ -269,19 +269,19 @@ Native["java/lang/System.getProperty0.(Ljava/lang/String;)Ljava/lang/String;"] =
     return J2ME.newString(value);
 };
 
-Native["java/lang/System.currentTimeMillis.()J"] = function() {
+Native["java/lang/System.currentTimeMillis.()J"] = function(addr) {
     return J2ME.returnLongValue(Date.now());
 };
 
-Native["com/sun/cldchi/jvm/JVM.unchecked_char_arraycopy.([CI[CII)V"] = function(src, srcOffset, dst, dstOffset, length) {
+Native["com/sun/cldchi/jvm/JVM.unchecked_char_arraycopy.([CI[CII)V"] = function(addr, src, srcOffset, dst, dstOffset, length) {
   dst.set(src.subarray(srcOffset, srcOffset + length), dstOffset);
 };
 
-Native["com/sun/cldchi/jvm/JVM.unchecked_int_arraycopy.([II[III)V"] = function(src, srcOffset, dst, dstOffset, length) {
+Native["com/sun/cldchi/jvm/JVM.unchecked_int_arraycopy.([II[III)V"] = function(addr, src, srcOffset, dst, dstOffset, length) {
   dst.set(src.subarray(srcOffset, srcOffset + length), dstOffset);
 };
 
-Native["com/sun/cldchi/jvm/JVM.unchecked_obj_arraycopy.([Ljava/lang/Object;I[Ljava/lang/Object;II)V"] = function(src, srcOffset, dst, dstOffset, length) {
+Native["com/sun/cldchi/jvm/JVM.unchecked_obj_arraycopy.([Ljava/lang/Object;I[Ljava/lang/Object;II)V"] = function(addr, src, srcOffset, dst, dstOffset, length) {
     if (dst !== src || dstOffset < srcOffset) {
         for (var n = 0; n < length; ++n)
             dst[dstOffset++] = src[srcOffset++];
@@ -293,15 +293,15 @@ Native["com/sun/cldchi/jvm/JVM.unchecked_obj_arraycopy.([Ljava/lang/Object;I[Lja
     }
 };
 
-Native["com/sun/cldchi/jvm/JVM.monotonicTimeMillis.()J"] = function() {
+Native["com/sun/cldchi/jvm/JVM.monotonicTimeMillis.()J"] = function(addr) {
     return J2ME.returnLongValue(performance.now());
 };
 
-Native["java/lang/Object.getClass.()Ljava/lang/Class;"] = function() {
+Native["java/lang/Object.getClass.()Ljava/lang/Class;"] = function(addr) {
     return $.getRuntimeKlass(this.klass).classObject;
 };
 
-Native["java/lang/Class.getSuperclass.()Ljava/lang/Class;"] = function() {
+Native["java/lang/Class.getSuperclass.()Ljava/lang/Class;"] = function(addr) {
     var superKlass = this.runtimeKlass.templateKlass.superKlass;
     if (!superKlass) {
       return null;
@@ -309,7 +309,7 @@ Native["java/lang/Class.getSuperclass.()Ljava/lang/Class;"] = function() {
     return superKlass.classInfo.getClassObject();
 };
 
-Native["java/lang/Class.invoke_clinit.()V"] = function() {
+Native["java/lang/Class.invoke_clinit.()V"] = function(addr) {
     var classInfo = this.runtimeKlass.templateKlass.classInfo;
     var className = classInfo.getClassNameSlow();
     var clinit = classInfo.staticInitializer;
@@ -319,20 +319,20 @@ Native["java/lang/Class.invoke_clinit.()V"] = function() {
     }
 };
 
-Native["java/lang/Class.invoke_verify.()V"] = function() {
+Native["java/lang/Class.invoke_verify.()V"] = function(addr) {
     // There is currently no verification.
 };
 
-Native["java/lang/Class.init9.()V"] = function() {
+Native["java/lang/Class.init9.()V"] = function(addr) {
     $.setClassInitialized(this.runtimeKlass);
     J2ME.preemptionLockLevel--;
 };
 
-Native["java/lang/Class.getName.()Ljava/lang/String;"] = function() {
+Native["java/lang/Class.getName.()Ljava/lang/String;"] = function(addr) {
     return J2ME.newString(this.runtimeKlass.templateKlass.classInfo.getClassNameSlow().replace(/\//g, "."));
 };
 
-Native["java/lang/Class.forName0.(Ljava/lang/String;)V"] = function(name) {
+Native["java/lang/Class.forName0.(Ljava/lang/String;)V"] = function(addr, name) {
   var classInfo = null;
   try {
     if (!name)
@@ -348,14 +348,14 @@ Native["java/lang/Class.forName0.(Ljava/lang/String;)V"] = function(name) {
   J2ME.classInitCheck(classInfo);
 };
 
-Native["java/lang/Class.forName1.(Ljava/lang/String;)Ljava/lang/Class;"] = function(name) {
+Native["java/lang/Class.forName1.(Ljava/lang/String;)Ljava/lang/Class;"] = function(addr, name) {
   var className = J2ME.fromJavaString(name).replace(/\./g, "/");
   var classInfo = CLASSES.getClass(className);
   var classObject = classInfo.getClassObject();
   return classObject;
 };
 
-Native["java/lang/Class.newInstance0.()Ljava/lang/Object;"] = function() {
+Native["java/lang/Class.newInstance0.()Ljava/lang/Object;"] = function(addr) {
   if (this.runtimeKlass.templateKlass.classInfo.isInterface ||
       this.runtimeKlass.templateKlass.classInfo.isAbstract) {
     throw $.newInstantiationException("Can't instantiate interfaces or abstract classes");
@@ -368,7 +368,7 @@ Native["java/lang/Class.newInstance0.()Ljava/lang/Object;"] = function() {
   return new this.runtimeKlass.templateKlass;
 };
 
-Native["java/lang/Class.newInstance1.(Ljava/lang/Object;)V"] = function(o) {
+Native["java/lang/Class.newInstance1.(Ljava/lang/Object;)V"] = function(addr, o) {
   // The following can trigger an unwind.
   var methodInfo = o.klass.classInfo.getLocalMethodByNameString("<init>", "()V", false);
   if (!methodInfo) {
@@ -377,44 +377,44 @@ Native["java/lang/Class.newInstance1.(Ljava/lang/Object;)V"] = function(o) {
   J2ME.getLinkedMethod(methodInfo).call(o);
 };
 
-Native["java/lang/Class.isInterface.()Z"] = function() {
+Native["java/lang/Class.isInterface.()Z"] = function(addr) {
     return this.runtimeKlass.templateKlass.classInfo.isInterface ? 1 : 0;
 };
 
-Native["java/lang/Class.isArray.()Z"] = function() {
+Native["java/lang/Class.isArray.()Z"] = function(addr) {
     return this.runtimeKlass.templateKlass.classInfo instanceof J2ME.ArrayClassInfo ? 1 : 0;
 };
 
-Native["java/lang/Class.isAssignableFrom.(Ljava/lang/Class;)Z"] = function(fromClass) {
+Native["java/lang/Class.isAssignableFrom.(Ljava/lang/Class;)Z"] = function(addr, fromClass) {
     if (!fromClass)
         throw $.newNullPointerException();
     return J2ME.isAssignableTo(fromClass.runtimeKlass.templateKlass, this.runtimeKlass.templateKlass) ? 1 : 0;
 };
 
-Native["java/lang/Class.isInstance.(Ljava/lang/Object;)Z"] = function(obj) {
+Native["java/lang/Class.isInstance.(Ljava/lang/Object;)Z"] = function(addr, obj) {
     return obj && J2ME.isAssignableTo(obj.klass, this.runtimeKlass.templateKlass) ? 1 : 0;
 };
 
-Native["java/lang/Float.floatToIntBits.(F)I"] = function(f) {
+Native["java/lang/Float.floatToIntBits.(F)I"] = function(addr, f) {
     return aliasedF32[0] = f, aliasedI32[0];
 }
 
-Native["java/lang/Float.intBitsToFloat.(I)F"] = function (i) {
+Native["java/lang/Float.intBitsToFloat.(I)F"] = function(addr, i) {
     return aliasedI32[0] = i, aliasedF32[0];
 }
 
-Native["java/lang/Double.doubleToLongBits.(D)J"] = function (d) {
+Native["java/lang/Double.doubleToLongBits.(D)J"] = function(addr, d) {
     aliasedF64[0] = d;
     return J2ME.returnLong(aliasedI32[0], aliasedI32[1]);
 }
 
-Native["java/lang/Double.longBitsToDouble.(J)D"] = function (l, h) {
+Native["java/lang/Double.longBitsToDouble.(J)D"] = function(addr, l, h) {
     aliasedI32[0] = l;
     aliasedI32[1] = h;
     return aliasedF64[0];
 }
 
-Native["java/lang/Throwable.fillInStackTrace.()V"] = function() {
+Native["java/lang/Throwable.fillInStackTrace.()V"] = function(addr) {
     this.stackTrace = [];
     J2ME.traceWriter && J2ME.traceWriter.writeLn("REDUX");
     //$.ctx.frames.forEach(function(frame) {
@@ -430,7 +430,7 @@ Native["java/lang/Throwable.fillInStackTrace.()V"] = function() {
     //}.bind(this));
 };
 
-Native["java/lang/Throwable.obtainBackTrace.()Ljava/lang/Object;"] = function() {
+Native["java/lang/Throwable.obtainBackTrace.()Ljava/lang/Object;"] = function(addr) {
     var result = null;
     if (this.stackTrace) {
         var depth = this.stackTrace.length;
@@ -453,69 +453,69 @@ Native["java/lang/Throwable.obtainBackTrace.()Ljava/lang/Object;"] = function() 
     return result;
 };
 
-Native["java/lang/Runtime.freeMemory.()J"] = function() {
+Native["java/lang/Runtime.freeMemory.()J"] = function(addr) {
     return J2ME.returnLong(0x800000, 0);
 };
 
-Native["java/lang/Runtime.totalMemory.()J"] = function() {
+Native["java/lang/Runtime.totalMemory.()J"] = function(addr) {
     return J2ME.returnLong(0x1000000, 0);
 };
 
-Native["java/lang/Runtime.gc.()V"] = function() {
+Native["java/lang/Runtime.gc.()V"] = function(addr) {
 };
 
-Native["java/lang/Math.floor.(D)D"] = function(val) {
+Native["java/lang/Math.floor.(D)D"] = function(addr, val) {
     return Math.floor(val);
 };
 
-Native["java/lang/Math.asin.(D)D"] = function(val) {
+Native["java/lang/Math.asin.(D)D"] = function(addr, val) {
     return Math.asin(val);
 };
 
-Native["java/lang/Math.acos.(D)D"] = function(val) {
+Native["java/lang/Math.acos.(D)D"] = function(addr, val) {
     return Math.acos(val);
 };
 
-Native["java/lang/Math.atan.(D)D"] = function(val) {
+Native["java/lang/Math.atan.(D)D"] = function(addr, val) {
     return Math.atan(val);
 };
 
-Native["java/lang/Math.atan2.(DD)D"] = function(x, y) {
+Native["java/lang/Math.atan2.(DD)D"] = function(addr, x, y) {
     return Math.atan2(x, y);
 };
 
-Native["java/lang/Math.sin.(D)D"] = function(val) {
+Native["java/lang/Math.sin.(D)D"] = function(addr, val) {
     return Math.sin(val);
 };
 
-Native["java/lang/Math.cos.(D)D"] = function(val) {
+Native["java/lang/Math.cos.(D)D"] = function(addr, val) {
     return Math.cos(val);
 };
 
-Native["java/lang/Math.tan.(D)D"] = function(val) {
+Native["java/lang/Math.tan.(D)D"] = function(addr, val) {
     return Math.tan(val);
 };
 
-Native["java/lang/Math.sqrt.(D)D"] = function(val) {
+Native["java/lang/Math.sqrt.(D)D"] = function(addr, val) {
     return Math.sqrt(val);
 };
 
-Native["java/lang/Math.ceil.(D)D"] = function(val) {
+Native["java/lang/Math.ceil.(D)D"] = function(addr, val) {
     return Math.ceil(val);
 };
 
-Native["java/lang/Math.floor.(D)D"] = function(val) {
+Native["java/lang/Math.floor.(D)D"] = function(addr, val) {
     return Math.floor(val);
 };
 
-Native["java/lang/Thread.currentThread.()Ljava/lang/Thread;"] = function() {
+Native["java/lang/Thread.currentThread.()Ljava/lang/Thread;"] = function(addr) {
     return getHandle($.ctx.threadAddress);
 };
 
-Native["java/lang/Thread.setPriority0.(II)V"] = function(oldPriority, newPriority) {
+Native["java/lang/Thread.setPriority0.(II)V"] = function(addr, oldPriority, newPriority) {
 };
 
-Native["java/lang/Thread.start0.()V"] = function() {
+Native["java/lang/Thread.start0.()V"] = function(addr) {
     // The main thread starts during bootstrap and don't allow calling start()
     // on already running threads.
     if (this._address === $.ctx.runtime.mainThread || this.nativeAlive)
@@ -535,7 +535,7 @@ Native["java/lang/Thread.start0.()V"] = function() {
     newCtx.start();
 }
 
-Native["java/lang/Thread.activeCount.()I"] = function() {
+Native["java/lang/Thread.activeCount.()I"] = function(addr) {
     return $.ctx.runtime.threadCount;
 };
 
@@ -557,11 +557,11 @@ console.print = function(ch) {
     }
 };
 
-Native["com/sun/cldchi/io/ConsoleOutputStream.write.(I)V"] = function(ch) {
+Native["com/sun/cldchi/io/ConsoleOutputStream.write.(I)V"] = function(addr, ch) {
     console.print(ch);
 };
 
-Native["com/sun/cldc/io/ResourceInputStream.open.(Ljava/lang/String;)Ljava/lang/Object;"] = function(name) {
+Native["com/sun/cldc/io/ResourceInputStream.open.(Ljava/lang/String;)Ljava/lang/Object;"] = function(addr, name) {
     var fileName = J2ME.fromJavaString(name);
     var data = JARStore.loadFile(fileName);
     var obj = null;
@@ -575,7 +575,7 @@ Native["com/sun/cldc/io/ResourceInputStream.open.(Ljava/lang/String;)Ljava/lang/
     return obj;
 };
 
-Native["com/sun/cldc/io/ResourceInputStream.clone.(Ljava/lang/Object;)Ljava/lang/Object;"] = function(source) {
+Native["com/sun/cldc/io/ResourceInputStream.clone.(Ljava/lang/Object;)Ljava/lang/Object;"] = function(addr, source) {
     var obj = J2ME.newObject(CLASSES.java_lang_Object.klass);
     var sourceDecoder = getNative(source);
     setNative(obj, {
@@ -585,17 +585,17 @@ Native["com/sun/cldc/io/ResourceInputStream.clone.(Ljava/lang/Object;)Ljava/lang
     return obj;
 };
 
-Native["com/sun/cldc/io/ResourceInputStream.bytesRemain.(Ljava/lang/Object;)I"] = function(fileDecoder) {
+Native["com/sun/cldc/io/ResourceInputStream.bytesRemain.(Ljava/lang/Object;)I"] = function(addr, fileDecoder) {
     var handle = getNative(fileDecoder);
     return handle.data.length - handle.pos;
 };
 
-Native["com/sun/cldc/io/ResourceInputStream.readByte.(Ljava/lang/Object;)I"] = function(fileDecoder) {
+Native["com/sun/cldc/io/ResourceInputStream.readByte.(Ljava/lang/Object;)I"] = function(addr, fileDecoder) {
     var handle = getNative(fileDecoder);
     return (handle.data.length - handle.pos > 0) ? handle.data[handle.pos++] : -1;
 };
 
-Native["com/sun/cldc/io/ResourceInputStream.readBytes.(Ljava/lang/Object;[BII)I"] = function(fileDecoder, b, off, len) {
+Native["com/sun/cldc/io/ResourceInputStream.readBytes.(Ljava/lang/Object;[BII)I"] = function(addr, fileDecoder, b, off, len) {
     var handle = getNative(fileDecoder);
     var data = handle.data;
     var remaining = data.length - handle.pos;
@@ -607,34 +607,34 @@ Native["com/sun/cldc/io/ResourceInputStream.readBytes.(Ljava/lang/Object;[BII)I"
     return (len > 0) ? len : -1;
 };
 
-Native["java/lang/ref/WeakReference.initializeWeakReference.(Ljava/lang/Object;)V"] = function(target) {
+Native["java/lang/ref/WeakReference.initializeWeakReference.(Ljava/lang/Object;)V"] = function(addr, target) {
     // XXX Make these real weak references.
     setNative(this, target);
 };
 
-Native["java/lang/ref/WeakReference.get.()Ljava/lang/Object;"] = function() {
+Native["java/lang/ref/WeakReference.get.()Ljava/lang/Object;"] = function(addr) {
     var target = getNative(this);
     return target ? target : null;
 };
 
-Native["java/lang/ref/WeakReference.clear.()V"] = function() {
+Native["java/lang/ref/WeakReference.clear.()V"] = function(addr) {
     deleteNative(this);
 };
 
-Native["com/sun/cldc/isolate/Isolate.registerNewIsolate.()V"] = function() {
+Native["com/sun/cldc/isolate/Isolate.registerNewIsolate.()V"] = function(addr) {
     this._id = util.id();
 };
 
-Native["com/sun/cldc/isolate/Isolate.getStatus.()I"] = function() {
+Native["com/sun/cldc/isolate/Isolate.getStatus.()I"] = function(addr) {
     var runtime = Runtime.isolateMap[this._address];
     return runtime ? runtime.status : J2ME.RuntimeStatus.New;
 };
 
-Native["com/sun/cldc/isolate/Isolate.nativeStart.()V"] = function() {
+Native["com/sun/cldc/isolate/Isolate.nativeStart.()V"] = function(addr) {
     $.ctx.runtime.jvm.startIsolate(this);
 };
 
-Native["com/sun/cldc/isolate/Isolate.waitStatus.(I)V"] = function(status) {
+Native["com/sun/cldc/isolate/Isolate.waitStatus.(I)V"] = function(addr, status) {
     var runtime = Runtime.isolateMap[this._address];
     asyncImpl("V", new Promise(function(resolve, reject) {
         if (runtime.status >= status) {
@@ -652,11 +652,11 @@ Native["com/sun/cldc/isolate/Isolate.waitStatus.(I)V"] = function(status) {
     }));
 };
 
-Native["com/sun/cldc/isolate/Isolate.currentIsolate0.()Lcom/sun/cldc/isolate/Isolate;"] = function() {
+Native["com/sun/cldc/isolate/Isolate.currentIsolate0.()Lcom/sun/cldc/isolate/Isolate;"] = function(addr) {
     return getHandle($.ctx.runtime.isolateAddress);
 };
 
-Native["com/sun/cldc/isolate/Isolate.getIsolates0.()[Lcom/sun/cldc/isolate/Isolate;"] = function() {
+Native["com/sun/cldc/isolate/Isolate.getIsolates0.()[Lcom/sun/cldc/isolate/Isolate;"] = function(addr) {
     var isolates = J2ME.newObjectArray(Runtime.all.keys().length);
     var n = 0;
     Runtime.all.forEach(function (runtime) {
@@ -667,15 +667,15 @@ Native["com/sun/cldc/isolate/Isolate.getIsolates0.()[Lcom/sun/cldc/isolate/Isola
     return isolates;
 };
 
-Native["com/sun/cldc/isolate/Isolate.setPriority0.(I)V"] = function(newPriority) {
+Native["com/sun/cldc/isolate/Isolate.setPriority0.(I)V"] = function(addr, newPriority) {
     // XXX Figure out if there's anything to do here.  If not, say so.
 };
 
-Native["com/sun/j2me/content/AppProxy.midletIsAdded.(ILjava/lang/String;)V"] = function(suiteId, className) {
+Native["com/sun/j2me/content/AppProxy.midletIsAdded.(ILjava/lang/String;)V"] = function(addr, suiteId, className) {
   console.warn("com/sun/j2me/content/AppProxy.midletIsAdded.(ILjava/lang/String;)V not implemented");
 };
 
-Native["com/nokia/mid/impl/jms/core/Launcher.handleContent.(Ljava/lang/String;)V"] = function(content) {
+Native["com/nokia/mid/impl/jms/core/Launcher.handleContent.(Ljava/lang/String;)V"] = function(addr, content) {
     var fileName = J2ME.fromJavaString(content);
 
     var ext = fileName.split('.').pop().toLowerCase();
@@ -734,16 +734,16 @@ function addUnimplementedNative(signature, returnValue) {
         return doNotWarn();
     };
 
-    Native[signature] = function() { return warnOnce() };
+    Native[signature] = function(addr) { return warnOnce() };
 }
 
-Native["org/mozilla/internal/Sys.eval.(Ljava/lang/String;)V"] = function(src) {
+Native["org/mozilla/internal/Sys.eval.(Ljava/lang/String;)V"] = function(addr, src) {
     if (!release) {
         eval(J2ME.fromJavaString(src));
     }
 };
 
-Native["java/lang/String.intern.()Ljava/lang/String;"] = function() {
+Native["java/lang/String.intern.()Ljava/lang/String;"] = function(addr) {
   var internedStrings = J2ME.internedStrings;
   var internedString = internedStrings.getByRange(this.value, this.offset, this.count);
   if (internedString !== null) {
@@ -754,7 +754,7 @@ Native["java/lang/String.intern.()Ljava/lang/String;"] = function() {
 };
 
 var profileStarted = false;
-Native["org/mozilla/internal/Sys.startProfile.()V"] = function() {
+Native["org/mozilla/internal/Sys.startProfile.()V"] = function(addr) {
     if (profile === 4) {
         if (!profileStarted) {
             profileStarted = true;
@@ -766,7 +766,7 @@ Native["org/mozilla/internal/Sys.startProfile.()V"] = function() {
 };
 
 var profileSaved = false;
-Native["org/mozilla/internal/Sys.stopProfile.()V"] = function() {
+Native["org/mozilla/internal/Sys.stopProfile.()V"] = function(addr) {
     if (profile === 4) {
         if (!profileSaved) {
             profileSaved = true;

--- a/string.js
+++ b/string.js
@@ -19,25 +19,25 @@
 ////****************************************************************
 //// Constructors
 //
-//Native["java/lang/String.init.()V"] = function() {
+//Native["java/lang/String.init.()V"] = function(addr) {
 //  this.str = "";
 //};
 //
-//Native["java/lang/String.init.(Ljava/lang/String;)V"] = function(jStr) {
+//Native["java/lang/String.init.(Ljava/lang/String;)V"] = function(addr, jStr) {
 //  if (!jStr) {
 //    throw $.newNullPointerException();
 //  }
 //  this.str = jStr.str;
 //};
 //
-//Native["java/lang/String.init.([C)V"] = function(chars) {
+//Native["java/lang/String.init.([C)V"] = function(addr, chars) {
 //  if (!chars) {
 //    throw $.newNullPointerException();
 //  }
 //  this.str = util.fromJavaChars(chars);
 //};
 //
-//Native["java/lang/String.init.([CII)V"] = function(value, offset, count) {
+//Native["java/lang/String.init.([CII)V"] = function(addr, value, offset, count) {
 //  if (offset < 0 || count < 0 || offset > value.length - count) {
 //    throw $.newStringIndexOutOfBoundsException();
 //  }
@@ -88,18 +88,18 @@
 ////****************************************************************
 //// Methods
 //
-//Native["java/lang/String.length.()I"] = function() {
+//Native["java/lang/String.length.()I"] = function(addr) {
 //  return this.str.length;
 //};
 //
-//Native["java/lang/String.charAt.(I)C"] = function(index) {
+//Native["java/lang/String.charAt.(I)C"] = function(addr, index) {
 //  if (index < 0 || index >= this.str.length) {
 //    throw $.newStringIndexOutOfBoundsException();
 //  }
 //  return this.str.charCodeAt(index);
 //};
 //
-//Native["java/lang/String.getChars.(II[CI)V"] = function(srcBegin, srcEnd, dst, dstBegin) {
+//Native["java/lang/String.getChars.(II[CI)V"] = function(addr, srcBegin, srcEnd, dst, dstBegin) {
 //  if (srcBegin < 0 || srcEnd > this.str.length || srcBegin > srcEnd ||
 //      dstBegin + (srcEnd - srcBegin) > dst.length || dstBegin < 0) {
 //    throw $.newStringIndexOutOfBoundsException();
@@ -117,7 +117,7 @@
 //  return encoding;
 //}
 //
-//Native["java/lang/String.getBytes.(Ljava/lang/String;)[B"] = function(jEnc) {
+//Native["java/lang/String.getBytes.(Ljava/lang/String;)[B"] = function(addr, jEnc) {
 //  try {
 //    var encoding = normalizeEncoding(jEnc.str);
 //    return new Int8Array(new TextEncoder(encoding).encode(this.str));
@@ -126,19 +126,19 @@
 //  }
 //};
 //
-//Native["java/lang/String.getBytes.()[B"] = function() {
+//Native["java/lang/String.getBytes.()[B"] = function(addr) {
 //  return new Int8Array(new TextEncoder("utf-8").encode(this.str));
 //};
 //
-//Native["java/lang/String.equals.(Ljava/lang/Object;)Z"] = function(anObject) {
+//Native["java/lang/String.equals.(Ljava/lang/Object;)Z"] = function(addr, anObject) {
 //  return (isString(anObject) && anObject.str === this.str) ? 1 : 0;
 //};
 //
-//Native["java/lang/String.equalsIgnoreCase.(Ljava/lang/String;)Z"] = function(anotherString) {
+//Native["java/lang/String.equalsIgnoreCase.(Ljava/lang/String;)Z"] = function(addr, anotherString) {
 //  return (isString(anotherString) && anotherString.str.toLowerCase() === this.str.toLowerCase()) ? 1 : 0;
 //};
 //
-//Native["java/lang/String.compareTo.(Ljava/lang/String;)I"] = function(anotherString) {
+//Native["java/lang/String.compareTo.(Ljava/lang/String;)I"] = function(addr, anotherString) {
 //  // Sadly, JS String doesn't have a compareTo() method, so we must
 //  // replicate the Java algorithm. (There is String.localeCompare, but
 //  // that only returns {-1, 0, 1}, not a distance measure, which this
@@ -158,25 +158,25 @@
 //  return len1 - len2;
 //};
 //
-//Native["java/lang/String.regionMatches.(ZILjava/lang/String;II)Z"] = function(ignoreCase, toffset, other, ooffset, len) {
+//Native["java/lang/String.regionMatches.(ZILjava/lang/String;II)Z"] = function(addr, ignoreCase, toffset, other, ooffset, len) {
 //  var a = (ignoreCase ? this.str.toLowerCase() : this.str);
 //  var b = (ignoreCase ? other.str.toLowerCase() : other.str);
 //  return a.substr(toffset, len) === b.substr(ooffset, len) ? 1 : 0;
 //};
 //
-//Native["java/lang/String.startsWith.(Ljava/lang/String;I)Z"] = function(prefix, toffset) {
+//Native["java/lang/String.startsWith.(Ljava/lang/String;I)Z"] = function(addr, prefix, toffset) {
 //  return this.str.substr(toffset, prefix.str.length) === prefix.str ? 1 : 0;
 //};
 //
-//Native["java/lang/String.startsWith.(Ljava/lang/String;)Z"] = function(prefix) {
+//Native["java/lang/String.startsWith.(Ljava/lang/String;)Z"] = function(addr, prefix) {
 //  return this.str.substr(0, prefix.str.length) === prefix.str ? 1 : 0;
 //};
 //
-//Native["java/lang/String.endsWith.(Ljava/lang/String;)Z"] = function(suffix) {
+//Native["java/lang/String.endsWith.(Ljava/lang/String;)Z"] = function(addr, suffix) {
 //  return this.str.indexOf(suffix.str, this.str.length - suffix.str.length) !== -1 ? 1 : 0;
 //};
 //
-//Native["java/lang/String.hashCode.()I"] = function() {
+//Native["java/lang/String.hashCode.()I"] = function(addr) {
 //  var hash = 0;
 //  for (var i = 0; i < this.str.length; i++) {
 //    hash = Math.imul(31, hash) + this.str.charCodeAt(i) | 0;
@@ -184,45 +184,45 @@
 //  return hash;
 //};
 //
-//Native["java/lang/String.indexOf.(I)I"] = function(ch) {
+//Native["java/lang/String.indexOf.(I)I"] = function(addr, ch) {
 //  return this.str.indexOf(String.fromCharCode(ch));
 //};
 //
-//Native["java/lang/String.indexOf.(II)I"] = function(ch, fromIndex) {
+//Native["java/lang/String.indexOf.(II)I"] = function(addr, ch, fromIndex) {
 //  return this.str.indexOf(String.fromCharCode(ch), fromIndex);
 //};
 //
-//Native["java/lang/String.lastIndexOf.(I)I"] = function(ch) {
+//Native["java/lang/String.lastIndexOf.(I)I"] = function(addr, ch) {
 //  return this.str.lastIndexOf(String.fromCharCode(ch));
 //};
 //
-//Native["java/lang/String.lastIndexOf.(II)I"] = function(ch, fromIndex) {
+//Native["java/lang/String.lastIndexOf.(II)I"] = function(addr, ch, fromIndex) {
 //  return this.str.lastIndexOf(String.fromCharCode(ch), fromIndex);
 //};
 //
-//Native["java/lang/String.indexOf.(Ljava/lang/String;)I"] = function(s) {
+//Native["java/lang/String.indexOf.(Ljava/lang/String;)I"] = function(addr, s) {
 //  return this.str.indexOf(s.str);
 //};
 //
-//Native["java/lang/String.indexOf.(Ljava/lang/String;I)I"] = function(s, fromIndex) {
+//Native["java/lang/String.indexOf.(Ljava/lang/String;I)I"] = function(addr, s, fromIndex) {
 //  return this.str.indexOf(s.str, fromIndex);
 //};
 //
-//Native["java/lang/String.substring.(I)Ljava/lang/String;"] = function(beginIndex) {
+//Native["java/lang/String.substring.(I)Ljava/lang/String;"] = function(addr, beginIndex) {
 //  if (beginIndex < 0 || beginIndex > this.str.length) {
 //    throw $.newStringIndexOutOfBoundsException();
 //  }
 //  return J2ME.newString(this.str.substring(beginIndex));
 //};
 //
-//Native["java/lang/String.substring.(II)Ljava/lang/String;"] = function(beginIndex, endIndex) {
+//Native["java/lang/String.substring.(II)Ljava/lang/String;"] = function(addr, beginIndex, endIndex) {
 //  if (beginIndex < 0 || endIndex > this.str.length || beginIndex > endIndex) {
 //    throw $.newStringIndexOutOfBoundsException();
 //  }
 //  return J2ME.newString(this.str.substring(beginIndex, endIndex));
 //};
 //
-//Native["java/lang/String.concat.(Ljava/lang/String;)Ljava/lang/String;"] = function(s) {
+//Native["java/lang/String.concat.(Ljava/lang/String;)Ljava/lang/String;"] = function(addr, s) {
 //  return J2ME.newString(this.str + s.str);
 //};
 //
@@ -231,22 +231,22 @@
 //  return str.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&");
 //}
 //
-//Native["java/lang/String.replace.(CC)Ljava/lang/String;"] = function(oldChar, newChar) {
+//Native["java/lang/String.replace.(CC)Ljava/lang/String;"] = function(addr, oldChar, newChar) {
 //  // Using a RegExp here to replace all matches of oldChar, rather than just the first.
 //  return J2ME.newString(this.str.replace(
 //    new RegExp(escapeRegExp(String.fromCharCode(oldChar)), "g"),
 //    String.fromCharCode(newChar)));
 //};
 //
-//Native["java/lang/String.toLowerCase.()Ljava/lang/String;"] = function() {
+//Native["java/lang/String.toLowerCase.()Ljava/lang/String;"] = function(addr) {
 //  return J2ME.newString(this.str.toLowerCase());
 //};
 //
-//Native["java/lang/String.toUpperCase.()Ljava/lang/String;"] = function() {
+//Native["java/lang/String.toUpperCase.()Ljava/lang/String;"] = function(addr) {
 //  return J2ME.newString(this.str.toUpperCase());
 //};
 //
-//Native["java/lang/String.trim.()Ljava/lang/String;"] = function() {
+//Native["java/lang/String.trim.()Ljava/lang/String;"] = function(addr) {
 //  // Java's String.trim() removes any character <= ASCII 32;
 //  // JavaScript's only removes a few whitespacey chars.
 //  var start = 0;
@@ -261,11 +261,11 @@
 //  return J2ME.newString(this.str.substring(start, end));
 //};
 //
-//Native["java/lang/String.toString.()Ljava/lang/String;"] = function() {
+//Native["java/lang/String.toString.()Ljava/lang/String;"] = function(addr) {
 //  return this; // Note: returning "this" so that we keep the same object.
 //};
 //
-//Native["java/lang/String.toCharArray.()[C"] = function() {
+//Native["java/lang/String.toCharArray.()[C"] = function(addr) {
 //  return util.stringToCharArray(this.str);
 //};
 //
@@ -275,33 +275,33 @@
 //// NOTE: String.valueOf(Object) left in Java to avoid having to call
 //// back into Java for Object.toString().
 //
-//Native["java/lang/String.valueOf.([C)Ljava/lang/String;"] = function(chars) {
+//Native["java/lang/String.valueOf.([C)Ljava/lang/String;"] = function(addr, chars) {
 //  if (!chars) {
 //    throw $.newNullPointerException();
 //  }
 //  return J2ME.newString(util.fromJavaChars(chars));
 //};
 //
-//Native["java/lang/String.valueOf.([CII)Ljava/lang/String;"] = function(chars, offset, count) {
+//Native["java/lang/String.valueOf.([CII)Ljava/lang/String;"] = function(addr, chars, offset, count) {
 //  if (!chars) {
 //    throw $.newNullPointerException();
 //  }
 //  return J2ME.newString(util.fromJavaChars(chars, offset, count));
 //};
 //
-//Native["java/lang/String.valueOf.(Z)Ljava/lang/String;"] = function(bool) {
+//Native["java/lang/String.valueOf.(Z)Ljava/lang/String;"] = function(addr, bool) {
 //  return J2ME.newString(bool ? "true" : "false");
 //};
 //
-//Native["java/lang/String.valueOf.(C)Ljava/lang/String;"] = function(ch) {
+//Native["java/lang/String.valueOf.(C)Ljava/lang/String;"] = function(addr, ch) {
 //  return J2ME.newString(String.fromCharCode(ch));
 //};
 //
-//Native["java/lang/String.valueOf.(I)Ljava/lang/String;"] = function(n) {
+//Native["java/lang/String.valueOf.(I)Ljava/lang/String;"] = function(addr, n) {
 //  return J2ME.newString(n.toString());
 //};
 //
-//Native["java/lang/String.valueOf.(J)Ljava/lang/String;"] = function(l, h) {
+//Native["java/lang/String.valueOf.(J)Ljava/lang/String;"] = function(addr, l, h) {
 //  return J2ME.newString(J2ME.longToNumber(l, h).toString());
 //};
 //
@@ -313,7 +313,7 @@
 //
 //var internedStrings = J2ME.internedStrings;
 //
-//Native["java/lang/String.intern.()Ljava/lang/String;"] = function() {
+//Native["java/lang/String.intern.()Ljava/lang/String;"] = function(addr) {
 //    var string = J2ME.fromJavaString(this);
 //
 //    var internedString = internedStrings.get(string);
@@ -331,12 +331,12 @@
 ////################################################################
 //// java.lang.StringBuffer (manipulated via the 'buf' property)
 //
-//Native["java/lang/StringBuffer.init.()V"] = function() {
+//Native["java/lang/StringBuffer.init.()V"] = function(addr) {
 //  this.buf = new Uint16Array(16); // Initial buffer size: 16, per the Java implementation.
 //  this.count = 0;
 //};
 //
-//Native["java/lang/StringBuffer.init.(I)V"] = function(length) {
+//Native["java/lang/StringBuffer.init.(I)V"] = function(addr, length) {
 //  if (length < 0) {
 //    throw $.newNegativeArraySizeException();
 //  }
@@ -344,22 +344,22 @@
 //  this.count = 0;
 //};
 //
-//Native["java/lang/StringBuffer.init.(Ljava/lang/String;)V"] = function(jStr) {
+//Native["java/lang/StringBuffer.init.(Ljava/lang/String;)V"] = function(addr, jStr) {
 //  var stringBuf = util.stringToCharArray(jStr.str);
 //  this.buf = new Uint16Array(stringBuf.length + 16); // Add 16, per the Java implementation.
 //  this.buf.set(stringBuf, 0);
 //  this.count = stringBuf.length;
 //};
 //
-//Native["java/lang/StringBuffer.length.()I"] = function() {
+//Native["java/lang/StringBuffer.length.()I"] = function(addr) {
 //  return this.count;
 //};
 //
-//Native["java/lang/StringBuffer.capacity.()I"] = function() {
+//Native["java/lang/StringBuffer.capacity.()I"] = function(addr) {
 //  return this.buf.length;
 //};
 //
-//Native["java/lang/StringBuffer.copy.()V"] = function() {
+//Native["java/lang/StringBuffer.copy.()V"] = function(addr) {
 //  // We don't support copying (there's no need unless we also support shared buffers).
 //};
 //
@@ -380,7 +380,7 @@
 //  this.buf.set(oldBuf, 0);
 //}
 //
-//Native["java/lang/StringBuffer.ensureCapacity.(I)V"] = function(minCapacity) {
+//Native["java/lang/StringBuffer.ensureCapacity.(I)V"] = function(addr, minCapacity) {
 //  if (this.buf.length < minCapacity) {
 //    expandCapacity.call(this, minCapacity);
 //  }
@@ -388,7 +388,7 @@
 //
 //// StringBuffer.expandCapacity is private and not needed with these overrides.
 //
-//Native["java/lang/StringBuffer.setLength.(I)V"] = function(newLength) {
+//Native["java/lang/StringBuffer.setLength.(I)V"] = function(addr, newLength) {
 //  if (newLength < 0) {
 //    throw $.newStringIndexOutOfBoundsException();
 //  }
@@ -403,14 +403,14 @@
 //};
 //
 //
-//Native["java/lang/StringBuffer.charAt.(I)C"] = function(index) {
+//Native["java/lang/StringBuffer.charAt.(I)C"] = function(addr, index) {
 //  if (index < 0 || index >= this.count) {
 //    throw $.newStringIndexOutOfBoundsException();
 //  }
 //  return this.buf[index];
 //};
 //
-//Native["java/lang/StringBuffer.getChars.(II[CI)V"] = function(srcBegin, srcEnd, dst, dstBegin) {
+//Native["java/lang/StringBuffer.getChars.(II[CI)V"] = function(addr, srcBegin, srcEnd, dst, dstBegin) {
 //  if (srcBegin < 0 || srcEnd < 0 || srcEnd > this.count || srcBegin > srcEnd) {
 //    throw $.newStringIndexOutOfBoundsException();
 //  }
@@ -420,7 +420,7 @@
 //  dst.set(this.buf.subarray(srcBegin, srcEnd), dstBegin);
 //};
 //
-//Native["java/lang/StringBuffer.setCharAt.(IC)V"] = function(index, ch) {
+//Native["java/lang/StringBuffer.setCharAt.(IC)V"] = function(addr, index, ch) {
 //  if (index < 0 || index >= this.count) {
 //    throw $.newStringIndexOutOfBoundsException();
 //  }
@@ -453,18 +453,18 @@
 //
 //// StringBuffer.append(java.lang.Object) left in Java to avoid Object.toString().
 //
-//Native["java/lang/StringBuffer.append.(Ljava/lang/String;)Ljava/lang/StringBuffer;"] = function(jStr) {
+//Native["java/lang/StringBuffer.append.(Ljava/lang/String;)Ljava/lang/StringBuffer;"] = function(addr, jStr) {
 //  return stringBufferAppend.call(this, jStr ? jStr.str : "null");
 //};
 //
-//Native["java/lang/StringBuffer.append.([C)Ljava/lang/StringBuffer;"] = function(chars) {
+//Native["java/lang/StringBuffer.append.([C)Ljava/lang/StringBuffer;"] = function(addr, chars) {
 //  if (chars == null) {
 //    throw $.newNullPointerException();
 //  }
 //  return stringBufferAppend.call(this, chars);
 //};
 //
-//Native["java/lang/StringBuffer.append.([CII)Ljava/lang/StringBuffer;"] = function(chars, offset, length) {
+//Native["java/lang/StringBuffer.append.([CII)Ljava/lang/StringBuffer;"] = function(addr, chars, offset, length) {
 //  if (chars == null) {
 //    throw $.newNullPointerException();
 //  }
@@ -474,11 +474,11 @@
 //  return stringBufferAppend.call(this, chars.subarray(offset, offset + length));
 //};
 //
-//Native["java/lang/StringBuffer.append.(Z)Ljava/lang/StringBuffer;"] = function(bool) {
+//Native["java/lang/StringBuffer.append.(Z)Ljava/lang/StringBuffer;"] = function(addr, bool) {
 //  return stringBufferAppend.call(this, bool ? "true" : "false");
 //};
 //
-//Native["java/lang/StringBuffer.append.(C)Ljava/lang/StringBuffer;"] = function(ch) {
+//Native["java/lang/StringBuffer.append.(C)Ljava/lang/StringBuffer;"] = function(addr, ch) {
 //  if (this.buf.length < this.count + 1) {
 //    expandCapacity.call(this, this.count + 1);
 //  }
@@ -486,11 +486,11 @@
 //  return this;
 //};
 //
-//Native["java/lang/StringBuffer.append.(I)Ljava/lang/StringBuffer;"] = function(n) {
+//Native["java/lang/StringBuffer.append.(I)Ljava/lang/StringBuffer;"] = function(addr, n) {
 //  return stringBufferAppend.call(this, n + "");
 //};
 //
-//Native["java/lang/StringBuffer.append.(J)Ljava/lang/StringBuffer;"] = function(l, h) {
+//Native["java/lang/StringBuffer.append.(J)Ljava/lang/StringBuffer;"] = function(addr, l, h) {
 //  return stringBufferAppend.call(this, J2ME.longToNumber(l, h).toString());
 //};
 //
@@ -528,7 +528,7 @@
 //
 //Native["java/lang/StringBuffer.delete.(II)Ljava/lang/StringBuffer;"] = stringBufferDelete;
 //
-//Native["java/lang/StringBuffer.deleteCharAt.(I)Ljava/lang/StringBuffer;"] = function(index) {
+//Native["java/lang/StringBuffer.deleteCharAt.(I)Ljava/lang/StringBuffer;"] = function(addr, index) {
 //  if (index >= this.count) {
 //    // stringBufferDelete handles the other boundary checks; this check is specific to deleteCharAt.
 //    throw $.newStringIndexOutOfBoundsException();
@@ -566,27 +566,27 @@
 //
 //// StringBuffer.insert(Object) left in Java (for String.valueOf()).
 //
-//Native["java/lang/StringBuffer.insert.(ILjava/lang/String;)Ljava/lang/StringBuffer;"] = function(offset, jStr) {
+//Native["java/lang/StringBuffer.insert.(ILjava/lang/String;)Ljava/lang/StringBuffer;"] = function(addr, offset, jStr) {
 //  return stringBufferInsert.call(this, offset, jStr ? jStr.str : "null");
 //};
 //
-//Native["java/lang/StringBuffer.insert.(I[C)Ljava/lang/StringBuffer;"] = function(offset, chars) {
+//Native["java/lang/StringBuffer.insert.(I[C)Ljava/lang/StringBuffer;"] = function(addr, offset, chars) {
 //  return stringBufferInsert.call(this, offset, chars);
 //};
 //
-//Native["java/lang/StringBuffer.insert.(IZ)Ljava/lang/StringBuffer;"] = function(offset, bool) {
+//Native["java/lang/StringBuffer.insert.(IZ)Ljava/lang/StringBuffer;"] = function(addr, offset, bool) {
 //  return stringBufferInsert.call(this, offset, bool ? "true" : "false");
 //};
 //
-//Native["java/lang/StringBuffer.insert.(IC)Ljava/lang/StringBuffer;"] = function(offset, ch) {
+//Native["java/lang/StringBuffer.insert.(IC)Ljava/lang/StringBuffer;"] = function(addr, offset, ch) {
 //  return stringBufferInsert.call(this, offset, String.fromCharCode(ch));
 //};
 //
-//Native["java/lang/StringBuffer.insert.(II)Ljava/lang/StringBuffer;"] = function(offset, n) {
+//Native["java/lang/StringBuffer.insert.(II)Ljava/lang/StringBuffer;"] = function(addr, offset, n) {
 //  return stringBufferInsert.call(this, offset, n + "");
 //};
 //
-//Native["java/lang/StringBuffer.insert.(IJ)Ljava/lang/StringBuffer;"] = function(offset, l, h) {
+//Native["java/lang/StringBuffer.insert.(IJ)Ljava/lang/StringBuffer;"] = function(addr, offset, l, h) {
 //  return stringBufferInsert.call(this, offset, J2ME.longToNumber(l, h) + "");
 //};
 //
@@ -594,7 +594,7 @@
 //
 //// StringBuffer.insert(double) left in Java.
 //
-//Native["java/lang/StringBuffer.reverse.()Ljava/lang/StringBuffer;"] = function() {
+//Native["java/lang/StringBuffer.reverse.()Ljava/lang/StringBuffer;"] = function(addr) {
 //  var buf = this.buf;
 //  for (var i = 0, j = this.count - 1; i < j; i++, j--) {
 //    var tmp = buf[i];
@@ -604,15 +604,15 @@
 //  return this;
 //};
 //
-//Native["java/lang/StringBuffer.toString.()Ljava/lang/String;"] = function() {
+//Native["java/lang/StringBuffer.toString.()Ljava/lang/String;"] = function(addr) {
 //  return J2ME.newString(util.fromJavaChars(this.buf, 0, this.count));
 //};
 //
-//Native["java/lang/StringBuffer.setShared.()V"] = function() {
+//Native["java/lang/StringBuffer.setShared.()V"] = function(addr) {
 //  // Our StringBuffers are never shared. Everyone gets their very own!
 //};
 //
-//Native["java/lang/StringBuffer.getValue.()[C"] = function() {
+//Native["java/lang/StringBuffer.getValue.()[C"] = function(addr) {
 //  // In theory, this method should only be called by String (which
 //  // we've overridden to not do), so it should never be called. In any
 //  // case, mutating this buf would have the same effect here as it

--- a/tests/mozactivitymock.unprivileged.js
+++ b/tests/mozactivitymock.unprivileged.js
@@ -1,7 +1,7 @@
 /* -*- Mode: Java; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
 /* vim: set shiftwidth=2 tabstop=2 autoindent cindent expandtab: */
 
-Native["javax/wireless/messaging/SendSMSTest.getNumber.()Ljava/lang/String;"] = function() {
+Native["javax/wireless/messaging/SendSMSTest.getNumber.()Ljava/lang/String;"] = function(addr) {
   asyncImpl("Ljava/lang/String;", new Promise(function(resolve, reject) {
     var sender = DumbPipe.open("lastSMSNumber", {}, function(lastSMSNumber) {
       DumbPipe.close(sender);
@@ -10,7 +10,7 @@ Native["javax/wireless/messaging/SendSMSTest.getNumber.()Ljava/lang/String;"] = 
   }));
 };
 
-Native["javax/wireless/messaging/SendSMSTest.getBody.()Ljava/lang/String;"] = function() {
+Native["javax/wireless/messaging/SendSMSTest.getBody.()Ljava/lang/String;"] = function(addr) {
   asyncImpl("Ljava/lang/String;", new Promise(function(resolve, reject) {
     var sender = DumbPipe.open("lastSMSBody", {}, function(lastSMSBody) {
       DumbPipe.close(sender);
@@ -19,7 +19,7 @@ Native["javax/wireless/messaging/SendSMSTest.getBody.()Ljava/lang/String;"] = fu
   }));
 };
 
-Native["com/sun/midp/midlet/AddContactTest.getNumber.()Ljava/lang/String;"] = function() {
+Native["com/sun/midp/midlet/AddContactTest.getNumber.()Ljava/lang/String;"] = function(addr) {
   asyncImpl("Ljava/lang/String;", new Promise(function(resolve, reject) {
     var sender = DumbPipe.open("lastAddContactParams", {}, function(lastAddContactParams) {
       DumbPipe.close(sender);
@@ -28,7 +28,7 @@ Native["com/sun/midp/midlet/AddContactTest.getNumber.()Ljava/lang/String;"] = fu
   }));
 };
 
-Native["com/sun/midp/midlet/AddContactTest.hasNumber.()Z"] = function() {
+Native["com/sun/midp/midlet/AddContactTest.hasNumber.()Z"] = function(addr) {
   asyncImpl("Z", new Promise(function(resolve, reject) {
     var sender = DumbPipe.open("lastAddContactParams", {}, function(lastAddContactParams) {
       DumbPipe.close(sender);

--- a/tests/native.js
+++ b/tests/native.js
@@ -1,27 +1,27 @@
 /* -*- Mode: Java; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
 /* vim: set shiftwidth=2 tabstop=2 autoindent cindent expandtab: */
 
-Native["gnu/testlet/vm/NativeTest.getInt.()I"] = function() {
+Native["gnu/testlet/vm/NativeTest.getInt.()I"] = function(addr) {
   return ~~(0xFFFFFFFF);
 };
 
-Native["gnu/testlet/vm/NativeTest.getLongReturnLong.(J)J"] = function(valLow, valHigh) {
+Native["gnu/testlet/vm/NativeTest.getLongReturnLong.(J)J"] = function(addr, valLow, valHigh) {
   return J2ME.returnLong(valLow + 40, valHigh);
 };
 
-Native["gnu/testlet/vm/NativeTest.getLongReturnInt.(J)I"] = function(valLow, valHigh) {
+Native["gnu/testlet/vm/NativeTest.getLongReturnInt.(J)I"] = function(addr, valLow, valHigh) {
   return ~~(40 + J2ME.longToNumber(valLow, valHigh));
 };
 
-Native["gnu/testlet/vm/NativeTest.getIntReturnLong.(I)J"] = function(val) {
+Native["gnu/testlet/vm/NativeTest.getIntReturnLong.(I)J"] = function(addr, val) {
   return J2ME.returnLongValue(40 + val);
 };
 
-Native["gnu/testlet/vm/NativeTest.throwException.()V"] = function() {
+Native["gnu/testlet/vm/NativeTest.throwException.()V"] = function(addr) {
   throw $.newNullPointerException("An exception");
 };
 
-Native["gnu/testlet/vm/NativeTest.throwExceptionAfterPause.()V"] = function() {
+Native["gnu/testlet/vm/NativeTest.throwExceptionAfterPause.()V"] = function(addr) {
   var ctx = $.ctx;
   asyncImpl("V", new Promise(function(resolve, reject) {
     setTimeout(function() {
@@ -31,25 +31,25 @@ Native["gnu/testlet/vm/NativeTest.throwExceptionAfterPause.()V"] = function() {
   }));
 };
 
-Native["gnu/testlet/vm/NativeTest.returnAfterPause.()I"] = function() {
+Native["gnu/testlet/vm/NativeTest.returnAfterPause.()I"] = function(addr) {
   asyncImpl("I", new Promise(function(resolve, reject) {
     setTimeout(resolve.bind(null, 42), 100);
   }));
 };
 
-Native["gnu/testlet/vm/NativeTest.nonStatic.(I)I"] = function(val) {
+Native["gnu/testlet/vm/NativeTest.nonStatic.(I)I"] = function(addr, val) {
   return val + 40;
 };
 
-Native["gnu/testlet/vm/NativeTest.fromJavaString.(Ljava/lang/String;)I"] = function(str) {
+Native["gnu/testlet/vm/NativeTest.fromJavaString.(Ljava/lang/String;)I"] = function(addr, str) {
   return J2ME.fromJavaString(str).length;
 };
 
-Native["gnu/testlet/vm/NativeTest.decodeUtf8.([B)I"] = function(str) {
+Native["gnu/testlet/vm/NativeTest.decodeUtf8.([B)I"] = function(addr, str) {
   return util.decodeUtf8(str).length;
 };
 
-Native["gnu/testlet/vm/NativeTest.newFunction.()Z"] = function() {
+Native["gnu/testlet/vm/NativeTest.newFunction.()Z"] = function(addr) {
   try {
     var fn = new Function("return true;");
     return fn() ? 1 : 0;
@@ -59,7 +59,7 @@ Native["gnu/testlet/vm/NativeTest.newFunction.()Z"] = function() {
   }
 };
 
-Native["gnu/testlet/vm/NativeTest.dumbPipe.()Z"] = function() {
+Native["gnu/testlet/vm/NativeTest.dumbPipe.()Z"] = function(addr) {
   asyncImpl("Z", new Promise(function(resolve, reject) {
     // Ensure we can echo a large amount of data.
     var array = [];
@@ -72,26 +72,26 @@ Native["gnu/testlet/vm/NativeTest.dumbPipe.()Z"] = function() {
   }));
 };
 
-Native["com/nokia/mid/ui/TestVirtualKeyboard.hideKeyboard.()V"] = function() {
+Native["com/nokia/mid/ui/TestVirtualKeyboard.hideKeyboard.()V"] = function(addr) {
   MIDP.isVKVisible = function() { return false; };
   MIDP.sendVirtualKeyboardEvent();
 };
 
-Native["com/nokia/mid/ui/TestVirtualKeyboard.showKeyboard.()V"] = function() {
+Native["com/nokia/mid/ui/TestVirtualKeyboard.showKeyboard.()V"] = function(addr) {
   MIDP.isVKVisible = function() { return true; };
   MIDP.sendVirtualKeyboardEvent();
 };
 
-Native["javax/microedition/lcdui/TestAlert.isTextEditorReallyFocused.()Z"] = function() {
+Native["javax/microedition/lcdui/TestAlert.isTextEditorReallyFocused.()Z"] = function(addr) {
   return (currentlyFocusedTextEditor && currentlyFocusedTextEditor.focused) ? 1 : 0;
 };
 
-Native["javax/microedition/lcdui/TestTextEditorFocus.isTextEditorReallyFocused.(Lcom/nokia/mid/ui/TextEditor;)Z"] = function(textEditor) {
+Native["javax/microedition/lcdui/TestTextEditorFocus.isTextEditorReallyFocused.(Lcom/nokia/mid/ui/TextEditor;)Z"] = function(addr, textEditor) {
   var nativeTextEditor = getNative(textEditor);
   return (currentlyFocusedTextEditor == nativeTextEditor && currentlyFocusedTextEditor.focused) ? 1 : 0;
 };
 
-Native["gnu/testlet/TestHarness.getNumDifferingPixels.(Ljava/lang/String;)I"] = function(pathStr) {
+Native["gnu/testlet/TestHarness.getNumDifferingPixels.(Ljava/lang/String;)I"] = function(addr, pathStr) {
   var path = J2ME.fromJavaString(pathStr);
   asyncImpl("I", new Promise(function(resolve, reject) {
     var gotCanvas = document.getElementById("canvas");
@@ -137,26 +137,26 @@ Native["gnu/testlet/TestHarness.getNumDifferingPixels.(Ljava/lang/String;)I"] = 
   }));
 };
 
-Native["com/nokia/mid/impl/jms/core/TestLauncher.checkImageModalDialog.()Z"] = function() {
+Native["com/nokia/mid/impl/jms/core/TestLauncher.checkImageModalDialog.()Z"] = function(addr) {
   return document.getElementById("image-launcher") != null ? 1 : 0;
 };
 
-Native["org/mozilla/io/TestNokiaPhoneStatusServer.sendFakeOnlineEvent.()V"] = function() {
+Native["org/mozilla/io/TestNokiaPhoneStatusServer.sendFakeOnlineEvent.()V"] = function(addr) {
   window.dispatchEvent(new CustomEvent("online"));
 };
 
-Native["org/mozilla/io/TestNokiaPhoneStatusServer.sendFakeOfflineEvent.()V"] = function() {
+Native["org/mozilla/io/TestNokiaPhoneStatusServer.sendFakeOfflineEvent.()V"] = function(addr) {
   window.dispatchEvent(new CustomEvent("offline"));
 };
 
-Native["javax/microedition/media/TestAudioRecorder.convert3gpToAmr.([B)[B"] = function(data) {
+Native["javax/microedition/media/TestAudioRecorder.convert3gpToAmr.([B)[B"] = function(addr, data) {
   var converted = Media.convert3gpToAmr(new Uint8Array(data));
   var result = J2ME.newByteArray(converted.length);
   result.set(converted);
   return result;
 };
 
-Native["com/sun/midp/i18n/TestResourceConstants.setLanguage.(Ljava/lang/String;)V"] = function(language) {
+Native["com/sun/midp/i18n/TestResourceConstants.setLanguage.(Ljava/lang/String;)V"] = function(addr, language) {
   MIDP.localizedStrings = null;
   config.language = J2ME.fromJavaString(language);
 }
@@ -165,7 +165,7 @@ Native["com/sun/midp/i18n/TestResourceConstants.setLanguage.(Ljava/lang/String;)
 // so add it to the list of valid roots.
 MIDP.fsRoots.push("/");
 
-Native["org/mozilla/MemorySampler.sampleMemory.(Ljava/lang/String;)V"] = function(label) {
+Native["org/mozilla/MemorySampler.sampleMemory.(Ljava/lang/String;)V"] = function(addr, label) {
   if (typeof Benchmark !== "undefined") {
     asyncImpl("V", Benchmark.sampleMemory().then(function(memory) {
       var keys = ["totalSize", "domSize", "styleSize", "jsObjectsSize", "jsStringsSize", "jsOtherSize", "otherSize"];
@@ -179,11 +179,11 @@ Native["org/mozilla/MemorySampler.sampleMemory.(Ljava/lang/String;)V"] = functio
   }
 };
 
-Native["org/mozilla/Test.callSyncNative.()V"] = function() {
+Native["org/mozilla/Test.callSyncNative.()V"] = function(addr) {
   // A noop sync implementation for comparison with the noop async one.
 };
 
-Native["org/mozilla/Test.callAsyncNative.()V"] = function() {
+Native["org/mozilla/Test.callAsyncNative.()V"] = function(addr) {
   // A noop async implementation for comparison with the noop sync one.
   asyncImpl("V", new Promise(function (resolve, reject) {
     resolve();
@@ -197,7 +197,7 @@ Native["org/mozilla/Test.callAsyncNative.()V"] = function() {
 var readerOpened = false;
 var readerOpenedWaiting = null;
 
-Native["tests/recordstore/ReaderMIDlet.readerOpened.()V"] = function() {
+Native["tests/recordstore/ReaderMIDlet.readerOpened.()V"] = function(addr) {
   readerOpened = true;
 
   if (readerOpenedWaiting) {
@@ -205,7 +205,7 @@ Native["tests/recordstore/ReaderMIDlet.readerOpened.()V"] = function() {
   }
 };
 
-Native["tests/recordstore/WriterMIDlet.waitReaderOpened.()V"] = function() {
+Native["tests/recordstore/WriterMIDlet.waitReaderOpened.()V"] = function(addr) {
   asyncImpl("V", new Promise(function(resolve, reject) {
     if (readerOpened) {
       resolve();
@@ -218,7 +218,7 @@ Native["tests/recordstore/WriterMIDlet.waitReaderOpened.()V"] = function() {
 var writerWrote = false;
 var writerWroteWaiting = null;
 
-Native["tests/recordstore/WriterMIDlet.writerWrote.()V"] = function() {
+Native["tests/recordstore/WriterMIDlet.writerWrote.()V"] = function(addr) {
   writerWrote = true;
 
   if (writerWroteWaiting) {
@@ -226,7 +226,7 @@ Native["tests/recordstore/WriterMIDlet.writerWrote.()V"] = function() {
   }
 };
 
-Native["tests/recordstore/ReaderMIDlet.waitWriterWrote.()V"] = function() {
+Native["tests/recordstore/ReaderMIDlet.waitWriterWrote.()V"] = function(addr) {
   asyncImpl("V", new Promise(function(resolve, reject) {
     if (writerWrote) {
       resolve();
@@ -236,42 +236,42 @@ Native["tests/recordstore/ReaderMIDlet.waitWriterWrote.()V"] = function() {
   }));
 };
 
-Native["tests/background/DestroyMIDlet.sendDestroyMIDletEvent.()V"] = function() {
+Native["tests/background/DestroyMIDlet.sendDestroyMIDletEvent.()V"] = function(addr) {
   MIDP.setDestroyedForRestart(true);
   MIDP.sendDestroyMIDletEvent(J2ME.newString("tests.background.DestroyMIDlet"));
 };
 
-Native["tests/background/DestroyMIDlet.sendExecuteMIDletEvent.()V"] = function() {
+Native["tests/background/DestroyMIDlet.sendExecuteMIDletEvent.()V"] = function(addr) {
   setTimeout(function() {
     MIDP.sendExecuteMIDletEvent();
   }, 0);
 };
 
 var called = 0;
-Native["tests/background/DestroyMIDlet.maybePrintDone.()V"] = function() {
+Native["tests/background/DestroyMIDlet.maybePrintDone.()V"] = function(addr) {
   if (++called === 2) {
     console.log("DONE");
   }
 };
 
-Native["javax/microedition/content/TestContentHandler.addInvocation.(Ljava/lang/String;Ljava/lang/String;)V"] = function(argument, action) {
+Native["javax/microedition/content/TestContentHandler.addInvocation.(Ljava/lang/String;Ljava/lang/String;)V"] = function(addr, argument, action) {
   Content.addInvocation(J2ME.fromJavaString(argument), J2ME.fromJavaString(action));
 };
 
 var ContentHandlerMIDletStarted = 0;
 
 Native["tests/midlets/ContentHandlerMIDlet.sendShareMessage.()V"] =
-Native["tests/midlets/ContentHandlerStarterMIDlet.sendShareMessage.()V"] = function() {
+Native["tests/midlets/ContentHandlerStarterMIDlet.sendShareMessage.()V"] = function(addr) {
   DumbPipe.close(DumbPipe.open("callShareActivityMessageHandler", { num: ContentHandlerMIDletStarted }));
 };
 
-Native["tests/midlets/ContentHandlerStarterMIDlet.startMIDlet.()V"] = function() {
+Native["tests/midlets/ContentHandlerStarterMIDlet.startMIDlet.()V"] = function(addr) {
   setTimeout(function() {
     MIDP.sendExecuteMIDletEvent(1, J2ME.newString("tests.midlets.ContentHandlerMIDlet"));
   }, 0);
 };
 
-Native["tests/midlets/ContentHandlerMIDlet.shouldStop.()Z"] = function() {
+Native["tests/midlets/ContentHandlerMIDlet.shouldStop.()Z"] = function(addr) {
   if (++ContentHandlerMIDletStarted === 3) {
     return 1;
   }


### PR DESCRIPTION
This passes the address of the *this* object as the first argument to every native function call. It doesn't yet make the interpreter stop binding natives to handles, however. Nor does it make the natives use the *addr* value to get handles (except in a few test cases in nat.ts).

This is based on top of intex-object-layout (#1659), but I can't request a pull into that branch within the https://github.com/mozilla/pluotsorbet repository, since that branch is in my personal repository, so the diff view doesn't here show an accurate set of changes.
