### PR TITLE
Use addresses in Object::wait and Object::notify and cleanup invoke*

### DIFF
--- a/int.ts
+++ b/int.ts
@@ -1709,7 +1709,7 @@ module J2ME {
               object = null;
             } else {
               address = ref[sp - calleeMethodInfo.argumentSlots];
-              if (address === null || address === Constants.NULL) {
+              if (address === Constants.NULL) {
                 object = null;
                 klass = null;
               } else if (typeof address === "number") {

--- a/int.ts
+++ b/int.ts
@@ -555,7 +555,7 @@ module J2ME {
 
     var tag: TAGS;
     var type, size;
-    var value, index, arrayAddr: number, object, klass, offset, buffer, tag: TAGS, targetPC;
+    var value, index, arrayAddr: number, klass, offset, buffer, tag: TAGS, targetPC;
     var address = 0, isStatic = false;
     var ia = 0, ib = 0; // Integer Operands
     var ll = 0, lh = 0; // Long Low / High
@@ -950,9 +950,9 @@ module J2ME {
             sp += 2;
             continue;
           case Bytecodes.SWAP:
-            ia = i32[sp - 1];               object = ref[sp - 1];
+            ia = i32[sp - 1];               address = ref[sp - 1];
             i32[sp - 1] = i32[sp - 2];      ref[sp - 1] = ref[sp - 2];
-            i32[sp - 2] = ia;               ref[sp - 2] = object;
+            i32[sp - 2] = ia;               ref[sp - 2] = address;
             continue;
           case Bytecodes.IINC:
             index = code[pc++];

--- a/int.ts
+++ b/int.ts
@@ -1706,16 +1706,10 @@ module J2ME {
             var callee = null;
 
             if (isStatic) {
-              object = null;
+              address = Constants.NULL;
             } else {
               address = ref[sp - calleeMethodInfo.argumentSlots];
-              if (address === Constants.NULL) {
-                object = null;
-                klass = null;
-              } else {
-                object = getHandle(address);
-                klass = klassIdMap[i32[address >> 2]];
-              }
+              klass = (address !== Constants.NULL) ? klassIdMap[i32[address >> 2]] : null;
             }
 
             if (isStatic) {
@@ -1727,7 +1721,7 @@ module J2ME {
 
             switch (op) {
               case Bytecodes.INVOKESPECIAL:
-                if (!object) {
+                if (address === Constants.NULL) {
                   thread.throwException(fp, sp, opPC, ExceptionType.NullPointerException);
                 }
               case Bytecodes.INVOKESTATIC:
@@ -1877,7 +1871,7 @@ module J2ME {
             if (calleeTargetMethodInfo.isSynchronized) {
               monitor = calleeTargetMethodInfo.isStatic
                 ? calleeTargetMethodInfo.classInfo.getClassObject()
-                : getMonitor(object);
+                : getMonitor(address);
               ref[fp + FrameLayout.MonitorOffset] = monitor;
               $.ctx.monitorEnter(monitor);
               release || assert(U !== VMState.Yielding, "Monitors should never yield.");

--- a/int.ts
+++ b/int.ts
@@ -88,7 +88,6 @@ module J2ME {
       return 0;
     }
 
-
     // XXX Also check that |reference instanceof java.lang.Object|?
     if ("_address" in reference) {
       return reference._address;
@@ -1719,12 +1718,14 @@ module J2ME {
               if (address === null || address === 0) {
                 object = null;
                 klass = null;
+                address = 0;
               } else if (typeof address === "number") {
                 object = getHandle(address);
                 klass = klassIdMap[i32[address >> 2]];
               } else {
                 object = address;
                 klass = object["klass"];
+                address = object._address;
               }
             }
 
@@ -1769,7 +1770,7 @@ module J2ME {
 
                 thread.set(fp, sp, opPC);
 
-                returnValue = callee.call(object, object ? object._address : 0);
+                returnValue = callee.call(object, address);
               } else {
                 args.length = 0;
 
@@ -1823,7 +1824,7 @@ module J2ME {
                   // assert(callee.length === args.length, "Function " + callee + " (" + calleeTargetMethodInfo.implKey + "), should have " + args.length + " arguments.");
                 }
 
-                args.unshift(object ? object._address : 0);
+                args.unshift(address);
                 returnValue = callee.apply(object, args);
               }
 

--- a/int.ts
+++ b/int.ts
@@ -1712,13 +1712,9 @@ module J2ME {
               if (address === Constants.NULL) {
                 object = null;
                 klass = null;
-              } else if (typeof address === "number") {
+              } else {
                 object = getHandle(address);
                 klass = klassIdMap[i32[address >> 2]];
-              } else {
-                object = address;
-                klass = object["klass"];
-                address = object._address;
               }
             }
 
@@ -1791,16 +1787,7 @@ module J2ME {
                     case Kind.Reference:
                       // XXX Update natives to expect addresses and stop passing
                       // handles.
-                      var paramAddress = ref[--sp];
-                      if (typeof paramAddress === "number") {
-                        if (paramAddress === Constants.NULL) {
-                          args.unshift(null);
-                        } else {
-                          args.unshift(getHandle(paramAddress));
-                        }
-                      } else {
-                        args.unshift(paramAddress);
-                      }
+                      args.unshift(getHandle(ref[--sp]));
                       break;
                     default:
                       release || assert(false, "Invalid Kind: " + Kind[kind]);

--- a/nat.ts
+++ b/nat.ts
@@ -111,19 +111,16 @@ module J2ME {
   };
 
   Native["java/lang/Object.wait.(J)V"] = function(addr: number, timeoutL: number, timeoutH: number) {
-    var self = getHandle(addr);
-    $.ctx.wait(self, longToNumber(timeoutL, timeoutH));
+    $.ctx.wait(addr, longToNumber(timeoutL, timeoutH));
     $.ctx.nativeThread.advancePastInvokeBytecode();
   };
 
   Native["java/lang/Object.notify.()V"] = function(addr: number) {
-    var self = getHandle(addr);
-    $.ctx.notify(self, false);
+    $.ctx.notify(addr, false);
   };
 
   Native["java/lang/Object.notifyAll.()V"] = function(addr: number) {
-    var self = getHandle(addr);
-    $.ctx.notify(self, true);
+    $.ctx.notify(addr, true);
   };
 
   Native["org/mozilla/internal/Sys.getUnwindCount.()I"] = function(addr: number) {

--- a/vm/context.ts
+++ b/vm/context.ts
@@ -641,8 +641,8 @@ module J2ME {
       this.unblock(monitor, "ready", false);
     }
 
-    wait(object: java.lang.Object, timeout: number) {
-      var monitor = getMonitor(object);
+    wait(objectAddr: number, timeout: number) {
+      var monitor = getMonitor(objectAddr);
       var lock = monitor._lock;
       if (timeout < 0)
         throw $.newIllegalArgumentException();
@@ -669,8 +669,8 @@ module J2ME {
       this.block(monitor, "waiting", lockLevel);
     }
 
-    notify(object: java.lang.Object, notifyAll: boolean) {
-      var monitor = getMonitor(object);
+    notify(objectAddr: number, notifyAll: boolean) {
+      var monitor = getMonitor(objectAddr);
       if (!monitor._lock || monitor._lock.threadAddress !== this.threadAddress)
         throw $.newIllegalMonitorStateException();
 

--- a/vm/runtime.ts
+++ b/vm/runtime.ts
@@ -1969,7 +1969,6 @@ module J2ME {
     i32[(addr >> 2) + 1] = size;
     // XXX: To remove
     (<any>arr).klass = constructor;
-    (<any>arr)._address = addr;
     arrayMap[addr] = arr;
 
     return addr;


### PR DESCRIPTION
This depends on #1685 and #1676.

Passing addresses to Object::wait and Object::nofify allows us to remove the "_address" property from arrays.