### PR TITLE
increase main automation test timeout

### DIFF
--- a/tests/automation.js
+++ b/tests/automation.js
@@ -16,7 +16,7 @@ casper.on('remote.message', function(message) {
     this.echo(message);
 });
 
-casper.options.waitTimeout = 80000;
+casper.options.waitTimeout = 90000;
 casper.options.verbose = true;
 casper.options.viewportSize = { width: 240, height: 320 };
 casper.options.clientScripts = [


### PR DESCRIPTION
When my machine is under load, it takes more than 80 seconds for the basic unit tests to run, so they time out. This change increases the timeout to 90 seconds.