### PR TITLE
Get rid of canonicalizeRef (almost)

### DIFF
--- a/int.ts
+++ b/int.ts
@@ -1852,7 +1852,7 @@ module J2ME {
                   i32[sp++] = returnValue;
                   continue;
                 case Kind.Reference:
-                  release || assert(returnValue === "number", "native return value is a number");
+                  release || assert(returnValue !== "number", "native return value is a number");
                   ref[sp++] = returnValue;
                   continue;
                 case Kind.Void:

--- a/int.ts
+++ b/int.ts
@@ -184,7 +184,7 @@ module J2ME {
     setParameter(kind: Kind, i: number, v: any) {
       switch (kind) {
         case Kind.Reference:
-          ref[this.fp + this.parameterOffset + i] = canonicalizeRef(v);
+          ref[this.fp + this.parameterOffset + i] = v;
           break;
         case Kind.Int:
           i32[this.fp + this.parameterOffset + i] = v;
@@ -461,10 +461,10 @@ module J2ME {
       var kinds = methodInfo.signatureKinds;
       var index = 0;
       if (!methodInfo.isStatic) {
-        frame.setParameter(Kind.Reference, index++, this);
+        frame.setParameter(Kind.Reference, index++, canonicalizeRef(this));
       }
       for (var i = 1; i < kinds.length; i++) {
-        frame.setParameter(kinds[i], index++, arguments[i - 1]);
+        frame.setParameter(kinds[i], index++, canonicalizeRef(arguments[i - 1]));
       }
       if (methodInfo.isSynchronized) {
         var monitor = methodInfo.isStatic ? methodInfo.classInfo.getClassObject() : getMonitor(this);

--- a/int.ts
+++ b/int.ts
@@ -1852,7 +1852,8 @@ module J2ME {
                   i32[sp++] = returnValue;
                   continue;
                 case Kind.Reference:
-                  ref[sp++] = canonicalizeRef(returnValue);
+                  release || assert(returnValue === "number", "native return value is a number");
+                  ref[sp++] = returnValue;
                   continue;
                 case Kind.Void:
                   continue;

--- a/int.ts
+++ b/int.ts
@@ -84,7 +84,7 @@ module J2ME {
       return reference;
     }
 
-    if (reference === null || reference === Constants.NULL) {
+    if (reference === null) {
       return Constants.NULL;
     }
 
@@ -1463,7 +1463,7 @@ module J2ME {
 
             switch (fieldInfo.kind) {
               case Kind.Reference:
-                ref[sp++] = canonicalizeRef(ref[address >> 2]);
+                ref[sp++] = ref[address >> 2];
                 continue;
               case Kind.Int:
               case Kind.Byte:

--- a/midp/content.js
+++ b/midp/content.js
@@ -21,7 +21,7 @@ var Content = (function() {
 
   Native["com/sun/j2me/content/RegistryStore.forSuite0.(I)Ljava/lang/String;"] = function(suiteID) {
     if (!chRegisteredClassName) {
-      return null;
+      return J2ME.Constants.NULL;
     }
 
     var serializedString = serializeString([
@@ -34,7 +34,7 @@ var Content = (function() {
     return J2ME.newString(String.fromCharCode(serializedString.length * 2) + serializedString);
   };
 
-  addUnimplementedNative("com/sun/j2me/content/RegistryStore.findHandler0.(Ljava/lang/String;ILjava/lang/String;)Ljava/lang/String;", null);
+  addUnimplementedNative("com/sun/j2me/content/RegistryStore.findHandler0.(Ljava/lang/String;ILjava/lang/String;)Ljava/lang/String;", J2ME.Constants.NULL);
 
   Native["com/sun/j2me/content/RegistryStore.register0.(ILjava/lang/String;Lcom/sun/j2me/content/ContentHandlerRegData;)Z"] = function(storageId, className, handlerData) {
     var registerID = J2ME.fromJavaString(getHandle(handlerData.ID));
@@ -71,7 +71,7 @@ var Content = (function() {
 
   Native["com/sun/j2me/content/RegistryStore.getHandler0.(Ljava/lang/String;Ljava/lang/String;I)Ljava/lang/String;"] = function(callerId, id, mode) {
     if (!chRegisteredClassName) {
-      return null;
+      return J2ME.Constants.NULL;
     }
 
     if (mode != 0) {

--- a/midp/fs.js
+++ b/midp/fs.js
@@ -249,7 +249,7 @@ Native["com/sun/midp/rms/RecordStoreRegistry.getRecordStoreListeners.(ILjava/lan
 function(suiteId, storeName) {
     console.warn("RecordStoreRegistry.getRecordStoreListeners.(IL...String;)[I not implemented (" +
                  suiteId + ", " + J2ME.fromJavaString(storeName) + ")");
-    return null;
+    return J2ME.Constants.NULL;
 };
 
 Native["com/sun/midp/rms/RecordStoreRegistry.sendRecordStoreChangeEvent.(ILjava/lang/String;II)V"] =

--- a/midp/gfx.js
+++ b/midp/gfx.js
@@ -30,7 +30,7 @@ var currentlyFocusedTextEditor;
     };
 
     Native["com/sun/midp/lcdui/DisplayDevice.getDisplayName0.(I)Ljava/lang/String;"] = function(id) {
-        return null;
+        return J2ME.Constants.NULL;
     };
 
     Native["com/sun/midp/lcdui/DisplayDevice.isDisplayPrimary0.(I)Z"] = function(id) {
@@ -416,7 +416,7 @@ var currentlyFocusedTextEditor;
     }
 
     Native["javax/microedition/lcdui/Font.getDefaultFont.()Ljavax/microedition/lcdui/Font;"] = function() {
-        return getDefaultFont();
+        return getDefaultFont()._address;
     };
 
     Native["javax/microedition/lcdui/Font.stringWidth.(Ljava/lang/String;)I"] = function(str) {
@@ -641,7 +641,7 @@ var currentlyFocusedTextEditor;
     };
 
     Native["javax/microedition/lcdui/Graphics.getFont.()Ljavax/microedition/lcdui/Font;"] = function() {
-        return getNative(this).currentFont;
+        return getNative(this).currentFont._address;
     };
 
     Native["javax/microedition/lcdui/Graphics.setFont.(Ljavax/microedition/lcdui/Font;)V"] = function(font) {

--- a/midp/media.js
+++ b/midp/media.js
@@ -161,10 +161,10 @@ Native["com/sun/mmedia/DefaultConfiguration.nListContentTypesNext.(I)Ljava/lang/
     var cached = Media.ListCache.get(hdlr);
     if (!cached) {
         console.error("Invalid hdlr: " + hdlr);
-        return null;
+        return J2ME.Constants.NULL;
     }
     var s = cached.shift();
-    return s ? J2ME.newString(s) : null;
+    return s ? J2ME.newString(s) : J2ME.Constants.NULL;
 };
 
 Native["com/sun/mmedia/DefaultConfiguration.nListContentTypesClose.(I)V"] = function(hdlr) {
@@ -189,10 +189,10 @@ Native["com/sun/mmedia/DefaultConfiguration.nListProtocolsNext.(I)Ljava/lang/Str
     var cached = Media.ListCache.get(hdlr);
     if (!cached) {
         console.error("Invalid hdlr: " + hdlr);
-        return null;
+        return J2ME.Constants.NULL;
     }
     var s = cached.shift();
-    return s ? J2ME.newString(s) : null;
+    return s ? J2ME.newString(s) : J2ME.Constants.NULL;
 };
 
 Native["com/sun/mmedia/DefaultConfiguration.nListProtocolsClose.(I)V"] = function(hdlr) {

--- a/midp/midp.js
+++ b/midp/midp.js
@@ -171,9 +171,9 @@ var MIDP = (function() {
     state.suiteId = suiteId;
     state.midletClassName = J2ME.newString(config.midletClassName);
     var args = config.args;
-    state.arg0 = J2ME.newString((args.length > 0) ? args[0] : "");
-    state.arg1 = J2ME.newString((args.length > 1) ? args[1] : "");
-    state.arg2 = J2ME.newString((args.length > 2) ? args[2] : "");
+    state.arg0 = J2ME.newString((args.length > 0) ? args[0] : "")._address;
+    state.arg1 = J2ME.newString((args.length > 1) ? args[1] : "")._address;
+    state.arg2 = J2ME.newString((args.length > 2) ? args[2] : "")._address;
   };
 
   Native["com/sun/midp/main/MIDletSuiteUtils.getIsolateId.()I"] = function() {

--- a/midp/midp.js
+++ b/midp/midp.js
@@ -298,7 +298,7 @@ var MIDP = (function() {
     var data = JARStore.loadFile(fileName);
     if (!data) {
       console.warn("ResourceHandler::loadRomizedResource0: file " + fileName + " not found");
-      return null;
+      return J2ME.Constants.NULL;
     }
     var len = data.byteLength;
     var arrayAddr = J2ME.newByteArray(len);
@@ -1264,9 +1264,9 @@ var MIDP = (function() {
     throw $.newIllegalArgumentException("VirtualKeyboard::getCustomKeyboardControl() not implemented")
   };
 
-  var keyboardVisibilityListener = null;
+  var keyboardVisibilityListener = J2ME.Constants.NULL;
   Native["com/nokia/mid/ui/VirtualKeyboard.setVisibilityListener.(Lcom/nokia/mid/ui/KeyboardVisibilityListener;)V"] = function(listener) {
-    keyboardVisibilityListener = listener;
+    keyboardVisibilityListener = listener ? listener._address : J2ME.Constants.NULL;
   };
 
   Native["javax/microedition/lcdui/Display.getKeyboardVisibilityListener.()Lcom/nokia/mid/ui/KeyboardVisibilityListener;"] = function() {

--- a/midp/midp.js
+++ b/midp/midp.js
@@ -171,9 +171,9 @@ var MIDP = (function() {
     state.suiteId = suiteId;
     state.midletClassName = J2ME.newString(config.midletClassName);
     var args = config.args;
-    state.arg0 = J2ME.newString((args.length > 0) ? args[0] : "")._address;
-    state.arg1 = J2ME.newString((args.length > 1) ? args[1] : "")._address;
-    state.arg2 = J2ME.newString((args.length > 2) ? args[2] : "")._address;
+    state.arg0 = J2ME.newString((args.length > 0) ? args[0] : "");
+    state.arg1 = J2ME.newString((args.length > 1) ? args[1] : "");
+    state.arg2 = J2ME.newString((args.length > 2) ? args[2] : "");
   };
 
   Native["com/sun/midp/main/MIDletSuiteUtils.getIsolateId.()I"] = function() {

--- a/midp/pim.js
+++ b/midp/pim.js
@@ -113,7 +113,7 @@ Native["com/sun/j2me/pim/PIMProxy.getNextItemData0.(I[BI)Z"] = function(itemHand
 
 Native["com/sun/j2me/pim/PIMProxy.getItemCategories0.(II)Ljava/lang/String;"] = function(itemHandle, dataHandle) {
   console.warn("PIMProxy.getItemCategories0.(II)Ljava/lang/String; not implemented");
-  return null;
+  return J2ME.Constants.NULL;
 };
 
 Native["com/sun/j2me/pim/PIMProxy.listClose0.(I)Z"] = function(listHandle, description) {
@@ -138,7 +138,7 @@ Native["com/sun/j2me/pim/PIMProxy.getDefaultListName.(I)Ljava/lang/String;"] = f
     return J2ME.newString("TodoList");
   }
 
-  return null;
+  return J2ME.Constants.NULL;
 };
 
 Native["com/sun/j2me/pim/PIMProxy.getFieldsCount0.(I[I)I"] = function(listHandle, dataHandle) {

--- a/nat.ts
+++ b/nat.ts
@@ -87,7 +87,7 @@ module J2ME {
       var classInfo = CLASSES.getClass("org/mozilla/internal/Sys");
       var methodInfo = classInfo.getMethodByNameString("throwException", "(Ljava/lang/Exception;)V");
       ctx.nativeThread.pushFrame(methodInfo);
-      ctx.nativeThread.frame.setParameter(J2ME.Kind.Reference, 0, exception);
+      ctx.nativeThread.frame.setParameter(J2ME.Kind.Reference, 0, exception._address);
       Scheduler.enqueue(ctx);
     });
 

--- a/nat.ts
+++ b/nat.ts
@@ -74,7 +74,7 @@ module J2ME {
           i32[sp++] = l;
           break;
         case Kind.Reference:
-          release || assert(l === "number", "async native return value is a number");
+          release || assert(l !== "number", "async native return value is a number");
           ref[sp++] = l;
           break;
         case Kind.Void:

--- a/nat.ts
+++ b/nat.ts
@@ -17,7 +17,7 @@ var i32: Int32Array = ASM.HEAP32;
 var u32: Uint32Array = ASM.HEAPU32;
 var f32: Float32Array = ASM.HEAPF32;
 var f64: Float64Array = ASM.HEAPF64;
-var ref = J2ME.ArrayUtilities.makeDenseArray(buffer.byteLength >> 2, null);
+var ref = J2ME.ArrayUtilities.makeDenseArray(buffer.byteLength >> 2, 0 /* J2ME.Constants.NULL */);
 
 var aliasedI32 = J2ME.IntegerUtilities.i32;
 var aliasedF32 = J2ME.IntegerUtilities.f32;

--- a/nat.ts
+++ b/nat.ts
@@ -74,7 +74,8 @@ module J2ME {
           i32[sp++] = l;
           break;
         case Kind.Reference:
-          ref[sp++] = J2ME.canonicalizeRef(l);
+          release || assert(l === "number", "async native return value is a number");
+          ref[sp++] = l;
           break;
         case Kind.Void:
           break;
@@ -144,9 +145,9 @@ module J2ME {
     thread.nativeAlive = true;
   };
 
-  Native["org/mozilla/internal/Sys.getIsolateMain.()Ljava/lang/String;"] = function(): java.lang.String {
+  Native["org/mozilla/internal/Sys.getIsolateMain.()Ljava/lang/String;"] = function(): number {
     var isolate = <com.sun.cldc.isolate.Isolate>getHandle($.isolateAddress);
-    return <java.lang.String>getHandle(isolate._mainClass);
+    return isolate._mainClass;
   };
 
   Native["org/mozilla/internal/Sys.executeMain.(Ljava/lang/Class;)V"] = function(main: java.lang.Class) {

--- a/native.js
+++ b/native.js
@@ -306,7 +306,7 @@ Native["com/sun/cldchi/jvm/JVM.monotonicTimeMillis.()J"] = function() {
 };
 
 Native["java/lang/Object.getClass.()Ljava/lang/Class;"] = function() {
-    return $.getRuntimeKlass(this.klass).classObject;
+    return $.getRuntimeKlass(this.klass).classObject._address;
 };
 
 Native["java/lang/Class.getSuperclass.()Ljava/lang/Class;"] = function() {
@@ -314,7 +314,7 @@ Native["java/lang/Class.getSuperclass.()Ljava/lang/Class;"] = function() {
     if (!superKlass) {
       return null;
     }
-    return superKlass.classInfo.getClassObject();
+    return superKlass.classInfo.getClassObject()._address;
 };
 
 Native["java/lang/Class.invoke_clinit.()V"] = function() {
@@ -360,7 +360,7 @@ Native["java/lang/Class.forName1.(Ljava/lang/String;)Ljava/lang/Class;"] = funct
   var className = J2ME.fromJavaString(name).replace(/\./g, "/");
   var classInfo = CLASSES.getClass(className);
   var classObject = classInfo.getClassObject();
-  return classObject;
+  return classObject._address;
 };
 
 Native["java/lang/Class.newInstance0.()Ljava/lang/Object;"] = function() {
@@ -373,7 +373,7 @@ Native["java/lang/Class.newInstance0.()Ljava/lang/Object;"] = function() {
     throw $.newInstantiationException("Can't instantiate array classes");
   }
 
-  return new this.runtimeKlass.templateKlass;
+  return (new this.runtimeKlass.templateKlass)._address;
 };
 
 Native["java/lang/Class.newInstance1.(Ljava/lang/Object;)V"] = function(o) {
@@ -523,7 +523,7 @@ Native["java/lang/Math.floor.(D)D"] = function(val) {
 };
 
 Native["java/lang/Thread.currentThread.()Ljava/lang/Thread;"] = function() {
-    return getHandle($.ctx.threadAddress);
+    return $.ctx.threadAddress;
 };
 
 Native["java/lang/Thread.setPriority0.(II)V"] = function(oldPriority, newPriority) {
@@ -586,7 +586,7 @@ Native["com/sun/cldc/io/ResourceInputStream.open.(Ljava/lang/String;)Ljava/lang/
             pos: 0,
         });
     }
-    return obj;
+    return obj ? obj._address : J2ME.Constants.NULL;
 };
 
 Native["com/sun/cldc/io/ResourceInputStream.clone.(Ljava/lang/Object;)Ljava/lang/Object;"] = function(source) {
@@ -596,7 +596,7 @@ Native["com/sun/cldc/io/ResourceInputStream.clone.(Ljava/lang/Object;)Ljava/lang
         data: new Uint8Array(sourceDecoder.data),
         pos: sourceDecoder.pos,
     });
-    return obj;
+    return obj._address;
 };
 
 Native["com/sun/cldc/io/ResourceInputStream.bytesRemain.(Ljava/lang/Object;)I"] = function(fileDecoder) {
@@ -628,7 +628,7 @@ Native["java/lang/ref/WeakReference.initializeWeakReference.(Ljava/lang/Object;)
 
 Native["java/lang/ref/WeakReference.get.()Ljava/lang/Object;"] = function() {
     var target = getNative(this);
-    return target ? target : null;
+    return target ? target._address : J2ME.Constants.NULL;
 };
 
 Native["java/lang/ref/WeakReference.clear.()V"] = function() {
@@ -667,7 +667,7 @@ Native["com/sun/cldc/isolate/Isolate.waitStatus.(I)V"] = function(status) {
 };
 
 Native["com/sun/cldc/isolate/Isolate.currentIsolate0.()Lcom/sun/cldc/isolate/Isolate;"] = function() {
-    return getHandle($.ctx.runtime.isolateAddress);
+    return $.ctx.runtime.isolateAddress;
 };
 
 Native["com/sun/cldc/isolate/Isolate.getIsolates0.()[Lcom/sun/cldc/isolate/Isolate;"] = function() {
@@ -761,10 +761,10 @@ Native["java/lang/String.intern.()Ljava/lang/String;"] = function() {
   var internedStrings = J2ME.internedStrings;
   var internedString = internedStrings.getByRange(value, this.offset, this.count);
   if (internedString !== null) {
-    return internedString;
+    return internedString._address;
   }
   internedStrings.put(value.subarray(this.offset, this.offset + this.count), this);
-  return this;
+  return this._address;
 };
 
 var profileStarted = false;

--- a/native.js
+++ b/native.js
@@ -545,7 +545,7 @@ Native["java/lang/Thread.start0.()V"] = function() {
     var run = classInfo.getMethodByNameString("runThread", "(Ljava/lang/Thread;)V", true);
     newCtx.nativeThread.pushFrame(null);
     newCtx.nativeThread.pushFrame(run);
-    newCtx.nativeThread.frame.setParameter(J2ME.Kind.Reference, 0, this);
+    newCtx.nativeThread.frame.setParameter(J2ME.Kind.Reference, 0, this._address);
     newCtx.start();
 }
 

--- a/tests/native.js
+++ b/tests/native.js
@@ -73,7 +73,7 @@ Native["gnu/testlet/vm/NativeTest.dumbPipe.()Z"] = function() {
 };
 
 Native["org/mozilla/regression/TestVectorNull.nativeThatReturnsNull.()Ljava/lang/Object;"] = function() {
-  return null;
+  return J2ME.Constants.NULL;
 };
 
 Native["com/nokia/mid/ui/TestVirtualKeyboard.hideKeyboard.()V"] = function() {

--- a/vm/context.ts
+++ b/vm/context.ts
@@ -337,7 +337,7 @@ module J2ME {
 
       ctx.nativeThread.pushFrame(null);
       ctx.nativeThread.pushFrame(sys.getMethodByNameString("isolate0Entry", "(Ljava/lang/String;[Ljava/lang/String;)V"));
-      ctx.nativeThread.frame.setParameter(Kind.Reference, 0, J2ME.newString(className.replace(/\./g, "/"))._address);
+      ctx.nativeThread.frame.setParameter(Kind.Reference, 0, J2ME.newString(className.replace(/\./g, "/")));
       ctx.nativeThread.frame.setParameter(Kind.Reference, 1, arrayAddr);
       ctx.start();
       release || Debug.assert(!U, "Unexpected unwind during isolate initialization.");

--- a/vm/context.ts
+++ b/vm/context.ts
@@ -337,7 +337,7 @@ module J2ME {
 
       ctx.nativeThread.pushFrame(null);
       ctx.nativeThread.pushFrame(sys.getMethodByNameString("isolate0Entry", "(Ljava/lang/String;[Ljava/lang/String;)V"));
-      ctx.nativeThread.frame.setParameter(Kind.Reference, 0, J2ME.newString(className.replace(/\./g, "/")));
+      ctx.nativeThread.frame.setParameter(Kind.Reference, 0, J2ME.newString(className.replace(/\./g, "/"))._address);
       ctx.nativeThread.frame.setParameter(Kind.Reference, 1, arrayAddr);
       ctx.start();
       release || Debug.assert(!U, "Unexpected unwind during isolate initialization.");
@@ -365,7 +365,7 @@ module J2ME {
 
       ctx.nativeThread.pushFrame(null);
       ctx.nativeThread.pushFrame(entryPoint);
-      ctx.nativeThread.frame.setParameter(Kind.Reference, 0, isolate);
+      ctx.nativeThread.frame.setParameter(Kind.Reference, 0, isolate._address);
       ctx.start();
       release || Debug.assert(!U, "Unexpected unwind during isolate initialization.");
     }

--- a/vm/runtime.ts
+++ b/vm/runtime.ts
@@ -1311,7 +1311,7 @@ module J2ME {
         if (true || release) {
           switch (field.kind) {
             case Kind.Reference:
-              setter = new Function("value", "ref[this._address + " + field.byteOffset + " >> 2] = value;");
+              setter = new Function("value", "ref[this._address + " + field.byteOffset + " >> 2] = J2ME.canonicalizeRef(value);");
               getter = new Function("return ref[this._address + " + field.byteOffset + " >> 2];");
               break;
             case Kind.Boolean:

--- a/vm/runtime.ts
+++ b/vm/runtime.ts
@@ -1311,7 +1311,7 @@ module J2ME {
         if (true || release) {
           switch (field.kind) {
             case Kind.Reference:
-              setter = new Function("value", "ref[this._address + " + field.byteOffset + " >> 2] = J2ME.canonicalizeRef(value);");
+              setter = new Function("value", "ref[this._address + " + field.byteOffset + " >> 2] = value;");
               getter = new Function("return ref[this._address + " + field.byteOffset + " >> 2];");
               break;
             case Kind.Boolean:

--- a/vm/runtime.ts
+++ b/vm/runtime.ts
@@ -543,7 +543,7 @@ module J2ME {
       var utf16Array = getArrayFromAddr(utf16ArrayAddr);
       var javaString = internedStrings.get(utf16Array);
       if (javaString !== null) {
-        return javaString;
+        return javaString._address;
       }
       // It's ok to create and intern an object here, because we only return it
       // to ConstantPool.resolve, which itself is only called by a few callers,


### PR DESCRIPTION
There are still three places where it's used:
- *fastInterpreterFrameAdapter*, used by natives that call getLinkedMethod;
- getfield or getstatic, because some natives set JS objects as Java properties. Removing this instance of canonicalizeRef makes WeChat fail (but not tests or WhatsApp), so there are probably just a few natives that are doing that.
- invoke*, for natives that return objects instead of addresses.

I'm submitting this PR anyways because it removes all instances of Java objects and arrays from the *ref* array (there were still a few added by getfield or getstatic).
So, after this PR, on the ref array Java objects and arrays are always represented as addresses.