### PR TITLE
remove references to *this* object from natives

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,9 @@ We use `Native` object in JS to handle creation and registration of `native` fun
 
 e.g.:
 
-    Native["java/lang/System.arraycopy.(Ljava/lang/Object;ILjava/lang/Object;II)V" = function(src, srcOffset, dst, dstOffset, length) {...};
+    Native["java/lang/System.arraycopy.(Ljava/lang/Object;ILjava/lang/Object;II)V" = function(addr, src, srcOffset, dst, dstOffset, length) {...};
+
+The first parameter of every native, *addr*, is the address in memory of the object on which the native is being called. If the native is static, then the value of *addr* is `Constants.NULL`. Call `getHandle(addr)` to get a handle to a JavaScript object that wraps the Java object with getters/setters for its fields.
 
 If raising a Java `Exception`, throw new instance of Java `Exception` class as defined in vm/runtime.ts, e.g.:
 
@@ -316,7 +318,6 @@ e.g:
 Remember:
 
   * Return types are automatically converted to Java types, but parameters are not automatically converted from Java types to JS types
-  * `this` will be available in any context that `this` would be available to the Java method. i.e. `this` will be `null` for `static` methods.
   * `$` is current runtime and `$.ctx` current Context
   * Parameter types are specified in [JNI](http://www.iastate.edu/~java/docs/guide/nativemethod/types.doc.html)
 

--- a/int.ts
+++ b/int.ts
@@ -1768,7 +1768,7 @@ module J2ME {
 
                 thread.set(fp, sp, opPC);
 
-                returnValue = callee.call(object, object ? object._address : Constants.NULL);
+                returnValue = callee(object ? object._address : Constants.NULL);
               } else {
                 args.length = 0;
 
@@ -1823,7 +1823,7 @@ module J2ME {
                 }
 
                 args.unshift(object ? object._address : Constants.NULL);
-                returnValue = callee.apply(object, args);
+                returnValue = callee.apply(null, args);
               }
 
               if (!release) {

--- a/midp/codec.js
+++ b/midp/codec.js
@@ -136,37 +136,37 @@ DataDecoder.prototype.getType = function() {
 }
 
 Native["com/nokia/mid/s40/codec/DataEncoder.init.()V"] = function(addr) {
-  setNative(this, new DataEncoder());
+  NativeMap.set(addr, new DataEncoder());
 };
 
 Native["com/nokia/mid/s40/codec/DataEncoder.putStart.(ILjava/lang/String;)V"] = function(addr, tag, name) {
-  getNative(this).putStart(tag, J2ME.fromJavaString(name));
+  NativeMap.get(addr).putStart(tag, J2ME.fromJavaString(name));
 };
 
 Native["com/nokia/mid/s40/codec/DataEncoder.put.(ILjava/lang/String;Ljava/lang/String;)V"] = function(addr, tag, name, value) {
-  getNative(this).put(tag, J2ME.fromJavaString(name), J2ME.fromJavaString(value));
+  NativeMap.get(addr).put(tag, J2ME.fromJavaString(name), J2ME.fromJavaString(value));
 };
 
 Native["com/nokia/mid/s40/codec/DataEncoder.put.(ILjava/lang/String;J)V"] = function(addr, tag, name, valueLow, valueHigh) {
-  getNative(this).put(tag, J2ME.fromJavaString(name), J2ME.longToNumber(valueLow, valueHigh));
+  NativeMap.get(addr).put(tag, J2ME.fromJavaString(name), J2ME.longToNumber(valueLow, valueHigh));
 };
 
 Native["com/nokia/mid/s40/codec/DataEncoder.put.(ILjava/lang/String;Z)V"] = function(addr, tag, name, value) {
-  getNative(this).put(tag, J2ME.fromJavaString(name), value);
+  NativeMap.get(addr).put(tag, J2ME.fromJavaString(name), value);
 };
 
 Native["com/nokia/mid/s40/codec/DataEncoder.put.(Ljava/lang/String;[BI)V"] = function(addr, name, data, length) {
   var array = Array.prototype.slice.call(data.subarray(0, length));
   array.constructor = Array;
-  getNative(this).putNoTag(J2ME.fromJavaString(name), array);
+  NativeMap.get(addr).putNoTag(J2ME.fromJavaString(name), array);
 };
 
 Native["com/nokia/mid/s40/codec/DataEncoder.putEnd.(ILjava/lang/String;)V"] = function(addr, tag, name) {
-  getNative(this).putEnd(tag, J2ME.fromJavaString(name));
+  NativeMap.get(addr).putEnd(tag, J2ME.fromJavaString(name));
 };
 
 Native["com/nokia/mid/s40/codec/DataEncoder.getData.()[B"] = function(addr) {
-  var data = getNative(this).getData();
+  var data = NativeMap.get(addr).getData();
 
   var arrayAddr = J2ME.newByteArray(data.length);
   var array = J2ME.getArrayFromAddr(arrayAddr);
@@ -178,23 +178,23 @@ Native["com/nokia/mid/s40/codec/DataEncoder.getData.()[B"] = function(addr) {
 };
 
 Native["com/nokia/mid/s40/codec/DataDecoder.init.([BII)V"] = function(addr, data, offset, length) {
-  setNative(this, new DataDecoder(data, offset, length));
+  NativeMap.set(addr, new DataDecoder(data, offset, length));
 };
 
 Native["com/nokia/mid/s40/codec/DataDecoder.getStart.(I)V"] = function(addr, tag) {
-  if (!getNative(this).getStart(tag)) {
+  if (!NativeMap.get(addr).getStart(tag)) {
     throw $.newIOException("no start found " + tag);
   }
 };
 
 Native["com/nokia/mid/s40/codec/DataDecoder.getEnd.(I)V"] = function(addr, tag) {
-  if (!getNative(this).getEnd(tag)) {
+  if (!NativeMap.get(addr).getEnd(tag)) {
     throw $.newIOException("no end found " + tag);
   }
 };
 
 Native["com/nokia/mid/s40/codec/DataDecoder.getString.(I)Ljava/lang/String;"] = function(addr, tag) {
-  var str = getNative(this).getValue(tag);
+  var str = NativeMap.get(addr).getValue(tag);
   if (str === undefined) {
     throw $.newIOException("tag (" + tag + ") invalid");
   }
@@ -202,7 +202,7 @@ Native["com/nokia/mid/s40/codec/DataDecoder.getString.(I)Ljava/lang/String;"] = 
 };
 
 Native["com/nokia/mid/s40/codec/DataDecoder.getInteger.(I)J"] = function(addr, tag) {
-  var num = getNative(this).getValue(tag);
+  var num = NativeMap.get(addr).getValue(tag);
   if (num === undefined) {
     throw $.newIOException("tag (" + tag + ") invalid");
   }
@@ -210,7 +210,7 @@ Native["com/nokia/mid/s40/codec/DataDecoder.getInteger.(I)J"] = function(addr, t
 };
 
 Native["com/nokia/mid/s40/codec/DataDecoder.getBoolean.()Z"] = function(addr) {
-  var val = getNative(this).getNextValue();
+  var val = NativeMap.get(addr).getNextValue();
   if (val === undefined) {
     throw $.newIOException();
   }
@@ -218,7 +218,7 @@ Native["com/nokia/mid/s40/codec/DataDecoder.getBoolean.()Z"] = function(addr) {
 };
 
 Native["com/nokia/mid/s40/codec/DataDecoder.getName.()Ljava/lang/String;"] = function(addr) {
-  var name = getNative(this).getName();
+  var name = NativeMap.get(addr).getName();
   if (name === undefined) {
     throw $.newIOException();
   }
@@ -226,7 +226,7 @@ Native["com/nokia/mid/s40/codec/DataDecoder.getName.()Ljava/lang/String;"] = fun
 };
 
 Native["com/nokia/mid/s40/codec/DataDecoder.getType.()I"] = function(addr) {
-  var tag = getNative(this).getTag();
+  var tag = NativeMap.get(addr).getTag();
   if (tag === undefined) {
     throw $.newIOException();
   }
@@ -234,5 +234,5 @@ Native["com/nokia/mid/s40/codec/DataDecoder.getType.()I"] = function(addr) {
 };
 
 Native["com/nokia/mid/s40/codec/DataDecoder.listHasMoreItems.()Z"] = function(addr) {
-  return getNative(this).getType() != DataEncoder.END ? 1 : 0;
+  return NativeMap.get(addr).getType() != DataEncoder.END ? 1 : 0;
 };

--- a/midp/frameanimator.js
+++ b/midp/frameanimator.js
@@ -34,11 +34,11 @@ FrameAnimator.prototype.isRegistered = function() {
 };
 
 Native["com/nokia/mid/ui/frameanimator/FrameAnimator.init.()V"] = function(addr) {
-  setNative(this, new FrameAnimator());
+  NativeMap.set(addr, new FrameAnimator());
 };
 
 Native["com/nokia/mid/ui/frameanimator/FrameAnimator.register.(IISSLcom/nokia/mid/ui/frameanimator/FrameAnimatorListener;)Z"] = function(addr, x, y, maxFps, maxPps, listener) {
-  var nativeObject = getNative(this);
+  var nativeObject = NativeMap.get(addr);
   if (nativeObject.isRegistered()) {
     throw $.newIllegalStateException("FrameAnimator already registered");
   }
@@ -58,7 +58,7 @@ Native["com/nokia/mid/ui/frameanimator/FrameAnimator.register.(IISSLcom/nokia/mi
 };
 
 Native["com/nokia/mid/ui/frameanimator/FrameAnimator.unregister.()V"] = function(addr) {
-  var nativeObject = getNative(this);
+  var nativeObject = NativeMap.get(addr);
   if (!nativeObject.isRegistered()) {
     throw $.newIllegalStateException("FrameAnimator not registered");
   }
@@ -72,7 +72,7 @@ addUnimplementedNative("com/nokia/mid/ui/frameanimator/FrameAnimator.limitedKine
 addUnimplementedNative("com/nokia/mid/ui/frameanimator/FrameAnimator.stop.()V");
 
 Native["com/nokia/mid/ui/frameanimator/FrameAnimator.isRegistered.()Z"] = function(addr) {
-  return getNative(this).isRegistered() ? 1 : 0;
+  return NativeMap.get(addr).isRegistered() ? 1 : 0;
 };
 
 Native["com/nokia/mid/ui/frameanimator/FrameAnimator.getNumRegisteredFrameAnimators.()I"] = function(addr) {

--- a/midp/fs.js
+++ b/midp/fs.js
@@ -232,7 +232,8 @@ Native["com/sun/midp/rms/RecordStoreSharedDBHeader.getHeaderRefCount0.(I)I"] = f
 };
 
 Native["com/sun/midp/rms/RecordStoreSharedDBHeader.cleanup0.()V"] = function(addr) {
-    var lookupId = this.lookupId;
+    var self = getHandle(addr);
+    var lookupId = self.lookupId;
     if (MIDP.RecordStoreCache[lookupId] &&
         --MIDP.RecordStoreCache[lookupId].refCount <= 0) {
         // Set to null instead of removing from array to maintain
@@ -275,7 +276,7 @@ Native["com/sun/midp/rms/RecordStoreRegistry.stopAllRecordStoreListeners.(I)V"] 
 };
 
 Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.create.()V"] = function(addr) {
-    var pathname = J2ME.fromJavaString(getHandle(this.nativePath));
+    var pathname = J2ME.fromJavaString(getHandle(getHandle(addr).nativePath));
     DEBUG_FS && console.log("DefaultFileHandler.create: " + pathname);
     if (config.ignoredFiles.has(pathname)) {
         DEBUG_FS && console.log("DefaultFileHandler.create: ignored file");
@@ -290,7 +291,7 @@ Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.create.()V"] = function(addr
 };
 
 Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.exists.()Z"] = function(addr) {
-    var pathname = J2ME.fromJavaString(getHandle(this.nativePath));
+    var pathname = J2ME.fromJavaString(getHandle(getHandle(addr).nativePath));
     DEBUG_FS && console.log("DefaultFileHandler.exists: " + pathname);
     if (config.ignoredFiles.has(pathname)) {
         DEBUG_FS && console.log("DefaultFileHandler.exists: ignored file");
@@ -303,7 +304,7 @@ Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.exists.()Z"] = function(addr
 };
 
 Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.isDirectory.()Z"] = function(addr) {
-    var pathname = J2ME.fromJavaString(getHandle(this.nativePath));
+    var pathname = J2ME.fromJavaString(getHandle(getHandle(addr).nativePath));
     DEBUG_FS && console.log("DefaultFileHandler.isDirectory: " + pathname);
     if (config.ignoredFiles.has(pathname)) {
         DEBUG_FS && console.log("DefaultFileHandler.isDirectory: ignored file");
@@ -317,7 +318,7 @@ Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.isDirectory.()Z"] = function
 }
 
 Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.delete.()V"] = function(addr) {
-    var pathname = J2ME.fromJavaString(getHandle(this.nativePath));
+    var pathname = J2ME.fromJavaString(getHandle(getHandle(addr).nativePath));
     DEBUG_FS && console.log("DefaultFileHandler.delete: " + pathname);
     if (config.ignoredFiles.has(pathname)) {
         DEBUG_FS && console.log("DefaultFileHandler.delete: ignored file");
@@ -331,7 +332,7 @@ Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.delete.()V"] = function(addr
 
 
 Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.rename0.(Ljava/lang/String;)V"] = function(addr, newName) {
-    var pathname = J2ME.fromJavaString(getHandle(this.nativePath));
+    var pathname = J2ME.fromJavaString(getHandle(getHandle(addr).nativePath));
     var newPathname = J2ME.fromJavaString(newName);
     DEBUG_FS && console.log("DefaultFileHandler.rename0: " + pathname + " to " + newPathname);
 
@@ -345,7 +346,7 @@ Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.rename0.(Ljava/lang/String;)
 };
 
 Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.truncate.(J)V"] = function(addr, byteOffsetL, byteOffsetH) {
-    var pathname = J2ME.fromJavaString(getHandle(this.nativePath));
+    var pathname = J2ME.fromJavaString(getHandle(getHandle(addr).nativePath));
     DEBUG_FS && console.log("DefaultFileHandler.lastModified: " + pathname);
     if (config.ignoredFiles.has(pathname)) {
         DEBUG_FS && console.log("DefaultFileHandler.lastModified: ignored file");
@@ -368,7 +369,7 @@ Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.truncate.(J)V"] = function(a
 };
 
 Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.fileSize.()J"] = function(addr) {
-    var pathname = J2ME.fromJavaString(getHandle(this.nativePath));
+    var pathname = J2ME.fromJavaString(getHandle(getHandle(addr).nativePath));
     DEBUG_FS && console.log("DefaultFileHandler.fileSize: " + pathname);
     if (config.ignoredFiles.has(pathname)) {
         DEBUG_FS && console.log("DefaultFileHandler.fileSize: ignored file");
@@ -382,7 +383,7 @@ addUnimplementedNative("com/sun/cdc/io/j2me/file/DefaultFileHandler.directorySiz
                        function() { return J2ME.returnLongValue(0) });
 
 Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.canRead.()Z"] = function(addr) {
-    var pathname = J2ME.fromJavaString(getHandle(this.nativePath));
+    var pathname = J2ME.fromJavaString(getHandle(getHandle(addr).nativePath));
     DEBUG_FS && console.log("DefaultFileHandler.canRead: " + pathname);
     if (config.ignoredFiles.has(pathname)) {
         DEBUG_FS && console.log("DefaultFileHandler.canRead: ignored file");
@@ -393,7 +394,7 @@ Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.canRead.()Z"] = function(add
 };
 
 Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.canWrite.()Z"] = function(addr) {
-    var pathname = J2ME.fromJavaString(getHandle(this.nativePath));
+    var pathname = J2ME.fromJavaString(getHandle(getHandle(addr).nativePath));
     DEBUG_FS && console.log("DefaultFileHandler.canWrite: " + pathname);
     if (config.ignoredFiles.has(pathname)) {
         DEBUG_FS && console.log("DefaultFileHandler.canWrite: ignored file");
@@ -410,7 +411,7 @@ Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.isHidden0.()Z"] = function(a
 };
 
 Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.setReadable.(Z)V"] = function(addr) {
-    var pathname = J2ME.fromJavaString(getHandle(this.nativePath));
+    var pathname = J2ME.fromJavaString(getHandle(getHandle(addr).nativePath));
     DEBUG_FS && console.log("DefaultFileHandler.setReadable: " + pathname);
     if (config.ignoredFiles.has(pathname)) {
         DEBUG_FS && console.log("DefaultFileHandler.setReadable: ignored file");
@@ -425,7 +426,7 @@ Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.setReadable.(Z)V"] = functio
 };
 
 Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.setWritable.(Z)V"] = function(addr) {
-    var pathname = J2ME.fromJavaString(getHandle(this.nativePath));
+    var pathname = J2ME.fromJavaString(getHandle(getHandle(addr).nativePath));
     DEBUG_FS && console.log("DefaultFileHandler.setWritable: " + pathname);
     if (config.ignoredFiles.has(pathname)) {
         DEBUG_FS && console.log("DefaultFileHandler.setWritable: ignored file");
@@ -442,7 +443,7 @@ Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.setWritable.(Z)V"] = functio
 addUnimplementedNative("com/sun/cdc/io/j2me/file/DefaultFileHandler.setHidden0.(Z)V");
 
 Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.mkdir.()V"] = function(addr) {
-    var pathname = J2ME.fromJavaString(getHandle(this.nativePath));
+    var pathname = J2ME.fromJavaString(getHandle(getHandle(addr).nativePath));
     DEBUG_FS && console.log("DefaultFileHandler.mkdir: " + pathname);
 
     if (!fs.mkdir(pathname)) {
@@ -457,7 +458,7 @@ addUnimplementedNative("com/sun/cdc/io/j2me/file/DefaultFileHandler.totalSize.()
                        function() { return J2ME.returnLongValue(1024 * 1024 * 1024) });
 
 Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.lastModified.()J"] = function(addr) {
-    var pathname = J2ME.fromJavaString(getHandle(this.nativePath));
+    var pathname = J2ME.fromJavaString(getHandle(getHandle(addr).nativePath));
     DEBUG_FS && console.log("DefaultFileHandler.lastModified: " + pathname);
     if (config.ignoredFiles.has(pathname)) {
         DEBUG_FS && console.log("DefaultFileHandler.lastModified: ignored file");
@@ -551,34 +552,35 @@ MIDP.closeFileHandler = function(fileHandler, mode) {
 };
 
 Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.openForRead.()V"] = function(addr) {
-    MIDP.openFileHandler(this, "read");
+    MIDP.openFileHandler(getHandle(addr), "read");
 };
 
 Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.closeForRead.()V"] = function(addr) {
-    MIDP.closeFileHandler(this, "read");
+    MIDP.closeFileHandler(getHandle(addr), "read");
 };
 
 Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.openForWrite.()V"] = function(addr) {
-    MIDP.openFileHandler(this, "write");
+    MIDP.openFileHandler(getHandle(addr), "write");
 };
 
 Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.closeForWrite.()V"] = function(addr) {
-    MIDP.closeFileHandler(this, "write");
+    MIDP.closeFileHandler(getHandle(addr), "write");
 };
 
 Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.closeForReadWrite.()V"] = function(addr) {
-    MIDP.closeFileHandler(this, "read");
-    MIDP.closeFileHandler(this, "write");
+    MIDP.closeFileHandler(getHandle(addr), "read");
+    MIDP.closeFileHandler(getHandle(addr), "write");
 };
 
 Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.read.([BII)I"] = function(addr, b, off, len) {
-    DEBUG_FS && console.log("DefaultFileHandler.read: " + J2ME.fromJavaString(getHandle(this.nativePath)) + " " + len);
-    if (this.nativeDescriptor === -1) {
+    var self = getHandle(addr);
+    DEBUG_FS && console.log("DefaultFileHandler.read: " + J2ME.fromJavaString(getHandle(self.nativePath)) + " " + len);
+    if (self.nativeDescriptor === -1) {
         DEBUG_FS && console.log("DefaultFileHandler.read: ignored file");
         return -1;
     }
 
-    var fd = this.nativeDescriptor;
+    var fd = self.nativeDescriptor;
 
     if (off < 0 || len < 0 || off > b.byteLength || (b.byteLength - off) < len) {
         throw $.newIOException();
@@ -596,8 +598,9 @@ Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.read.([BII)I"] = function(ad
 };
 
 Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.skip.(J)J"] = function(addr, l, h) {
-    DEBUG_FS && console.log("DefaultFileHandler.skip: " + J2ME.fromJavaString(getHandle(this.nativePath)));
-    if (this.nativeDescriptor === -1) {
+    var self = getHandle(addr);
+    DEBUG_FS && console.log("DefaultFileHandler.skip: " + J2ME.fromJavaString(getHandle(self.nativePath)));
+    if (self.nativeDescriptor === -1) {
         DEBUG_FS && console.log("DefaultFileHandler.skip: ignored file");
         return -1;
     }
@@ -608,7 +611,7 @@ Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.skip.(J)J"] = function(addr,
         return J2ME.returnLongValue(0);
     }
 
-    var fd = this.nativeDescriptor;
+    var fd = self.nativeDescriptor;
     var pos = fs.getpos(fd);
     var size = fs.getsize(fd);
     if (pos + toSkip > size) {
@@ -621,13 +624,14 @@ Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.skip.(J)J"] = function(addr,
 };
 
 Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.write.([BII)I"] = function(addr, b, off, len) {
-    DEBUG_FS && console.log("DefaultFileHandler.write: " + J2ME.fromJavaString(getHandle(this.nativePath)) + " " + off + "+" + len);
-    if (this.nativeDescriptor === -1) {
+    var self = getHandle(addr);
+    DEBUG_FS && console.log("DefaultFileHandler.write: " + J2ME.fromJavaString(getHandle(self.nativePath)) + " " + off + "+" + len);
+    if (self.nativeDescriptor === -1) {
         DEBUG_FS && console.log("DefaultFileHandler.write: ignored file");
         return preemptingImpl("I", len);
     }
 
-    var fd = this.nativeDescriptor;
+    var fd = self.nativeDescriptor;
     fs.write(fd, b, off, len);
     // The return value is the "length of data really written," which is
     // always the same as the length requested in our implementation.
@@ -635,32 +639,35 @@ Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.write.([BII)I"] = function(a
 };
 
 Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.positionForWrite.(J)V"] = function(addr, offsetLow, offsetHigh) {
-    DEBUG_FS && console.log("DefaultFileHandler.positionForWrite: " + J2ME.fromJavaString(getHandle(this.nativePath)));
-    if (this.nativeDescriptor === -1) {
+    var self = getHandle(addr);
+    DEBUG_FS && console.log("DefaultFileHandler.positionForWrite: " + J2ME.fromJavaString(getHandle(self.nativePath)));
+    if (self.nativeDescriptor === -1) {
         DEBUG_FS && console.log("DefaultFileHandler.positionForWrite: ignored file");
         return;
     }
 
-    var fd = this.nativeDescriptor;
+    var fd = self.nativeDescriptor;
     fs.setpos(fd, J2ME.longToNumber(offsetLow, offsetHigh));
 };
 
 Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.flush.()V"] = function(addr) {
-    DEBUG_FS && console.log("DefaultFileHandler.flush: " + J2ME.fromJavaString(getHandle(this.nativePath)));
-    if (this.nativeDescriptor === -1) {
+    var self = getHandle(addr);
+    DEBUG_FS && console.log("DefaultFileHandler.flush: " + J2ME.fromJavaString(getHandle(self.nativePath)));
+    if (self.nativeDescriptor === -1) {
         DEBUG_FS && console.log("DefaultFileHandler.flush: ignored file");
         return;
     }
 
-    var fd = this.nativeDescriptor;
+    var fd = self.nativeDescriptor;
     fs.flush(fd);
 };
 
 Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.close.()V"] = function(addr) {
-    DEBUG_FS && console.log("DefaultFileHandler.close: " + J2ME.fromJavaString(getHandle(this.nativePath)));
+    var self = getHandle(addr);
+    DEBUG_FS && console.log("DefaultFileHandler.close: " + J2ME.fromJavaString(getHandle(self.nativePath)));
 
-    MIDP.closeFileHandler(this, "read");
-    MIDP.closeFileHandler(this, "write");
+    MIDP.closeFileHandler(self, "read");
+    MIDP.closeFileHandler(self, "write");
 };
 
 // Not implemented because we don't use native pointers, so we've commented out
@@ -676,7 +683,8 @@ MIDP.openDirs = new Map();
 MIDP.openDirHandle = 0;
 
 Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.openDir.()J"] = function(addr) {
-    var pathname = J2ME.fromJavaString(getHandle(this.nativePath));
+    var self = getHandle(addr);
+    var pathname = J2ME.fromJavaString(getHandle(self.nativePath));
     DEBUG_FS && console.log("DefaultFileHandler.openDir: " + pathname);
 
     try {
@@ -736,7 +744,8 @@ DEBUG_FS && console.log("getSuiteIdString: " + id);
 };
 
 Native["com/sun/cdc/io/j2me/file/Protocol.available.()I"] = function(addr) {
-    var fileHandler = getHandle(this.fileHandler);
+    var self = getHandle(addr);
+    var fileHandler = getHandle(self.fileHandler);
     var fd = fileHandler.nativeDescriptor;
     var available = fs.getsize(fd) - fs.getpos(fd);
     DEBUG_FS && console.log("Protocol.available: " + J2ME.fromJavaString(fileHandler.nativePath) + ": " + available);

--- a/midp/gfx.js
+++ b/midp/gfx.js
@@ -302,7 +302,7 @@ var currentlyFocusedTextEditor;
     };
 
     Native["javax/microedition/lcdui/ImageData.getRGB.([IIIIIII)V"] = function(addr, rgbData, offset, scanlength, x, y, width, height) {
-        var abgrData = new Int32Array(getNative(this).context.getImageData(x, y, width, height).data.buffer);
+        var abgrData = new Int32Array(NativeMap.get(addr).context.getImageData(x, y, width, height).data.buffer);
         ABGRToARGB(abgrData, rgbData, width, height, offset, scanlength);
     };
 
@@ -350,6 +350,7 @@ var currentlyFocusedTextEditor;
     var SIZE_LARGE = 16;
 
     Native["javax/microedition/lcdui/Font.init.(III)V"] = function(addr, face, style, size) {
+        var self = getHandle(addr);
         var defaultSize = config.fontSize ? config.fontSize : Math.max(19, (offscreenCanvas.height / 35) | 0);
         if (size & SIZE_SMALL)
             size = defaultSize / 1.25;
@@ -373,10 +374,11 @@ var currentlyFocusedTextEditor;
         else
             face = "Arial,Helvetica,sans-serif";
 
-        this.baseline = size | 0;
-        this.height = (size * 1.3) | 0;
+        self.baseline = size | 0;
+        self.height = (size * 1.3) | 0;
 
-        var context = setNative(this, document.createElement("canvas").getContext("2d"));
+        var context = document.createElement("canvas").getContext("2d");
+        NativeMap.set(addr, context);
         context.canvas.width = 0;
         context.canvas.height = 0;
         context.font = style + size + "px " + face;
@@ -389,12 +391,11 @@ var currentlyFocusedTextEditor;
         context.fontSize = size;
     };
 
-    function calcStringWidth(font, str) {
+    function calcStringWidth(fontContext, str) {
         var emojiLen = 0;
 
-        var context = getNative(font);
-        var len = context.measureText(str.replace(emoji.regEx, function() {
-            emojiLen += context.fontSize;
+        var len = fontContext.measureText(str.replace(emoji.regEx, function() {
+            emojiLen += fontContext.fontSize;
             return "";
         })).width | 0;
 
@@ -420,19 +421,23 @@ var currentlyFocusedTextEditor;
     };
 
     Native["javax/microedition/lcdui/Font.stringWidth.(Ljava/lang/String;)I"] = function(addr, str) {
-        return calcStringWidth(this, J2ME.fromJavaString(str));
+        var fontContext = NativeMap.get(addr);
+        return calcStringWidth(fontContext, J2ME.fromJavaString(str));
     };
 
     Native["javax/microedition/lcdui/Font.charWidth.(C)I"] = function(addr, char) {
-        return getNative(this).measureText(String.fromCharCode(char)).width | 0;
+        var fontContext = NativeMap.get(addr);
+        return fontContext.measureText(String.fromCharCode(char)).width | 0;
     };
 
     Native["javax/microedition/lcdui/Font.charsWidth.([CII)I"] = function(addr, str, offset, len) {
-        return calcStringWidth(this, util.fromJavaChars(str).slice(offset, offset + len));
+        var fontContext = NativeMap.get(addr);
+        return calcStringWidth(fontContext, util.fromJavaChars(str).slice(offset, offset + len));
     };
 
     Native["javax/microedition/lcdui/Font.substringWidth.(Ljava/lang/String;II)I"] = function(addr, str, offset, len) {
-        return calcStringWidth(this, J2ME.fromJavaString(str).slice(offset, offset + len));
+        var fontContext = NativeMap.get(addr);
+        return calcStringWidth(fontContext, J2ME.fromJavaString(str).slice(offset, offset + len));
     };
 
     var HCENTER = 1;
@@ -445,7 +450,8 @@ var currentlyFocusedTextEditor;
 
     function withTextAnchor(c, font, anchor, x, str) {
         if (anchor & RIGHT || anchor & HCENTER) {
-            var w = calcStringWidth(font, str);
+            var fontContext = getNative(font);
+            var w = calcStringWidth(fontContext, str);
 
             if (anchor & RIGHT) {
                 x -= w;
@@ -521,78 +527,81 @@ var currentlyFocusedTextEditor;
     };
 
     Native["javax/microedition/lcdui/Graphics.resetGC.()V"] = function(addr) {
-        getNative(this).resetGC();
+        NativeMap.get(addr).resetGC();
     };
 
     Native["javax/microedition/lcdui/Graphics.reset.(IIII)V"] = function(addr, x1, y1, x2, y2) {
-        getNative(this).reset(x1, y1, x2, y2);
+        NativeMap.get(addr).reset(x1, y1, x2, y2);
     };
 
     Native["javax/microedition/lcdui/Graphics.reset.()V"] = function(addr) {
-        var info = getNative(this);
+        var info = NativeMap.get(addr);
         info.reset(0, 0, info.contextInfo.context.canvas.width, info.contextInfo.context.canvas.height);
     };
 
     Native["javax/microedition/lcdui/Graphics.copyArea.(IIIIIII)V"] = function(addr, x_src, y_src, width, height, x_dest, y_dest, anchor) {
-        if (isScreenGraphics(this)) {
+        var self = getHandle(addr);
+        if (isScreenGraphics(self)) {
             throw $.newIllegalStateException();
         }
         console.warn("javax/microedition/lcdui/Graphics.copyArea.(IIIIIII)V not implemented");
     };
 
     Native["javax/microedition/lcdui/Graphics.setDimensions.(II)V"] = function(addr, w, h) {
-        getNative(this).resetNonGC(0, 0, w, h);
+        NativeMap.get(addr).resetNonGC(0, 0, w, h);
     };
 
     Native["javax/microedition/lcdui/Graphics.translate.(II)V"] = function(addr, x, y) {
-        getNative(this).translate(x, y);
+        NativeMap.get(addr).translate(x, y);
     };
 
     Native["javax/microedition/lcdui/Graphics.getTranslateX.()I"] = function(addr) {
-        return getNative(this).transX;
+        return NativeMap.get(addr).transX;
     };
 
     Native["javax/microedition/lcdui/Graphics.getTranslateY.()I"] = function(addr) {
-        return getNative(this).transY;
+        return NativeMap.get(addr).transY;
     };
 
     Native["javax/microedition/lcdui/Graphics.getMaxWidth.()S"] = function(addr) {
-        return getNative(this).contextInfo.context.canvas.width;
+        return NativeMap.get(addr).contextInfo.context.canvas.width;
     };
 
     Native["javax/microedition/lcdui/Graphics.getMaxHeight.()S"] = function(addr) {
-        return getNative(this).contextInfo.context.canvas.height;
+        return NativeMap.get(addr).contextInfo.context.canvas.height;
     };
 
     Native["javax/microedition/lcdui/Graphics.getCreator.()Ljava/lang/Object;"] = function(addr) {
-        return this.creator;
+        var self = getHandle(addr);
+        return self.creator;
     };
 
     Native["javax/microedition/lcdui/Graphics.setCreator.(Ljava/lang/Object;)V"] = function(addr, creator) {
-        if (!this.creator) {
-            this.creator = creator;
+        var self = getHandle(addr);
+        if (!self.creator) {
+            self.creator = creator;
         }
     };
 
     Native["javax/microedition/lcdui/Graphics.getColor.()I"] = function(addr) {
-        var info = getNative(this);
+        var info = NativeMap.get(addr);
         return (info.red << 16) | (info.green << 8) | info.blue;
     };
 
     Native["javax/microedition/lcdui/Graphics.getRedComponent.()I"] = function(addr) {
-        return getNative(this).red;
+        return NativeMap.get(addr).red;
     };
 
     Native["javax/microedition/lcdui/Graphics.getGreenComponent.()I"] = function(addr) {
-        return getNative(this).green;
+        return NativeMap.get(addr).green;
     };
 
     Native["javax/microedition/lcdui/Graphics.getBlueComponent.()I"] = function(addr) {
-        return getNative(this).blue;
+        return NativeMap.get(addr).blue;
     };
 
     Native["javax/microedition/lcdui/Graphics.getGrayScale.()I"] = function(addr) {
-        var info = getNative(this);
+        var info = NativeMap.get(addr);
         return (info.red*76 + info.green*150 + info.blue*29) >>> 8;
     };
 
@@ -603,7 +612,7 @@ var currentlyFocusedTextEditor;
             throw $.newIllegalArgumentException("Value out of range");
         }
 
-        getNative(this).setPixel(0xFF, red, green, blue);
+        NativeMap.get(addr).setPixel(0xFF, red, green, blue);
     };
 
     Native["javax/microedition/lcdui/Graphics.setColor.(I)V"] = function(addr, rgb) {
@@ -617,7 +626,7 @@ var currentlyFocusedTextEditor;
         // value being set. This is the behavior
         // of the reference implementation so we are copying
         // that behavior.
-        var info = getNative(this);
+        var info = NativeMap.get(addr);
         if (red != info.red || green != info.green || blue != info.blue) {
             info.setPixel(0xFF, red, green, blue);
         }
@@ -634,18 +643,18 @@ var currentlyFocusedTextEditor;
         // the same as the values being set. This is the behavior
         // of the reference implementation so we are copying
         // that behavior.
-        var info = getNative(this);
+        var info = NativeMap.get(addr);
         if (value != info.red || value != info.green || value != info.blue) {
             info.setPixel(0xFF, value, value, value);
         }
     };
 
     Native["javax/microedition/lcdui/Graphics.getFont.()Ljavax/microedition/lcdui/Font;"] = function(addr) {
-        return getNative(this).currentFont;
+        return NativeMap.get(addr).currentFont;
     };
 
     Native["javax/microedition/lcdui/Graphics.setFont.(Ljavax/microedition/lcdui/Font;)V"] = function(addr, font) {
-        getNative(this).setFont(font);
+        NativeMap.get(addr).setFont(font);
     };
 
     var SOLID = 0;
@@ -663,27 +672,27 @@ var currentlyFocusedTextEditor;
     };
 
     Native["javax/microedition/lcdui/Graphics.getClipX.()I"] = function(addr) {
-        var info = getNative(this);
+        var info = NativeMap.get(addr);
         return info.clipX1 - info.transX;
     };
 
     Native["javax/microedition/lcdui/Graphics.getClipY.()I"] = function(addr) {
-        var info = getNative(this);
+        var info = NativeMap.get(addr);
         return info.clipY1 - info.transY;
     };
 
     Native["javax/microedition/lcdui/Graphics.getClipWidth.()I"] = function(addr) {
-        var info = getNative(this);
+        var info = NativeMap.get(addr);
         return info.clipX2 - info.clipX1;
     };
 
     Native["javax/microedition/lcdui/Graphics.getClipHeight.()I"] = function(addr) {
-        var info = getNative(this);
+        var info = NativeMap.get(addr);
         return info.clipY2 - info.clipY1;
     };
 
     Native["javax/microedition/lcdui/Graphics.getClip.([I)V"] = function(addr, region) {
-        var info = getNative(this);
+        var info = NativeMap.get(addr);
         region[0] = info.clipX1 - info.transX;
         region[1] = info.clipY1 - info.transY;
         region[2] = info.clipX2 - info.transX;
@@ -691,7 +700,7 @@ var currentlyFocusedTextEditor;
     };
 
     Native["javax/microedition/lcdui/Graphics.clipRect.(IIII)V"] = function(addr, x, y, width, height) {
-        var info = getNative(this);
+        var info = NativeMap.get(addr);
         info.setClip(x, y, width, height, info.clipX1, info.clipY1, info.clipX2, info.clipY2);
     };
 
@@ -700,19 +709,23 @@ var currentlyFocusedTextEditor;
     var TYPE_USHORT_565_RGB = 565;
 
     Native["com/nokia/mid/ui/DirectGraphicsImp.setARGBColor.(I)V"] = function(addr, argb) {
+        var self = getHandle(addr);
         var alpha = (argb >>> 24);
         var red = (argb >>> 16) & 0xFF;
         var green = (argb >>> 8) & 0xFF;
         var blue = argb & 0xFF;
-        getNative(getHandle(this.graphics)).setPixel(alpha, red, green, blue);
+        getNative(getHandle(self.graphics)).setPixel(alpha, red, green, blue);
     };
 
     Native["com/nokia/mid/ui/DirectGraphicsImp.getAlphaComponent.()I"] = function(addr) {
-        return getNative(getHandle(this.graphics)).alpha;
+        var self = getHandle(addr);
+        return getNative(getHandle(self.graphics)).alpha;
     };
 
     Native["com/nokia/mid/ui/DirectGraphicsImp.getPixels.([SIIIIIII)V"] =
     function(addr, pixels, offset, scanlength, x, y, width, height, format) {
+        var self = getHandle(addr);
+
         if (!pixels) {
             throw $.newNullPointerException("Pixels array is null");
         }
@@ -726,13 +739,15 @@ var currentlyFocusedTextEditor;
             throw $.newIllegalArgumentException("Format unsupported");
         }
 
-        var context = getNative(getHandle(this.graphics)).contextInfo.context;
+        var context = getNative(getHandle(self.graphics)).contextInfo.context;
         var abgrData = new Int32Array(context.getImageData(x, y, width, height).data.buffer);
         converterFunc(abgrData, pixels, width, height, offset, scanlength);
     };
 
     Native["com/nokia/mid/ui/DirectGraphicsImp.drawPixels.([SZIIIIIIII)V"] =
     function(addr, pixels, transparency, offset, scanlength, x, y, width, height, manipulation, format) {
+        var self = getHandle(addr);
+
         if (!pixels) {
             throw $.newNullPointerException("Pixels array is null");
         }
@@ -753,7 +768,7 @@ var currentlyFocusedTextEditor;
 
         tempContext.putImageData(imageData, 0, 0);
 
-        var c = getNative(getHandle(this.graphics)).getGraphicsContext();
+        var c = getNative(getHandle(self.graphics)).getGraphicsContext();
 
         c.drawImage(tempContext.canvas, x, y);
         tempContext.canvas.width = 0;
@@ -761,7 +776,7 @@ var currentlyFocusedTextEditor;
     };
 
     Native["javax/microedition/lcdui/Graphics.render.(Ljavax/microedition/lcdui/Image;III)Z"] = function(addr, image, x, y, anchor) {
-        renderRegion(getNative(this).getGraphicsContext(), getNative(getHandle(image.imageData)).context.canvas,
+        renderRegion(NativeMap.get(addr).getGraphicsContext(), getNative(getHandle(image.imageData)).context.canvas,
                      0, 0, image.width, image.height, TRANS_NONE, x, y, anchor);
         return 1;
     };
@@ -771,7 +786,7 @@ var currentlyFocusedTextEditor;
             throw $.newNullPointerException("src image is null");
         }
 
-        renderRegion(getNative(this).getGraphicsContext(), getNative(getHandle(src.imageData)).context.canvas,
+        renderRegion(NativeMap.get(addr).getGraphicsContext(), getNative(getHandle(src.imageData)).context.canvas,
                      x_src, y_src, width, height, transform, x_dest, y_dest, anchor);
     };
 
@@ -781,7 +796,7 @@ var currentlyFocusedTextEditor;
         }
 
         var imageData = getHandle(image.imageData);
-        renderRegion(getNative(this).getGraphicsContext(), getNative(imageData).context.canvas,
+        renderRegion(NativeMap.get(addr).getGraphicsContext(), getNative(imageData).context.canvas,
                      0, 0, imageData.width, imageData.height, TRANS_NONE, x, y, anchor);
     };
 
@@ -919,15 +934,17 @@ var currentlyFocusedTextEditor;
     };
 
     Native["javax/microedition/lcdui/Graphics.initScreen0.(I)V"] = function(addr, displayId) {
-        this.displayId = displayId;
-        setNative(this, new GraphicsInfo(screenContextInfo));
-        this.creator = null;
+        var self = getHandle(addr);
+        self.displayId = displayId;
+        NativeMap.set(addr, new GraphicsInfo(screenContextInfo));
+        self.creator = null;
     };
 
     Native["javax/microedition/lcdui/Graphics.initImage0.(Ljavax/microedition/lcdui/Image;)V"] = function(addr, img) {
-        this.displayId = -1;
-        setNative(this, new GraphicsInfo(getNative(getHandle(img.imageData))));
-        this.creator = null;
+        var self = getHandle(addr);
+        self.displayId = -1;
+        NativeMap.set(addr, new GraphicsInfo(getNative(getHandle(img.imageData))));
+        self.creator = null;
     };
 
     function isScreenGraphics(g) {
@@ -935,7 +952,7 @@ var currentlyFocusedTextEditor;
     }
 
     Native["javax/microedition/lcdui/Graphics.setClip.(IIII)V"] = function(addr, x, y, w, h) {
-        var info = getNative(this);
+        var info = NativeMap.get(addr);
         info.setClip(x, y, w, h, 0, 0, info.contextInfo.context.canvas.width, info.contextInfo.context.canvas.height);
     };
 
@@ -981,21 +998,21 @@ var currentlyFocusedTextEditor;
     }
 
     Native["javax/microedition/lcdui/Graphics.drawString.(Ljava/lang/String;III)V"] = function(addr, str, x, y, anchor) {
-        drawString(getNative(this), J2ME.fromJavaString(str), x, y, anchor);
+        drawString(NativeMap.get(addr), J2ME.fromJavaString(str), x, y, anchor);
     };
 
     Native["javax/microedition/lcdui/Graphics.drawSubstring.(Ljava/lang/String;IIIII)V"] =
     function(addr, str, offset, len, x, y, anchor) {
-        drawString(getNative(this), J2ME.fromJavaString(str).substr(offset, len), x, y, anchor);
+        drawString(NativeMap.get(addr), J2ME.fromJavaString(str).substr(offset, len), x, y, anchor);
     };
 
     Native["javax/microedition/lcdui/Graphics.drawChars.([CIIIII)V"] = function(addr, data, offset, len, x, y, anchor) {
-        drawString(getNative(this), util.fromJavaChars(data, offset, len), x, y, anchor);
+        drawString(NativeMap.get(addr), util.fromJavaChars(data, offset, len), x, y, anchor);
     };
 
     Native["javax/microedition/lcdui/Graphics.drawChar.(CIII)V"] = function(addr, jChr, x, y, anchor) {
         var chr = String.fromCharCode(jChr);
-        var info = getNative(this);
+        var info = NativeMap.get(addr);
 
         var c = info.getGraphicsContext();
 
@@ -1005,7 +1022,7 @@ var currentlyFocusedTextEditor;
     };
 
     Native["javax/microedition/lcdui/Graphics.fillTriangle.(IIIIII)V"] = function(addr, x1, y1, x2, y2, x3, y3) {
-        var c = getNative(this).getGraphicsContext();
+        var c = NativeMap.get(addr).getGraphicsContext();
 
         var dx1 = (x2 - x1) || 1;
         var dy1 = (y2 - y1) || 1;
@@ -1025,7 +1042,7 @@ var currentlyFocusedTextEditor;
             return;
         }
 
-        var c = getNative(this).getGraphicsContext();
+        var c = NativeMap.get(addr).getGraphicsContext();
 
         w = w || 1;
         h = h || 1;
@@ -1038,7 +1055,7 @@ var currentlyFocusedTextEditor;
             return;
         }
 
-        var c = getNative(this).getGraphicsContext();
+        var c = NativeMap.get(addr).getGraphicsContext();
 
         w = w || 1;
         h = h || 1;
@@ -1053,7 +1070,7 @@ var currentlyFocusedTextEditor;
             return;
         }
 
-        var c = getNative(this).getGraphicsContext();
+        var c = NativeMap.get(addr).getGraphicsContext();
 
         w = w || 1;
         h = h || 1;
@@ -1066,7 +1083,7 @@ var currentlyFocusedTextEditor;
             return;
         }
 
-        var c = getNative(this).getGraphicsContext();
+        var c = NativeMap.get(addr).getGraphicsContext();
 
         w = w || 1;
         h = h || 1;
@@ -1081,7 +1098,7 @@ var currentlyFocusedTextEditor;
             return;
         }
 
-        var c = getNative(this).getGraphicsContext();
+        var c = NativeMap.get(addr).getGraphicsContext();
 
         var endRad = -startAngle * 0.0175;
         var startRad = endRad - arcAngle * 0.0175;
@@ -1095,7 +1112,7 @@ var currentlyFocusedTextEditor;
             return;
         }
 
-        var c = getNative(this).getGraphicsContext();
+        var c = NativeMap.get(addr).getGraphicsContext();
 
         var endRad = -startAngle * 0.0175;
         var startRad = endRad - arcAngle * 0.0175;
@@ -1224,7 +1241,7 @@ var currentlyFocusedTextEditor;
     };
 
     Native["javax/microedition/lcdui/Graphics.drawLine.(IIII)V"] = function(addr, x1, y1, x2, y2) {
-        var c = getNative(this).getGraphicsContext();
+        var c = NativeMap.get(addr).getGraphicsContext();
 
         // If we're drawing a completely vertical line that is
         // 1 pixel thick, we should draw it at half-pixel offsets.
@@ -1266,7 +1283,7 @@ var currentlyFocusedTextEditor;
 
         tempContext.putImageData(imageData, 0, 0);
 
-        var c = getNative(this).getGraphicsContext();
+        var c = NativeMap.get(addr).getGraphicsContext();
 
         c.drawImage(tempContext.canvas, x, y);
         tempContext.canvas.width = 0;
@@ -1307,43 +1324,48 @@ var currentlyFocusedTextEditor;
 
     Native["com/nokia/mid/ui/TextEditor.init.(Ljava/lang/String;IIII)V"] =
     function(addr, text, maxSize, constraints, width, height) {
+        var self = getHandle(addr);
+
         if (constraints !== 0) {
             console.warn("TextEditor.constraints not implemented");
         }
 
-        var textEditor = setNative(this, TextEditorProvider.getEditor(constraints, null, ++textEditorId));
+        var textEditor = TextEditorProvider.getEditor(constraints, null, ++textEditorId);
+        NativeMap.set(addr, textEditor);
         textEditor.setBackgroundColor(0xFFFFFFFF | 0); // opaque white
         textEditor.setForegroundColor(0xFF000000 | 0); // opaque black
 
         textEditor.setAttribute("maxlength", maxSize);
         textEditor.setSize(width, height);
         textEditor.setVisible(false);
-        var font = getHandle(this.font);
+        var font = getHandle(self.font);
         textEditor.setFont(font);
 
         textEditor.setContent(J2ME.fromJavaString(text));
-        setTextEditorCaretPosition(this, textEditor.getContentSize());
+        setTextEditorCaretPosition(self, textEditor.getContentSize());
 
         textEditor.oninput(function(e) {
-            wakeTextEditorThread(this);
-        }.bind(this));
+            wakeTextEditorThread(self);
+        });
     };
 
     Native["com/nokia/mid/ui/CanvasItem.attachNativeImpl.()V"] = function(addr) {
-        var textEditor = getNative(this);
+        var self = getHandle(addr);
+        var textEditor = NativeMap.get(addr);
         if (textEditor) {
             textEditor.attach();
-            if (this.caretPosition !== 0) {
-                textEditor.setSelectionRange(this.caretPosition, this.caretPosition);
-                this.caretPosition = null;
+            if (self.caretPosition !== 0) {
+                textEditor.setSelectionRange(self.caretPosition, self.caretPosition);
+                self.caretPosition = null;
             }
         }
     };
 
     Native["com/nokia/mid/ui/CanvasItem.detachNativeImpl.()V"] = function(addr) {
-        var textEditor = getNative(this);
+        var self = getHandle(addr);
+        var textEditor = NativeMap.get(addr);
         if (textEditor) {
-            this.caretPosition = textEditor.getSelectionStart();
+            self.caretPosition = textEditor.getSelectionStart();
             textEditor.detach();
         }
     };
@@ -1353,48 +1375,48 @@ var currentlyFocusedTextEditor;
     };
 
     Native["com/nokia/mid/ui/CanvasItem.setSize.(II)V"] = function(addr, width, height) {
-        getNative(this).setSize(width, height);
+        NativeMap.get(addr).setSize(width, height);
     };
 
     Native["com/nokia/mid/ui/CanvasItem.setVisible.(Z)V"] = function(addr, visible) {
-        getNative(this).setVisible(visible ? true : false);
+        NativeMap.get(addr).setVisible(visible ? true : false);
     };
 
     Native["com/nokia/mid/ui/CanvasItem.getWidth.()I"] = function(addr) {
-        return getNative(this).getWidth();
+        return NativeMap.get(addr).getWidth();
     };
 
     Native["com/nokia/mid/ui/CanvasItem.getHeight.()I"] = function(addr) {
-        return getNative(this).getHeight();
+        return NativeMap.get(addr).getHeight();
     };
 
     Native["com/nokia/mid/ui/CanvasItem.setPosition0.(II)V"] = function(addr, x, y) {
-        getNative(this).setPosition(x, y);
+        NativeMap.get(addr).setPosition(x, y);
     };
 
     Native["com/nokia/mid/ui/CanvasItem.getPositionX.()I"] = function(addr) {
-        return getNative(this).getLeft();
+        return NativeMap.get(addr).getLeft();
     };
 
     Native["com/nokia/mid/ui/CanvasItem.getPositionY.()I"] = function(addr) {
-        return getNative(this).getTop();
+        return NativeMap.get(addr).getTop();
     };
 
     Native["com/nokia/mid/ui/CanvasItem.isVisible.()Z"] = function(addr) {
-        return getNative(this).visible ? 1 : 0;
+        return NativeMap.get(addr).visible ? 1 : 0;
     };
 
     Native["com/nokia/mid/ui/TextEditor.setConstraints.(I)V"] = function(addr, constraints) {
-        var textEditor = getNative(this);
-        setNative(this, TextEditorProvider.getEditor(constraints, textEditor, textEditor.id));
+        var textEditor = NativeMap.get(addr);
+        NativeMap.set(addr, TextEditorProvider.getEditor(constraints, textEditor, textEditor.id));
     };
 
     Native["com/nokia/mid/ui/TextEditor.getConstraints.()I"] = function(addr) {
-        return getNative(this).constraints;
+        return NativeMap.get(addr).constraints;
     };
 
     Native["com/nokia/mid/ui/TextEditor.setFocus.(Z)V"] = function(addr, shouldFocus) {
-        var textEditor = getNative(this);
+        var textEditor = NativeMap.get(addr);
         var promise;
         if (shouldFocus && (currentlyFocusedTextEditor !== textEditor)) {
             promise = textEditor.focus();
@@ -1409,95 +1431,101 @@ var currentlyFocusedTextEditor;
     };
 
     Native["com/nokia/mid/ui/TextEditor.hasFocus.()Z"] = function(addr) {
-        return (getNative(this) === currentlyFocusedTextEditor) ? 1 : 0;
+        return (NativeMap.get(addr) === currentlyFocusedTextEditor) ? 1 : 0;
     };
 
     Native["com/nokia/mid/ui/TextEditor.setCaret.(I)V"] = function(addr, index) {
-        var textEditor = getNative(this);
+        var self = getHandle(addr);
+        var textEditor = NativeMap.get(addr);
 
         if (index < 0 || index > textEditor.getContentSize()) {
             throw $.newStringIndexOutOfBoundsException();
         }
 
-        setTextEditorCaretPosition(this, index);
+        setTextEditorCaretPosition(self, index);
     };
 
     Native["com/nokia/mid/ui/TextEditor.getCaretPosition.()I"] = function(addr) {
-        return getTextEditorCaretPosition(this);
+        var self = getHandle(addr);
+        return getTextEditorCaretPosition(self);
     };
 
     Native["com/nokia/mid/ui/TextEditor.getBackgroundColor.()I"] = function(addr) {
-        return getNative(this).getBackgroundColor();
+        return NativeMap.get(addr).getBackgroundColor();
     };
     Native["com/nokia/mid/ui/TextEditor.getForegroundColor.()I"] = function(addr) {
-        return getNative(this).getForegroundColor();
+        return NativeMap.get(addr).getForegroundColor();
     };
     Native["com/nokia/mid/ui/TextEditor.setBackgroundColor.(I)V"] = function(addr, backgroundColor) {
-        getNative(this).setBackgroundColor(backgroundColor);
+        NativeMap.get(addr).setBackgroundColor(backgroundColor);
     };
     Native["com/nokia/mid/ui/TextEditor.setForegroundColor.(I)V"] = function(addr, foregroundColor) {
-        getNative(this).setForegroundColor(foregroundColor);
+        NativeMap.get(addr).setForegroundColor(foregroundColor);
     };
 
     Native["com/nokia/mid/ui/TextEditor.getContent.()Ljava/lang/String;"] = function(addr) {
-        return J2ME.newString(getNative(this).getContent());
+        return J2ME.newString(NativeMap.get(addr).getContent());
     };
 
     Native["com/nokia/mid/ui/TextEditor.setContent.(Ljava/lang/String;)V"] = function(addr, jStr) {
-        var textEditor = getNative(this);
+        var self = getHandle(addr);
+        var nativeTextEditor = NativeMap.get(addr);
         var str = J2ME.fromJavaString(jStr);
-        textEditor.setContent(str);
-        setTextEditorCaretPosition(this, textEditor.getContentSize());
+        nativeTextEditor.setContent(str);
+        setTextEditorCaretPosition(self, nativeTextEditor.getContentSize());
     };
 
     addUnimplementedNative("com/nokia/mid/ui/TextEditor.getLineMarginHeight.()I", 0);
     addUnimplementedNative("com/nokia/mid/ui/TextEditor.getVisibleContentPosition.()I", 0);
 
     Native["com/nokia/mid/ui/TextEditor.getContentHeight.()I"] = function(addr) {
-        return getNative(this).getContentHeight();
+        return NativeMap.get(addr).getContentHeight();
     };
 
     Native["com/nokia/mid/ui/TextEditor.insert.(Ljava/lang/String;I)V"] = function(addr, jStr, pos) {
-        var textEditor = getNative(this);
+        var self = getHandle(addr);
+        var nativeTextEditor = NativeMap.get(addr);
         var str = J2ME.fromJavaString(jStr);
         var len = util.toCodePointArray(str).length;
-        if (textEditor.getContentSize() + len > textEditor.getAttribute("maxlength")) {
+        if (nativeTextEditor.getContentSize() + len > nativeTextEditor.getAttribute("maxlength")) {
             throw $.newIllegalArgumentException();
         }
-        textEditor.setContent(textEditor.getSlice(0, pos) + str + textEditor.getSlice(pos));
-        setTextEditorCaretPosition(this, pos + len);
+        nativeTextEditor.setContent(nativeTextEditor.getSlice(0, pos) + str + nativeTextEditor.getSlice(pos));
+        setTextEditorCaretPosition(self, pos + len);
     };
 
     Native["com/nokia/mid/ui/TextEditor.delete.(II)V"] = function(addr, offset, length) {
-        var textEditor = getNative(this);
-        var old = textEditor.getContent();
+        var self = getHandle(addr);
+        var nativeTextEditor = NativeMap.get(addr);
+        var old = nativeTextEditor.getContent();
 
-        var size = textEditor.getContentSize();
+        var size = nativeTextEditor.getContentSize();
         if (offset < 0 || offset > size || length < 0 || offset + length > size) {
             throw $.newStringIndexOutOfBoundsException("offset/length invalid");
         }
 
-        textEditor.setContent(textEditor.getSlice(0, offset) + textEditor.getSlice(offset + length));
-        setTextEditorCaretPosition(this, offset);
+        nativeTextEditor.setContent(nativeTextEditor.getSlice(0, offset) + nativeTextEditor.getSlice(offset + length));
+        setTextEditorCaretPosition(self, offset);
     };
 
     Native["com/nokia/mid/ui/TextEditor.getMaxSize.()I"] = function(addr) {
-        return parseInt(getNative(this).getAttribute("maxlength"));
+        return parseInt(NativeMap.get(addr).getAttribute("maxlength"));
     };
 
     Native["com/nokia/mid/ui/TextEditor.setMaxSize.(I)I"] = function(addr, maxSize) {
-        var textEditor = getNative(this);
-        if (textEditor.getContentSize() > maxSize) {
-            var oldCaretPosition = getTextEditorCaretPosition(this);
+        var self = getHandle(addr);
+        var nativeTextEditor = NativeMap.get(addr);
+        if (nativeTextEditor.getContentSize() > maxSize) {
+            var oldCaretPosition = getTextEditorCaretPosition(self);
 
-            textEditor.setContent(textEditor.getSlice(0, maxSize));
+            nativeTextEditor.setContent(nativeTextEditor.getSlice(0, maxSize));
 
             if (oldCaretPosition > maxSize) {
-                setTextEditorCaretPosition(this, maxSize);
+                setTextEditorCaretPosition(self, maxSize);
             }
         }
 
-        textEditor.setAttribute("maxlength", maxSize);
+        nativeTextEditor.setAttribute("maxlength", maxSize);
 
         // The return value is the assigned size, which could be less than
         // the size that was requested, although in this case we always set it
@@ -1506,13 +1534,14 @@ var currentlyFocusedTextEditor;
     };
 
     Native["com/nokia/mid/ui/TextEditor.size.()I"] = function(addr) {
-        return getNative(this).getContentSize();
+        return NativeMap.get(addr).getContentSize();
     };
 
     Native["com/nokia/mid/ui/TextEditor.setFont.(Ljavax/microedition/lcdui/Font;)V"] = function(addr, font) {
-        this.font = font._address;
-        var textEditor = getNative(this);
-        textEditor.setFont(font);
+        var self = getHandle(addr);
+        self.font = font._address;
+        var nativeTextEditor = NativeMap.get(addr);
+        nativeTextEditor.setFont(font);
     };
 
     Native["com/nokia/mid/ui/TextEditorThread.getNextDirtyEditor.()Lcom/nokia/mid/ui/TextEditor;"] = function(addr) {

--- a/midp/midp.js
+++ b/midp/midp.js
@@ -595,8 +595,9 @@ var MIDP = (function() {
   };
 
   Native["com/sun/midp/midletsuite/InstallInfo.load.()V"] = function(addr) {
+    var self = getHandle(addr);
     // The MIDlet has to be trusted for opening SSL connections using port 443.
-    this.trusted = 1;
+    self.trusted = 1;
     console.warn("com/sun/midp/midletsuite/InstallInfo.load.()V incomplete");
   };
 

--- a/midp/socket.js
+++ b/midp/socket.js
@@ -24,9 +24,10 @@ Native["com/sun/midp/io/j2me/socket/Protocol.getHost0.(Z)Ljava/lang/String;"] = 
     // as Protocol.open0 does.  Then we wouldn't have to get the native socket,
     // and we might avoid an exception if the socket hasn't been opened yet
     // (so the native socket doesn't exist).
-    // var host = J2ME.fromJavaString(getHandle(this.host));
+    // var self = getHandle(addr);
+    // var host = J2ME.fromJavaString(getHandle(self.host));
 
-    var socket = getNative(this);
+    var socket = NativeMap.get(addr);
     return local ? "127.0.0.1" : socket.host;
 };
 
@@ -100,21 +101,22 @@ Socket.prototype.close = function() {
 }
 
 Native["com/sun/midp/io/j2me/socket/Protocol.open0.([BI)V"] = function(addr, ipBytes, port) {
-    var host = J2ME.fromJavaString(getHandle(this.host));
+    var self = getHandle(addr);
+    var host = J2ME.fromJavaString(getHandle(self.host));
     // console.log("Protocol.open0: " + host + ":" + port);
-    asyncImpl("V", new Promise((function(resolve, reject) {
-        setNative(this, new Socket(host, port, $.ctx, resolve, reject));
-    }).bind(this)));
+    asyncImpl("V", new Promise(function(resolve, reject) {
+        NativeMap.set(addr, new Socket(host, port, $.ctx, resolve, reject));
+    }));
 };
 
 Native["com/sun/midp/io/j2me/socket/Protocol.available0.()I"] = function(addr) {
-    var socket = getNative(this);
+    var socket = NativeMap.get(addr);
     // console.log("Protocol.available0: " + socket.data.byteLength);
     return socket.dataLen;
 };
 
 Native["com/sun/midp/io/j2me/socket/Protocol.read0.([BII)I"] = function(addr, data, offset, length) {
-    var socket = getNative(this);
+    var socket = NativeMap.get(addr);
     // console.log("Protocol.read0: " + socket.isClosed);
 
     asyncImpl("I", new Promise(function(resolve, reject) {
@@ -163,7 +165,7 @@ Native["com/sun/midp/io/j2me/socket/Protocol.read0.([BII)I"] = function(addr, da
 };
 
 Native["com/sun/midp/io/j2me/socket/Protocol.write0.([BII)I"] = function(addr, data, offset, length) {
-    var socket = getNative(this);
+    var socket = NativeMap.get(addr);
     var ctx = $.ctx;
     asyncImpl("I", new Promise(function(resolve, reject) {
         if (socket.isClosed) {
@@ -193,7 +195,7 @@ Native["com/sun/midp/io/j2me/socket/Protocol.write0.([BII)I"] = function(addr, d
 };
 
 Native["com/sun/midp/io/j2me/socket/Protocol.setSockOpt0.(II)V"] = function(addr, option, value) {
-    var socket = getNative(this);
+    var socket = NativeMap.get(addr);
     if (!(option in socket.options)) {
         throw $.newIllegalArgumentException("Unsupported socket option");
     }
@@ -202,7 +204,7 @@ Native["com/sun/midp/io/j2me/socket/Protocol.setSockOpt0.(II)V"] = function(addr
 };
 
 Native["com/sun/midp/io/j2me/socket/Protocol.getSockOpt0.(I)I"] = function(addr, option) {
-    var socket = getNative(this);
+    var socket = NativeMap.get(addr);
     if (!(option in socket.options)) {
         throw new $.newIllegalArgumentException("Unsupported socket option");
     }
@@ -211,7 +213,7 @@ Native["com/sun/midp/io/j2me/socket/Protocol.getSockOpt0.(I)I"] = function(addr,
 };
 
 Native["com/sun/midp/io/j2me/socket/Protocol.close0.()V"] = function(addr) {
-    var socket = getNative(this);
+    var socket = NativeMap.get(addr);
     // console.log("Protocol.close0: " + socket.isClosed);
 
     asyncImpl("V", new Promise(function(resolve, reject) {
@@ -240,14 +242,14 @@ Native["com/sun/midp/io/j2me/socket/Protocol.shutdownOutput0.()V"] = function(ad
 };
 
 Native["com/sun/midp/io/j2me/socket/Protocol.notifyClosedInput0.()V"] = function(addr) {
-    var socket = getNative(this);
+    var socket = NativeMap.get(addr);
     if (socket.waitingData) {
         console.warn("Protocol.notifyClosedInput0.()V unimplemented while thread is blocked on read0");
     }
 };
 
 Native["com/sun/midp/io/j2me/socket/Protocol.notifyClosedOutput0.()V"] = function(addr) {
-    var socket = getNative(this);
+    var socket = NativeMap.get(addr);
     if (socket.ondrain) {
         console.warn("Protocol.notifyClosedOutput0.()V unimplemented while thread is blocked on write0");
     }

--- a/native.js
+++ b/native.js
@@ -306,11 +306,13 @@ Native["com/sun/cldchi/jvm/JVM.monotonicTimeMillis.()J"] = function(addr) {
 };
 
 Native["java/lang/Object.getClass.()Ljava/lang/Class;"] = function(addr) {
-    return $.getRuntimeKlass(this.klass).classObject;
+    var self = getHandle(addr);
+    return $.getRuntimeKlass(self.klass).classObject;
 };
 
 Native["java/lang/Class.getSuperclass.()Ljava/lang/Class;"] = function(addr) {
-    var superKlass = this.runtimeKlass.templateKlass.superKlass;
+    var self = getHandle(addr);
+    var superKlass = self.runtimeKlass.templateKlass.superKlass;
     if (!superKlass) {
       return null;
     }
@@ -318,7 +320,8 @@ Native["java/lang/Class.getSuperclass.()Ljava/lang/Class;"] = function(addr) {
 };
 
 Native["java/lang/Class.invoke_clinit.()V"] = function(addr) {
-    var classInfo = this.runtimeKlass.templateKlass.classInfo;
+    var self = getHandle(addr);
+    var classInfo = self.runtimeKlass.templateKlass.classInfo;
     var className = classInfo.getClassNameSlow();
     var clinit = classInfo.staticInitializer;
     J2ME.preemptionLockLevel++;
@@ -332,12 +335,14 @@ Native["java/lang/Class.invoke_verify.()V"] = function(addr) {
 };
 
 Native["java/lang/Class.init9.()V"] = function(addr) {
-    $.setClassInitialized(this.runtimeKlass);
+    var self = getHandle(addr);
+    $.setClassInitialized(self.runtimeKlass);
     J2ME.preemptionLockLevel--;
 };
 
 Native["java/lang/Class.getName.()Ljava/lang/String;"] = function(addr) {
-    return J2ME.newString(this.runtimeKlass.templateKlass.classInfo.getClassNameSlow().replace(/\//g, "."));
+    var self = getHandle(addr);
+    return J2ME.newString(self.runtimeKlass.templateKlass.classInfo.getClassNameSlow().replace(/\//g, "."));
 };
 
 Native["java/lang/Class.forName0.(Ljava/lang/String;)V"] = function(addr, name) {
@@ -364,16 +369,17 @@ Native["java/lang/Class.forName1.(Ljava/lang/String;)Ljava/lang/Class;"] = funct
 };
 
 Native["java/lang/Class.newInstance0.()Ljava/lang/Object;"] = function(addr) {
-  if (this.runtimeKlass.templateKlass.classInfo.isInterface ||
-      this.runtimeKlass.templateKlass.classInfo.isAbstract) {
+  var self = getHandle(addr);
+  if (self.runtimeKlass.templateKlass.classInfo.isInterface ||
+      self.runtimeKlass.templateKlass.classInfo.isAbstract) {
     throw $.newInstantiationException("Can't instantiate interfaces or abstract classes");
   }
 
-  if (this.runtimeKlass.templateKlass.classInfo instanceof J2ME.ArrayClassInfo) {
+  if (self.runtimeKlass.templateKlass.classInfo instanceof J2ME.ArrayClassInfo) {
     throw $.newInstantiationException("Can't instantiate array classes");
   }
 
-  return new this.runtimeKlass.templateKlass;
+  return new self.runtimeKlass.templateKlass;
 };
 
 Native["java/lang/Class.newInstance1.(Ljava/lang/Object;)V"] = function(addr, o) {
@@ -386,21 +392,25 @@ Native["java/lang/Class.newInstance1.(Ljava/lang/Object;)V"] = function(addr, o)
 };
 
 Native["java/lang/Class.isInterface.()Z"] = function(addr) {
-    return this.runtimeKlass.templateKlass.classInfo.isInterface ? 1 : 0;
+    var self = getHandle(addr);
+    return self.runtimeKlass.templateKlass.classInfo.isInterface ? 1 : 0;
 };
 
 Native["java/lang/Class.isArray.()Z"] = function(addr) {
-    return this.runtimeKlass.templateKlass.classInfo instanceof J2ME.ArrayClassInfo ? 1 : 0;
+    var self = getHandle(addr);
+    return self.runtimeKlass.templateKlass.classInfo instanceof J2ME.ArrayClassInfo ? 1 : 0;
 };
 
 Native["java/lang/Class.isAssignableFrom.(Ljava/lang/Class;)Z"] = function(addr, fromClass) {
+    var self = getHandle(addr);
     if (!fromClass)
         throw $.newNullPointerException();
-    return J2ME.isAssignableTo(fromClass.runtimeKlass.templateKlass, this.runtimeKlass.templateKlass) ? 1 : 0;
+    return J2ME.isAssignableTo(fromClass.runtimeKlass.templateKlass, self.runtimeKlass.templateKlass) ? 1 : 0;
 };
 
 Native["java/lang/Class.isInstance.(Ljava/lang/Object;)Z"] = function(addr, obj) {
-    return obj && J2ME.isAssignableTo(obj.klass, this.runtimeKlass.templateKlass) ? 1 : 0;
+    var self = getHandle(addr);
+    return obj && J2ME.isAssignableTo(obj.klass, self.runtimeKlass.templateKlass) ? 1 : 0;
 };
 
 Native["java/lang/Float.floatToIntBits.(F)I"] = function(addr, f) {
@@ -423,8 +433,9 @@ Native["java/lang/Double.longBitsToDouble.(J)D"] = function(addr, l, h) {
 }
 
 Native["java/lang/Throwable.fillInStackTrace.()V"] = function(addr) {
-    this.stackTrace = [];
     J2ME.traceWriter && J2ME.traceWriter.writeLn("REDUX");
+    //var stackTrace = [];
+    //NativeMap.set(addr, stackTrace);
     //$.ctx.frames.forEach(function(frame) {
     //    if (!frame.methodInfo)
     //        return;
@@ -434,15 +445,16 @@ Native["java/lang/Throwable.fillInStackTrace.()V"] = function(addr) {
     //        return;
     //    var classInfo = methodInfo.classInfo;
     //    var className = classInfo.getClassNameSlow();
-    //    this.stackTrace.unshift({ className: className, methodName: methodName, methodSignature: methodInfo.signature, offset: frame.bci });
-    //}.bind(this));
+    //    stackTrace.unshift({ className: className, methodName: methodName, methodSignature: methodInfo.signature, offset: frame.bci });
+    //});
 };
 
 Native["java/lang/Throwable.obtainBackTrace.()Ljava/lang/Object;"] = function(addr) {
     var resultAddr = J2ME.Constants.NULL;
     // XXX: Untested.
-    if (this.stackTrace) {
-        var depth = this.stackTrace.length;
+    var stackTrace = NativeMap.get(addr);
+    if (stackTrace) {
+        var depth = stackTrace.length;
         var classNamesAddr = J2ME.newStringArray(depth);
         var classNames = J2ME.getArrayFromAddr(classNamesAddr);
         var methodNamesAddr = J2ME.newStringArray(depth);
@@ -451,7 +463,7 @@ Native["java/lang/Throwable.obtainBackTrace.()Ljava/lang/Object;"] = function(ad
         var methodSignatures = J2ME.getArrayFromAddr(methodSignaturesAddr);
         var offsetsAddr = J2ME.newIntArray(depth);
         var offsets = J2ME.getArrayFromAddr(offsetsAddr);
-        this.stackTrace.forEach(function(e, n) {
+        stackTrace.forEach(function(e, n) {
             classNames[n] = J2ME.newString(e.className);
             methodNames[n] = J2ME.newString(e.methodName);
             methodSignatures[n] = J2ME.newString(e.methodSignature);
@@ -530,22 +542,24 @@ Native["java/lang/Thread.setPriority0.(II)V"] = function(addr, oldPriority, newP
 };
 
 Native["java/lang/Thread.start0.()V"] = function(addr) {
+    var self = getHandle(addr);
+
     // The main thread starts during bootstrap and don't allow calling start()
     // on already running threads.
-    if (this._address === $.ctx.runtime.mainThread || this.nativeAlive)
+    if (addr === $.ctx.runtime.mainThread || self.nativeAlive)
         throw $.newIllegalThreadStateException();
-    this.nativeAlive = 1;
-    // XXX this.pid seems to be unused, so remove it.
-    this.pid = util.id();
+    self.nativeAlive = 1;
+    // XXX self.pid seems to be unused, so remove it.
+    self.pid = util.id();
     // Create a context for the thread and start it.
     var newCtx = new Context($.ctx.runtime);
-    newCtx.threadAddress = this._address;
+    newCtx.threadAddress = addr;
 
     var classInfo = CLASSES.getClass("org/mozilla/internal/Sys");
     var run = classInfo.getMethodByNameString("runThread", "(Ljava/lang/Thread;)V", true);
     newCtx.nativeThread.pushFrame(null);
     newCtx.nativeThread.pushFrame(run);
-    newCtx.nativeThread.frame.setParameter(J2ME.Kind.Reference, 0, this);
+    newCtx.nativeThread.frame.setParameter(J2ME.Kind.Reference, 0, addr);
     newCtx.start();
 }
 
@@ -623,33 +637,35 @@ Native["com/sun/cldc/io/ResourceInputStream.readBytes.(Ljava/lang/Object;[BII)I"
 
 Native["java/lang/ref/WeakReference.initializeWeakReference.(Ljava/lang/Object;)V"] = function(addr, target) {
     // XXX Make these real weak references.
-    setNative(this, target);
+    NativeMap.set(addr, target);
 };
 
 Native["java/lang/ref/WeakReference.get.()Ljava/lang/Object;"] = function(addr) {
-    var target = getNative(this);
+    var target = NativeMap.get(addr);
     return target ? target : null;
 };
 
 Native["java/lang/ref/WeakReference.clear.()V"] = function(addr) {
-    deleteNative(this);
+    NativeMap.delete(addr);
 };
 
 Native["com/sun/cldc/isolate/Isolate.registerNewIsolate.()V"] = function(addr) {
-    this._id = util.id();
+    var self = getHandle(addr);
+    self._id = util.id();
 };
 
 Native["com/sun/cldc/isolate/Isolate.getStatus.()I"] = function(addr) {
-    var runtime = Runtime.isolateMap[this._address];
+    var runtime = Runtime.isolateMap[addr];
     return runtime ? runtime.status : J2ME.RuntimeStatus.New;
 };
 
 Native["com/sun/cldc/isolate/Isolate.nativeStart.()V"] = function(addr) {
-    $.ctx.runtime.jvm.startIsolate(this);
+    var self = getHandle(addr);
+    $.ctx.runtime.jvm.startIsolate(self);
 };
 
 Native["com/sun/cldc/isolate/Isolate.waitStatus.(I)V"] = function(addr, status) {
-    var runtime = Runtime.isolateMap[this._address];
+    var runtime = Runtime.isolateMap[addr];
     asyncImpl("V", new Promise(function(resolve, reject) {
         if (runtime.status >= status) {
             resolve();
@@ -757,14 +773,15 @@ Native["org/mozilla/internal/Sys.eval.(Ljava/lang/String;)V"] = function(addr, s
 };
 
 Native["java/lang/String.intern.()Ljava/lang/String;"] = function(addr) {
-  var value = J2ME.getArrayFromAddr(this.value);
+  var self = getHandle(addr);
+  var value = J2ME.getArrayFromAddr(self.value);
   var internedStrings = J2ME.internedStrings;
-  var internedString = internedStrings.getByRange(value, this.offset, this.count);
+  var internedString = internedStrings.getByRange(value, self.offset, self.count);
   if (internedString !== null) {
     return internedString;
   }
-  internedStrings.put(value.subarray(this.offset, this.offset + this.count), this);
-  return this;
+  internedStrings.put(value.subarray(self.offset, self.offset + self.count), self);
+  return self;
 };
 
 var profileStarted = false;

--- a/string.js
+++ b/string.js
@@ -7,6 +7,9 @@
 // *
 // * Methods are defined in the same order as the Java source.
 // * Any missing methods have been noted in comments.
+// *
+// * XXX If you reuse this code at some point, update it to work with the new
+// * way that natives associated with Java objects are stored in NativeMap.
 // */
 //
 ////################################################################
@@ -55,35 +58,29 @@
 //  }
 //}
 //
-//Native["java/lang/String.init.([BIILjava/lang/String;)V"] =
-//  function(bytes, off, len, enc) {
-//    constructFromByteArray.call(this, bytes, off, len, enc.str);
-//  };
+//Native["java/lang/String.init.([BIILjava/lang/String;)V"] = function(addr, bytes, off, len, enc) {
+//  constructFromByteArray.call(this, bytes, off, len, enc.str);
+//};
 //
-//Native["java/lang/String.init.([BLjava/lang/String;)V"] =
-//  function(bytes, enc) {
-//    constructFromByteArray.call(this, bytes, 0, bytes.length, enc.str);
-//  };
+//Native["java/lang/String.init.([BLjava/lang/String;)V"] = function(addr, bytes, enc) {
+//  constructFromByteArray.call(this, bytes, 0, bytes.length, enc.str);
+//};
 //
-//Native["java/lang/String.init.([BII)V"] =
-//  function(bytes, offset, len) {
-//    constructFromByteArray.call(this, bytes, offset, len, "UTF-8");
-//  };
+//Native["java/lang/String.init.([BII)V"] = function(addr, bytes, offset, len) {
+//  constructFromByteArray.call(this, bytes, offset, len, "UTF-8");
+//};
 //
-//Native["java/lang/String.init.([B)V"] =
-//  function(bytes) {
-//    constructFromByteArray.call(this, bytes, 0, bytes.length, "UTF-8");
-//  };
+//Native["java/lang/String.init.([B)V"] = function(addr, bytes) {
+//  constructFromByteArray.call(this, bytes, 0, bytes.length, "UTF-8");
+//};
 //
-//Native["java/lang/String.init.(Ljava/lang/StringBuffer;)V"] =
-//  function(jBuffer) {
-//    this.str = util.fromJavaChars(jBuffer.buf, 0, jBuffer.count);
-//  };
+//Native["java/lang/String.init.(Ljava/lang/StringBuffer;)V"] = function(addr, jBuffer) {
+//  this.str = util.fromJavaChars(jBuffer.buf, 0, jBuffer.count);
+//};
 //
-//Native["java/lang/String.init.(II[C)V"] =
-//  function(offset, count, value) {
-//    this.str = util.fromJavaChars(value, offset, count);
-//  };
+//Native["java/lang/String.init.(II[C)V"] = function(addr, offset, count, value) {
+//  this.str = util.fromJavaChars(value, offset, count);
+//};
 //
 ////****************************************************************
 //// Methods


### PR DESCRIPTION
This branch removes references to the *this* object from natives. It's a followup to (and depends on) #1676.