### PR TITLE
Use a node.js https server

### DIFF
--- a/tests/httpsServer.js
+++ b/tests/httpsServer.js
@@ -1,0 +1,21 @@
+const fs    = require("fs");
+const https = require("https");
+
+var pem = fs.readFileSync('cert.pem');
+
+var options = {
+  key: pem,
+  cert: pem,
+  secureProtocol: 'SSLv3_method',
+};
+
+https.createServer(options, function(req, res) {
+  var data = fs.readFileSync("." + req.url);
+
+  res.writeHead(200, {
+    'Content-Length': data.length,
+    'Content-Type': 'text/html',
+  });
+
+  res.end(data);
+}).listen(4443);

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -6,6 +6,14 @@ import socket
 import subprocess
 import sys
 import time
+import platform
+
+(system, node, release, version, machine, processor) = platform.uname()
+
+httpsServer = ['node', 'httpsServer.js']
+
+if system == "Darwin":
+  httpsServer = './httpsServer.py'
 
 # The test automation scripts to run via casperjs/slimerjs.
 automation_scripts = [
@@ -42,7 +50,7 @@ server_processes = [
 
     # The SSL-based servers need to have their current working directory set
     # to the tests/ subdirectory, since they load cert/key files relative to it.
-    subprocess.Popen('./httpsServer.py', stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+    subprocess.Popen(httpsServer, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
                      bufsize=1, cwd='tests'),
     subprocess.Popen('./sslEchoServer.py', stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
                      bufsize=1, cwd='tests'),

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -11,9 +11,11 @@ import platform
 (system, node, release, version, machine, processor) = platform.uname()
 
 httpsServer = ['node', 'httpsServer.js']
+sslEchoServer = ['node', 'sslEchoServer.js']
 
 if system == "Darwin":
   httpsServer = './httpsServer.py'
+  sslEchoServer = './sslEchoServer.py'
 
 # The test automation scripts to run via casperjs/slimerjs.
 automation_scripts = [
@@ -52,7 +54,7 @@ server_processes = [
     # to the tests/ subdirectory, since they load cert/key files relative to it.
     subprocess.Popen(httpsServer, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
                      bufsize=1, cwd='tests'),
-    subprocess.Popen('./sslEchoServer.py', stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+    subprocess.Popen(sslEchoServer, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
                      bufsize=1, cwd='tests'),
 ]
 

--- a/tests/sslEchoServer.js
+++ b/tests/sslEchoServer.js
@@ -1,0 +1,16 @@
+const fs  = require("fs");
+const tls = require("tls");
+
+var pem = fs.readFileSync('cert.pem');
+
+var options = {
+  key: pem,
+  cert: pem,
+  secureProtocol: 'SSLv3_method',
+};
+
+tls.createServer(options, function(socket) {
+  socket.on('data', function(data) {
+    socket.write(data);
+  });
+}).listen(54443);


### PR DESCRIPTION
The Python HTTPS server doesn't work on Fedora 22, so I've rewritten it in JS.

If it works on Travis and Mac, I'll rewrite the other SSL server as well.