### PR TITLE
Impl nextTickDuringEvents, rename setZeroTimeout

### DIFF
--- a/index.js.in
+++ b/index.js.in
@@ -55,7 +55,7 @@ var DumbPipe = {
       return;
     }
 
-    window.setZeroTimeout(this.handlePipeEvent.bind(this, event));
+    window.nextTickBeforeEvents(this.handlePipeEvent.bind(this, event));
   },
 
   handlePipeEvent: function(event) {
@@ -120,7 +120,7 @@ var DumbPipe = {
   },
 
   receiveMessage: function(pipeID, message, detail) {
-    window.setZeroTimeout(function() {
+    window.nextTickBeforeEvents(function() {
       if (!this.recipients[pipeID]) {
         console.warn("nonexistent pipe " + pipeID + " received message " + JSON.stringify(message));
         return;

--- a/jsc.ts
+++ b/jsc.ts
@@ -20,7 +20,7 @@ var CC = {};
 // but are unavailable in the shell environment.
 
 jsGlobal.window = {
-  setZeroTimeout: function(callback) {
+  nextTickBeforeEvents: function(callback) {
     callback();
   },
   addEventListener: function() {

--- a/jsshell.js
+++ b/jsshell.js
@@ -42,7 +42,7 @@ var window = {
   setTimeout: function(callback) {
     callbacks.push(callback);
   },
-  setZeroTimeout: function(callback) {
+  nextTickBeforeEvents: function(callback) {
     callbacks.push(callback);
   },
   addEventListener: function() {

--- a/jsshell.js
+++ b/jsshell.js
@@ -45,6 +45,9 @@ var window = {
   nextTickBeforeEvents: function(callback) {
     callbacks.push(callback);
   },
+  nextTickDuringEvents: function(callback) {
+    callbacks.push(callback);
+  },
   addEventListener: function() {
   },
   crypto: {

--- a/libs/contact2vcard.js
+++ b/libs/contact2vcard.js
@@ -229,7 +229,7 @@ var contact2vcard = (function() {
     function processContact(ct) {
       if (navigator.mozContact && !(ct instanceof navigator.mozContact)) {
         console.error('An instance of mozContact was expected');
-        setZeroTimeout(function() { appendVCard(''); });
+        nextTickBeforeEvents(function() { appendVCard(''); });
         return;
       }
 
@@ -257,7 +257,7 @@ var contact2vcard = (function() {
 
       // vCard standard does not accept contacts without 'n' or 'fn' fields.
       if (n === 'n:;;;;;' || !ct.name) {
-        setZeroTimeout(function() { appendVCard(''); });
+        nextTickBeforeEvents(function() { appendVCard(''); });
         return;
       }
 
@@ -324,7 +324,7 @@ var contact2vcard = (function() {
           appendVCard(joinFields(allFields));
         });
       } else {
-        setZeroTimeout(function() { appendVCard(joinFields(allFields)); });
+        nextTickBeforeEvents(function() { appendVCard(joinFields(allFields)); });
       }
     }
 

--- a/libs/fs.js
+++ b/libs/fs.js
@@ -219,7 +219,7 @@ var fs = (function() {
     // If there are no changes to sync, merely call the callback
     // (in a timeout so the callback always gets called asynchronously).
     if (this.changesToSync.size == 0) {
-      setZeroTimeout(cb);
+      nextTickBeforeEvents(cb);
       return;
     }
 
@@ -445,12 +445,12 @@ var fs = (function() {
 
     var record = store.getItem(path);
     if (record == null || record.isDir) {
-      setZeroTimeout(function() { cb(-1) });
+      nextTickBeforeEvents(function() { cb(-1) });
     } else {
       var reader = new FileReader();
       reader.addEventListener("error", function() {
         console.error("Failed to read blob data from: " + path);
-        setZeroTimeout(function() { cb(-1) });
+        nextTickBeforeEvents(function() { cb(-1) });
       });
       reader.addEventListener("load", function() {
         openedFiles.set(++lastId, {

--- a/libs/pipe.js
+++ b/libs/pipe.js
@@ -50,7 +50,7 @@ var DumbPipe = {
 
     if (!this.isRunningSendQueue) {
       this.isRunningSendQueue = true;
-      window.setZeroTimeout(this.runSendQueue.bind(this));
+      window.nextTickBeforeEvents(this.runSendQueue.bind(this));
     }
   },
 
@@ -58,7 +58,7 @@ var DumbPipe = {
     alert(JSON.stringify(this.sendQueue.shift()));
 
     if (this.sendQueue.length > 0) {
-      window.setZeroTimeout(this.runSendQueue.bind(this));
+      window.nextTickBeforeEvents(this.runSendQueue.bind(this));
     } else {
       this.isRunningSendQueue = false;
     }

--- a/midp/localmsg.js
+++ b/midp/localmsg.js
@@ -949,7 +949,7 @@ NokiaActiveStandbyLocalMsgConnection.prototype.sendMessageToServer = function(da
       var replyData = new TextEncoder().encode(encoder.getData());
       this.sendMessageToClient(replyData, 0, replyData.length);
 
-      setZeroTimeout((function() {
+      nextTickBeforeEvents((function() {
         var encoder = new DataEncoder();
 
         encoder.putStart(DataType.STRUCT, "event");

--- a/polyfill/chrome_polyfills.js
+++ b/polyfill/chrome_polyfills.js
@@ -4,7 +4,7 @@ if (config.midletClassName !== "RunTestsMIDlet" && navigator && !navigator.mozCo
   navigator.mozContacts = {
     getAll: function () {
       var req = {};
-      setZeroTimeout(function() {
+      nextTickBeforeEvents(function() {
         if (req.onsuccess) {
           req.result = null;
           req.onsuccess();

--- a/scheduler.ts
+++ b/scheduler.ts
@@ -145,7 +145,7 @@ module J2ME {
         return;
       }
       processQueueScheduled = true;
-      (<any>window).setTimeout(run);
+      (<any>window).nextTickDuringEvents(run);
     }
 
     private static updateMinVirtualRuntime() {

--- a/tests/contacts.js
+++ b/tests/contacts.js
@@ -98,7 +98,7 @@ navigator.mozContacts = {
     var contacts = fakeContacts.slice(0);
 
     req.continue = function() {
-      setZeroTimeout(function() {
+      nextTickBeforeEvents(function() {
         req.result = (contacts.length > 0) ? toMozContact(contacts.shift()) : null;
         req.onsuccess();
       });

--- a/tests/fs/fs-v1.js
+++ b/tests/fs/fs-v1.js
@@ -41,7 +41,7 @@ var fs = (function() {
   Store.prototype.getItem = function(key, cb) {
     if (this.map.has(key)) {
       var value = this.map.get(key);
-      window.setZeroTimeout(function() { cb(value) });
+      window.nextTickBeforeEvents(function() { cb(value) });
     } else {
       var transaction = this.db.transaction(Store.DBSTORENAME, "readonly");
       if (DEBUG_FS) { console.log("get " + key + " initiated"); }
@@ -94,7 +94,7 @@ var fs = (function() {
     // If there are no changes to sync, merely call the callback
     // (in a timeout so the callback always gets called asynchronously).
     if (this.changesToSync.size == 0) {
-      setZeroTimeout(cb);
+      nextTickBeforeEvents(cb);
       return;
     }
 
@@ -418,7 +418,7 @@ var fs = (function() {
     if (DEBUG_FS) { console.log("fs remove " + path); }
 
     if (openedFiles.findIndex(function(file) { return file && file.path === path; }) != -1) {
-      setZeroTimeout(function() { cb(false); });
+      nextTickBeforeEvents(function() { cb(false); });
       return;
     }
 
@@ -554,7 +554,7 @@ var fs = (function() {
     if (DEBUG_FS) { console.log("fs rename " + oldPath + " -> " + newPath); }
 
     if (openedFiles.findIndex(function(file) { return file && file.path === oldPath; }) != -1) {
-      setZeroTimeout(function() { cb(false); });
+      nextTickBeforeEvents(function() { cb(false); });
       return;
     }
 
@@ -604,7 +604,7 @@ var fs = (function() {
 
     var file = openedFiles.find(function (file) { return file && file.stat && file.path === path });
     if (file) {
-      setZeroTimeout(function() { cb(file.stat); });
+      nextTickBeforeEvents(function() { cb(file.stat); });
       return;
     }
 

--- a/tests/fs/fs-v2.js
+++ b/tests/fs/fs-v2.js
@@ -100,11 +100,11 @@ var fs = (function() {
   Store.prototype.getItem = function(key, cb) {
     if (this.map.has(key)) {
       var value = this.map.get(key);
-      window.setZeroTimeout(function() { cb(value) });
+      window.nextTickBeforeEvents(function() { cb(value) });
     } else if (this.transientPaths.has(key)) {
       var value = null;
       this.map.set(key, value);
-      window.setZeroTimeout(function() { cb(value) });
+      window.nextTickBeforeEvents(function() { cb(value) });
     } else {
       var transaction = this.db.transaction(Store.DBSTORENAME, "readonly");
       if (DEBUG_FS) { console.log("get " + key + " initiated"); }
@@ -173,7 +173,7 @@ var fs = (function() {
     // If there are no changes to sync, merely call the callback
     // (in a timeout so the callback always gets called asynchronously).
     if (this.changesToSync.size == 0) {
-      setZeroTimeout(cb);
+      nextTickBeforeEvents(cb);
       return;
     }
 
@@ -503,7 +503,7 @@ var fs = (function() {
     if (DEBUG_FS) { console.log("fs remove " + path); }
 
     if (openedFiles.findIndex(function(file) { return file && file.path === path; }) != -1) {
-      setZeroTimeout(function() { cb(false); });
+      nextTickBeforeEvents(function() { cb(false); });
       return;
     }
 
@@ -651,7 +651,7 @@ var fs = (function() {
     if (DEBUG_FS) { console.log("fs rename " + oldPath + " -> " + newPath); }
 
     if (openedFiles.findIndex(function(file) { return file && file.path === oldPath; }) != -1) {
-      setZeroTimeout(function() { cb(false); });
+      nextTickBeforeEvents(function() { cb(false); });
       return;
     }
 
@@ -695,7 +695,7 @@ var fs = (function() {
         mtime: file.record.mtime,
         size: file.record.size,
       };
-      setZeroTimeout(function() { cb(stat); });
+      nextTickBeforeEvents(function() { cb(stat); });
       return;
     }
 

--- a/tests/mozactivitymock.js
+++ b/tests/mozactivitymock.js
@@ -27,15 +27,17 @@ function MozActivity(obj) {
 
       case "webcontacts/contact":
         lastAddContactParams = obj.data.params;
+
       break;
 
       default:
         throw new Error("MozActivity with type " + obj.data.type + " not supported");
     }
 
-    setZeroTimeout((function() {
+    nextTickBeforeEvents((function() {
       this.onsuccess();
     }).bind(this));
+
   } else {
     throw new Error("MozActivity " + obj.name + " not supported");
   }

--- a/timer.js
+++ b/timer.js
@@ -33,10 +33,11 @@
       return;
     }
 
+    ev.stopPropagation();
     cbs.shift()();
   }
 
-  window.addEventListener("message", recv, false);
+  window.addEventListener("message", recv, true);
 
   window.nextTickDuringEvents = nextTickDuringEvents;
 })();

--- a/timer.js
+++ b/timer.js
@@ -3,7 +3,7 @@
 
 'use strict';
 
-// Only add setZeroTimeout to the window object, and hide everything
+// Only add nextTickBeforeEvents to the window object, and hide everything
 // else in a closure.
 (function() {
     var resolved = Promise.resolve();
@@ -11,10 +11,32 @@
     // Like setTimeout, but only takes a function argument.  There's
     // no time argument (always zero) and no arguments (you have to
     // use a closure).
-    function setZeroTimeout(fn) {
+    function nextTickBeforeEvents(fn) {
         resolved.then(fn);
     }
 
     // Add the one thing we want added to the window object.
-    window.setZeroTimeout = setZeroTimeout;
+    window.nextTickBeforeEvents = nextTickBeforeEvents;
+})();
+
+(function() {
+  var cbs = [];
+  var msg = 135921;
+
+  function nextTickDuringEvents(fn) {
+    cbs.push(fn);
+    window.postMessage(msg, window.location.origin);
+  }
+
+  function recv(ev) {
+    if (window !== ev.source || ev.data !== msg) {
+      return;
+    }
+
+    cbs.shift()();
+  }
+
+  window.addEventListener("message", recv, false);
+
+  window.nextTickDuringEvents = nextTickDuringEvents;
 })();

--- a/vm/context.ts
+++ b/vm/context.ts
@@ -18,7 +18,6 @@ module J2ME {
   import assert = Debug.assert;
   import Bytecodes = Bytecode.Bytecodes;
   declare var VM;
-  declare var setZeroTimeout;
 
   export enum WriterFlags {
     None  = 0x00,


### PR DESCRIPTION
Implement `window.nextTickDuringEvents`. This function implements a zero
timeout using `window.postMessage`, so the callbacks will be called
serially along with events during event loop processing.

Renamed `window.setZeroTimeout` to `window.nextTickBeforeEvents`. The
callbacks registered with this function are called before event
processing happens during the event loop.

The rename is because we now have two functions that accomplish a zero
timeout. They should have similar but unique/descriptive names.