### PR TITLE
Move Context-specific properties/functions into Context

### DIFF
--- a/interpreter.ts
+++ b/interpreter.ts
@@ -28,7 +28,7 @@ module J2ME {
 
   function classInitAndUnwindCheck(classInfo: ClassInfo, pc: number) {
     classInitCheck(classInfo);
-    if (U) {
+    if ($.ctx.U) {
       $.ctx.current().pc = pc;
       return;
     } 
@@ -77,7 +77,7 @@ module J2ME {
    * Debugging helper to make sure native methods were implemented correctly.
    */
   function checkReturnValue(methodInfo: MethodInfo, returnValue: any) {
-    if (U) {
+    if ($.ctx.U) {
       if (typeof returnValue !== "undefined") {
         assert(false, "Expected undefined return value during unwind, got " + returnValue + " in " + methodInfo.implKey);
       }
@@ -276,7 +276,7 @@ module J2ME {
 
               // Perform OSR, the callee reads the frame stored in |O| and updates its own state.
               returnValue = O.methodInfo.fn();
-              if (U) {
+              if (ctx.U) {
                 return;
               }
 
@@ -991,7 +991,7 @@ module J2ME {
             index = frame.read16();
             fieldInfo = mi.classInfo.constantPool.resolveField(index, true);
             classInitAndUnwindCheck(fieldInfo.classInfo, frame.pc - 3);
-            if (U) {
+            if (ctx.U) {
               return;
             }
             value = fieldInfo.getStatic();
@@ -1001,7 +1001,7 @@ module J2ME {
             index = frame.read16();
             fieldInfo = mi.classInfo.constantPool.resolveField(index, true);
             classInitAndUnwindCheck(fieldInfo.classInfo, frame.pc - 3);
-            if (U) {
+            if (ctx.U) {
               return;
             }
             fieldInfo.setStatic(stack.popKind(fieldInfo.kind));
@@ -1010,7 +1010,7 @@ module J2ME {
             index = frame.read16();
             classInfo = resolveClass(index, mi.classInfo);
             classInitAndUnwindCheck(classInfo, frame.pc - 3);
-            if (U) {
+            if (ctx.U) {
               return;
             }
             stack.push(newObject(classInfo.klass));
@@ -1042,7 +1042,7 @@ module J2ME {
           case Bytecodes.MONITORENTER:
             object = stack.pop();
             ctx.monitorEnter(object);
-            if (U === VMState.Pausing || U === VMState.Stopping) {
+            if (ctx.U === VMState.Pausing || ctx.U === VMState.Stopping) {
               return;
             }
             break;
@@ -1108,7 +1108,7 @@ module J2ME {
             if (!release) {
               checkReturnValue(calleeMethodInfo, returnValue);
             }
-            if (U) {
+            if (ctx.U) {
               return;
             }
             if (calleeMethodInfo.returnKind !== Kind.Void) {
@@ -1141,7 +1141,7 @@ module J2ME {
 
             if (isStatic) {
               classInitAndUnwindCheck(calleeMethodInfo.classInfo, lastPC);
-              if (U) {
+              if (ctx.U) {
                 return;
               }
             }
@@ -1190,7 +1190,7 @@ module J2ME {
                     : frame.local[0];
                 }
                 ctx.monitorEnter(calleeFrame.lockObject);
-                if (U === VMState.Pausing || U === VMState.Stopping) {
+                if (ctx.U === VMState.Pausing || ctx.U === VMState.Stopping) {
                   return;
                 }
               }
@@ -1236,7 +1236,7 @@ module J2ME {
               checkReturnValue(calleeMethodInfo, returnValue);
             }
 
-            if (U) {
+            if (ctx.U) {
               return;
             }
 

--- a/jit/baseline.ts
+++ b/jit/baseline.ts
@@ -334,9 +334,9 @@ module J2ME {
     static localNames = ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z"];
 
     /**
-     * Make sure that none of these shadow global names, like "U" and "O".
+     * Make sure that none of these shadow global names, like "O".
      */
-    static stackNames = ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "_O", "P", "Q", "R", "S", "T", "_U", "V", "W", "X", "Y", "Z"];
+    static stackNames = ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "_O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z"];
 
     /**
      * Indicates whether a unwind throw was emitted.
@@ -466,7 +466,7 @@ module J2ME {
         if (this.hasUnwindThrow) {
           var local = this.local.join(",");
           var stack = this.stack.join(",");
-          this.bodyEmitter.writeLn("if(U){$.T(ex,[" + local + "],[" + stack + "]," + this.lockObject + ");return;}");
+          this.bodyEmitter.writeLn("if($.ctx.U){$.T(ex,[" + local + "],[" + stack + "]," + this.lockObject + ");return;}");
         }
         this.bodyEmitter.writeLn(this.getStackName(0) + "=TE(ex);");
         this.blockStack = [this.getStackName(0)];
@@ -1096,25 +1096,25 @@ module J2ME {
           this.stack.length < 8) {
         this.flushBlockStack();
         if (<any>nextPC - <any>pc === 3) {
-          emitter.writeLn("U&&B" + this.sp + "(" + pc + ");");
+          emitter.writeLn("$.ctx.U&&B" + this.sp + "(" + pc + ");");
         } else {
-          emitter.writeLn("U&&B" + this.sp + "(" + pc + "," + nextPC + ");");
+          emitter.writeLn("$.ctx.U&&B" + this.sp + "(" + pc + "," + nextPC + ");");
         }
         this.hasUnwindThrow = true;
       } else {
         var local = this.local.join(",");
         var stack = this.blockStack.slice(0, this.sp).join(",");
-        emitter.writeLn("if(U){$.B(" + pc + "," + nextPC + ",[" + local + "],[" + stack + "]," + this.lockObject + ");return;}");
+        emitter.writeLn("if($.ctx.U){$.B(" + pc + "," + nextPC + ",[" + local + "],[" + stack + "]," + this.lockObject + ");return;}");
       }
       baselineCounter && baselineCounter.count("emitUnwind");
     }
 
     emitNoUnwindAssertion() {
-      this.blockEmitter.writeLn("if(U){J2ME.Debug.assert(false,'Unexpected unwind.');}");
+      this.blockEmitter.writeLn("if($.ctx.U){J2ME.Debug.assert(false,'Unexpected unwind.');}");
     }
 
     emitUndefinedReturnAssertion() {
-      this.blockEmitter.writeLn("if (U && re !== undefined) { J2ME.Debug.assert(false, 'Unexpected return value during unwind.'); }");
+      this.blockEmitter.writeLn("if($.ctx.U && re !== undefined) { J2ME.Debug.assert(false, 'Unexpected return value during unwind.'); }");
     }
 
     private emitMonitorEnter(emitter: Emitter, nextPC: number, object: string) {

--- a/midp/gfx.js
+++ b/midp/gfx.js
@@ -400,7 +400,7 @@ var currentlyFocusedTextEditor;
             var methodInfo = classInfo.getMethodByNameString("<init>", "(III)V", false);
             J2ME.preemptionLockLevel++;
             J2ME.getLinkedMethod(methodInfo).call(defaultFont, 0, 0, 0);
-            release || J2ME.Debug.assert(!U, "Unexpected unwind during createException.");
+            release || J2ME.Debug.assert(!$.ctx.U, "Unexpected unwind during createException.");
             J2ME.preemptionLockLevel--;
         }
         return defaultFont;

--- a/midp/gfx.js
+++ b/midp/gfx.js
@@ -114,7 +114,7 @@ var currentlyFocusedTextEditor;
             window.requestAnimationFrame(gotNewFrame);
         } else {
             ctxs.unshift($.ctx);
-            $.pause(asyncImplStringAsync);
+            $.ctx.pause(asyncImplStringAsync);
         }
     }
 

--- a/midp/midp.js
+++ b/midp/midp.js
@@ -705,7 +705,7 @@ var MIDP = (function() {
   };
 
   function exit(code) {
-    $.stop();
+    $.ctx.stop();
     DumbPipe.open("exit", null, function(message) {});
     showExitScreen();
   }

--- a/native.js
+++ b/native.js
@@ -22,7 +22,7 @@ function asyncImpl(returnKind, promise) {
     ctx.pushFrame(Frame.create(methodInfo, [exception]));
     J2ME.Scheduler.enqueue(ctx);
   });
-  $.pause(asyncImplStringAsync);
+  $.ctx.pause(asyncImplStringAsync);
 }
 
 function preemptingImpl(returnKind, returnValue) {
@@ -563,7 +563,7 @@ Native["java/lang/Thread.sleep.(J)V"] = function(delay) {
 };
 
 Native["java/lang/Thread.yield.()V"] = function() {
-    $.yield("Thread.yield");
+    $.ctx.yield("Thread.yield");
 };
 
 Native["java/lang/Thread.activeCount.()I"] = function() {

--- a/vm/context.ts
+++ b/vm/context.ts
@@ -551,7 +551,7 @@ module J2ME {
     block(obj, queue, lockLevel) {
       obj._lock[queue].push(this);
       this.lockLevel = lockLevel;
-      $.pause("block");
+      this.pause("block");
     }
 
     unblock(obj, queue, notifyAll) {
@@ -707,6 +707,27 @@ module J2ME {
       if (profiling) {
         this.methodTimeline.leave(key, MethodType[methodType]);
       }
+    }
+
+
+    yield(reason: string) {
+      unwindCount ++;
+      threadWriter && threadWriter.writeLn("yielding " + reason);
+      runtimeCounter && runtimeCounter.count("yielding " + reason);
+      this.U = VMState.Yielding;
+      profile && this.pauseMethodTimeline();
+    }
+
+    pause(reason: string) {
+      unwindCount ++;
+      threadWriter && threadWriter.writeLn("pausing " + reason);
+      runtimeCounter && runtimeCounter.count("pausing " + reason);
+      this.U = VMState.Pausing;
+      profile && this.pauseMethodTimeline();
+    }
+
+    stop() {
+      this.U = VMState.Stopping;
     }
   }
 }

--- a/vm/context.ts
+++ b/vm/context.ts
@@ -318,6 +318,11 @@ module J2ME {
     id: number;
 
     /**
+     * Are we currently unwinding the stack because of a Yield?
+     */
+    U: J2ME.VMState = J2ME.VMState.Running;
+
+    /**
      * Whether or not the context is currently paused.  The profiler uses this
      * to distinguish execution time from paused time in an async method.
      */
@@ -433,6 +438,8 @@ module J2ME {
       release || assert (Frame.isMarker(marker));
     }
 
+    // NB: This does not set this Context as the current context. This must only
+    // be called on the current context.
     executeFrame(frame: Frame) {
       var frames = this.frames;
       frames.push(Frame.Marker);
@@ -440,7 +447,7 @@ module J2ME {
 
       try {
         var returnValue = VM.execute();
-        if (U) {
+        if (this.U) {
           // Prepend all frames up until the first marker to the bailout frames.
           while (true) {
             var frame = frames.pop();
@@ -466,13 +473,13 @@ module J2ME {
       message = "" + message;
       var classInfo = CLASSES.loadAndLinkClass(className);
       classInitCheck(classInfo);
-      release || Debug.assert(!U, "Unexpected unwind during createException.");
+      release || Debug.assert(!this.U, "Unexpected unwind during createException.");
       runtimeCounter && runtimeCounter.count("createException " + className);
       var exception = new classInfo.klass();
       var methodInfo = classInfo.getMethodByNameString("<init>", "(Ljava/lang/String;)V");
       preemptionLockLevel++;
       getLinkedMethod(methodInfo).call(exception, message ? newString(message) : null);
-      release || Debug.assert(!U, "Unexpected unwind during createException.");
+      release || Debug.assert(!this.U, "Unexpected unwind during createException.");
       preemptionLockLevel--;
       return exception;
     }
@@ -511,13 +518,13 @@ module J2ME {
       profile && this.resumeMethodTimeline();
       do {
         VM.execute();
-        if (U) {
+        if (this.U) {
           if (this.bailoutFrames.length) {
             Array.prototype.push.apply(this.frames, this.bailoutFrames);
             this.bailoutFrames = [];
           }
           var frames = this.frames;
-          switch (U) {
+          switch (this.U) {
             case VMState.Yielding:
               this.resume();
               break;
@@ -528,7 +535,7 @@ module J2ME {
               this.kill();
               return;
           }
-          U = VMState.Running;
+          this.U = VMState.Running;
           this.clearCurrentContext();
           return;
         }
@@ -568,7 +575,7 @@ module J2ME {
       } else {
         while (this.lockLevel-- > 0) {
           this.monitorEnter(obj);
-          if (U === VMState.Pausing || U === VMState.Stopping) {
+          if (this.U === VMState.Pausing || this.U === VMState.Stopping) {
             return;
           }
         }

--- a/vm/jvm.ts
+++ b/vm/jvm.ts
@@ -42,7 +42,7 @@ module J2ME {
         Frame.create(isolateClassInfo.getMethodByNameString("<init>", "(Ljava/lang/String;[Ljava/lang/String;)V"),
                                        [ isolate, J2ME.newString(className.replace(/\./g, "/")), array ])
       ]);
-      release || Debug.assert(!U, "Unexpected unwind during isolate initialization.");
+      release || Debug.assert(!ctx.U, "Unexpected unwind during isolate initialization.");
     }
 
     startIsolate(isolate: Isolate) {
@@ -81,7 +81,7 @@ module J2ME {
                                [ runtime.mainThread, J2ME.newString("main") ]));
 
       ctx.start(frames);
-      release || Debug.assert(!U, "Unexpected unwind during isolate initialization.");
+      release || Debug.assert(!ctx.U, "Unexpected unwind during isolate initialization.");
     }
 
   }

--- a/vm/runtime.ts
+++ b/vm/runtime.ts
@@ -454,7 +454,7 @@ module J2ME {
         var methodInfo = runtimeKlass.classObject.klass.classInfo.getMethodByNameString("initialize", "()V");
         runtimeKlass.classObject[methodInfo.virtualName]();
         // runtimeKlass.classObject.initialize();
-        release || Debug.assert(!U, "Unexpected unwind during preInitializeClasses.");
+        release || Debug.assert(!ctx.U, "Unexpected unwind during preInitializeClasses.");
         preemptionLockLevel-- ;
       }
       ctx.clearCurrentContext();
@@ -679,7 +679,7 @@ module J2ME {
       unwindCount ++;
       threadWriter && threadWriter.writeLn("yielding " + reason);
       runtimeCounter && runtimeCounter.count("yielding " + reason);
-      U = VMState.Yielding;
+      this.ctx.U = VMState.Yielding;
       profile && $.ctx.pauseMethodTimeline();
     }
 
@@ -687,12 +687,12 @@ module J2ME {
       unwindCount ++;
       threadWriter && threadWriter.writeLn("pausing " + reason);
       runtimeCounter && runtimeCounter.count("pausing " + reason);
-      U = VMState.Pausing;
+      this.ctx.U = VMState.Pausing;
       profile && $.ctx.pauseMethodTimeline();
     }
 
     stop() {
-      U = VMState.Stopping;
+      this.ctx.U = VMState.Stopping;
     }
 
     constructor(jvm: JVM) {
@@ -1217,7 +1217,7 @@ module J2ME {
             : frame.local[0];
         }
         $.ctx.monitorEnter(frame.lockObject);
-        if (U === VMState.Pausing) {
+        if ($.ctx.U === VMState.Pausing) {
           $.ctx.pushFrame(frame);
           return;
         }
@@ -1336,7 +1336,7 @@ module J2ME {
           default:
             r = fn.apply(this, arguments);
         }
-        if (U) {
+        if ($.ctx.U) {
           release || assert(ctx.paused, "context is paused");
 
           if (methodInfo.isNative) {
@@ -2055,13 +2055,6 @@ module J2ME {
 var Runtime = J2ME.Runtime;
 
 var AOTMD = J2ME.aotMetaData;
-
-/**
- * Are we currently unwinding the stack because of a Yield? This technically
- * belonges to a context but we store it in the global object because it is
- * read very often.
- */
-var U: J2ME.VMState = J2ME.VMState.Running;
 
 // Several unwind throws for different stack heights.
 

--- a/vm/runtime.ts
+++ b/vm/runtime.ts
@@ -675,26 +675,6 @@ module J2ME {
       $.ctx.bailout(methodInfo, location.getPC(), location.getNextPC(), local, stack.slice(0, location.getSP()), lockObject);
     }
 
-    yield(reason: string) {
-      unwindCount ++;
-      threadWriter && threadWriter.writeLn("yielding " + reason);
-      runtimeCounter && runtimeCounter.count("yielding " + reason);
-      this.ctx.U = VMState.Yielding;
-      profile && $.ctx.pauseMethodTimeline();
-    }
-
-    pause(reason: string) {
-      unwindCount ++;
-      threadWriter && threadWriter.writeLn("pausing " + reason);
-      runtimeCounter && runtimeCounter.count("pausing " + reason);
-      this.ctx.U = VMState.Pausing;
-      profile && $.ctx.pauseMethodTimeline();
-    }
-
-    stop() {
-      this.ctx.U = VMState.Stopping;
-    }
-
     constructor(jvm: JVM) {
       super(jvm);
       this.id = Runtime._nextId ++;
@@ -1977,7 +1957,7 @@ module J2ME {
 
   export function preempt() {
     if (Scheduler.shouldPreempt()) {
-      $.yield("preemption");
+      $.ctx.yield("preemption");
     }
   }
 


### PR DESCRIPTION
The global `U` and the `yield`, `pause`, and `stop` functions all belong in the `Context` class. This change makes other changes easier to write.