### PR TITLE
pass objects/arrays to natives as addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ We use `Native` object in JS to handle creation and registration of `native` fun
 
 e.g.:
 
-    Native["java/lang/System.arraycopy.(Ljava/lang/Object;ILjava/lang/Object;II)V" = function(addr, src, srcOffset, dst, dstOffset, length) {...};
+    Native["java/lang/System.arraycopy.(Ljava/lang/Object;ILjava/lang/Object;II)V" = function(addr, srcAddr, srcOffset, dstAddr, dstOffset, length) {...};
 
 The first parameter of every native, *addr*, is the address in memory of the object on which the native is being called. If the native is static, then the value of *addr* is `Constants.NULL`. Call `getHandle(addr)` to get a handle to a JavaScript object that wraps the Java object with getters/setters for its fields.
 

--- a/int.ts
+++ b/int.ts
@@ -36,7 +36,7 @@ module J2ME {
       return "[" + getObjectInfo(o) + "] " + o.runtimeKlass.templateKlass.classInfo.getClassNameSlow();
     }
     if (o && o.klass === Klasses.java.lang.String) {
-      return "[" + getObjectInfo(o) + "] \"" + fromJavaString(o) + "\"";
+      return "[" + getObjectInfo(o) + "] \"" + fromStringAddr(o._address) + "\"";
     }
     return o ? ("[" + getObjectInfo(o) + "]") : "null";
   }
@@ -1791,7 +1791,7 @@ module J2ME {
                         if (address === Constants.NULL) {
                           args.unshift(null);
                         } else {
-                          args.unshift(getHandle(address));
+                          args.unshift(address);
                         }
                       } else {
                         args.unshift(address);

--- a/midp/background.js
+++ b/midp/background.js
@@ -67,8 +67,9 @@ Native["com/nokia/mid/s40/bg/BGUtils.getFGMIDletNumber.()I"] = function(addr) {
 
 MIDP.additionalProperties = {};
 
-Native["com/nokia/mid/s40/bg/BGUtils.launchIEMIDlet.(Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;)Z"] = function(addr, midletSuiteVendor, midletName, midletNumber, startupNoteText, args) {
-  J2ME.fromJavaString(args).split(";").splice(1).forEach(function(arg) {
+Native["com/nokia/mid/s40/bg/BGUtils.launchIEMIDlet.(Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;)Z"] =
+function(addr, midletSuiteVendorAddr, midletNameAddr, midletNumber, startupNoteTextAddr, argsAddr) {
+  J2ME.fromStringAddr(argsAddr).split(";").splice(1).forEach(function(arg) {
     var elems = arg.split("=");
     MIDP.additionalProperties[elems[0]] = elems[1];
   });

--- a/midp/codec.js
+++ b/midp/codec.js
@@ -139,30 +139,30 @@ Native["com/nokia/mid/s40/codec/DataEncoder.init.()V"] = function(addr) {
   NativeMap.set(addr, new DataEncoder());
 };
 
-Native["com/nokia/mid/s40/codec/DataEncoder.putStart.(ILjava/lang/String;)V"] = function(addr, tag, name) {
-  NativeMap.get(addr).putStart(tag, J2ME.fromJavaString(name));
+Native["com/nokia/mid/s40/codec/DataEncoder.putStart.(ILjava/lang/String;)V"] = function(addr, tag, nameAddr) {
+  NativeMap.get(addr).putStart(tag, J2ME.fromStringAddr(nameAddr));
 };
 
-Native["com/nokia/mid/s40/codec/DataEncoder.put.(ILjava/lang/String;Ljava/lang/String;)V"] = function(addr, tag, name, value) {
-  NativeMap.get(addr).put(tag, J2ME.fromJavaString(name), J2ME.fromJavaString(value));
+Native["com/nokia/mid/s40/codec/DataEncoder.put.(ILjava/lang/String;Ljava/lang/String;)V"] = function(addr, tag, nameAddr, valueAddr) {
+  NativeMap.get(addr).put(tag, J2ME.fromStringAddr(nameAddr), J2ME.fromStringAddr(valueAddr));
 };
 
-Native["com/nokia/mid/s40/codec/DataEncoder.put.(ILjava/lang/String;J)V"] = function(addr, tag, name, valueLow, valueHigh) {
-  NativeMap.get(addr).put(tag, J2ME.fromJavaString(name), J2ME.longToNumber(valueLow, valueHigh));
+Native["com/nokia/mid/s40/codec/DataEncoder.put.(ILjava/lang/String;J)V"] = function(addr, tag, nameAddr, valueLow, valueHigh) {
+  NativeMap.get(addr).put(tag, J2ME.fromStringAddr(nameAddr), J2ME.longToNumber(valueLow, valueHigh));
 };
 
-Native["com/nokia/mid/s40/codec/DataEncoder.put.(ILjava/lang/String;Z)V"] = function(addr, tag, name, value) {
-  NativeMap.get(addr).put(tag, J2ME.fromJavaString(name), value);
+Native["com/nokia/mid/s40/codec/DataEncoder.put.(ILjava/lang/String;Z)V"] = function(addr, tag, nameAddr, value) {
+  NativeMap.get(addr).put(tag, J2ME.fromStringAddr(nameAddr), value);
 };
 
-Native["com/nokia/mid/s40/codec/DataEncoder.put.(Ljava/lang/String;[BI)V"] = function(addr, name, data, length) {
-  var array = Array.prototype.slice.call(data.subarray(0, length));
+Native["com/nokia/mid/s40/codec/DataEncoder.put.(Ljava/lang/String;[BI)V"] = function(addr, nameAddr, dataAddr, length) {
+  var array = Array.prototype.slice.call(J2ME.getArrayFromAddr(dataAddr).subarray(0, length));
   array.constructor = Array;
-  NativeMap.get(addr).putNoTag(J2ME.fromJavaString(name), array);
+  NativeMap.get(addr).putNoTag(J2ME.fromStringAddr(nameAddr), array);
 };
 
-Native["com/nokia/mid/s40/codec/DataEncoder.putEnd.(ILjava/lang/String;)V"] = function(addr, tag, name) {
-  NativeMap.get(addr).putEnd(tag, J2ME.fromJavaString(name));
+Native["com/nokia/mid/s40/codec/DataEncoder.putEnd.(ILjava/lang/String;)V"] = function(addr, tag, nameAddr) {
+  NativeMap.get(addr).putEnd(tag, J2ME.fromStringAddr(nameAddr));
 };
 
 Native["com/nokia/mid/s40/codec/DataEncoder.getData.()[B"] = function(addr) {
@@ -177,8 +177,8 @@ Native["com/nokia/mid/s40/codec/DataEncoder.getData.()[B"] = function(addr) {
   return arrayAddr;
 };
 
-Native["com/nokia/mid/s40/codec/DataDecoder.init.([BII)V"] = function(addr, data, offset, length) {
-  NativeMap.set(addr, new DataDecoder(data, offset, length));
+Native["com/nokia/mid/s40/codec/DataDecoder.init.([BII)V"] = function(addr, dataAddr, offset, length) {
+  NativeMap.set(addr, new DataDecoder(J2ME.getArrayFromAddr(dataAddr), offset, length));
 };
 
 Native["com/nokia/mid/s40/codec/DataDecoder.getStart.(I)V"] = function(addr, tag) {

--- a/midp/content.js
+++ b/midp/content.js
@@ -36,13 +36,15 @@ var Content = (function() {
 
   addUnimplementedNative("com/sun/j2me/content/RegistryStore.findHandler0.(Ljava/lang/String;ILjava/lang/String;)Ljava/lang/String;", J2ME.Constants.NULL);
 
-  Native["com/sun/j2me/content/RegistryStore.register0.(ILjava/lang/String;Lcom/sun/j2me/content/ContentHandlerRegData;)Z"] = function(addr, storageId, className, handlerData) {
-    var registerID = J2ME.fromJavaString(getHandle(handlerData.ID));
+  Native["com/sun/j2me/content/RegistryStore.register0.(ILjava/lang/String;Lcom/sun/j2me/content/ContentHandlerRegData;)Z"] =
+  function(addr, storageId, classNameAddr, handlerDataAddr) {
+    var handlerData = getHandle(handlerDataAddr);
+    var registerID = J2ME.fromStringAddr(handlerData.ID);
     if (chRegisteredID && chRegisteredID != registerID) {
       console.warn("Dynamic registration ID doesn't match the configuration");
     }
 
-    var registerClassName = J2ME.fromJavaString(className);
+    var registerClassName = J2ME.fromStringAddr(classNameAddr);
     if (chRegisteredClassName && chRegisteredClassName != registerClassName) {
       console.warn("Dynamic registration class name doesn't match the configuration");
     }
@@ -69,7 +71,8 @@ var Content = (function() {
   // registered and unregisters it.
   addUnimplementedNative("com/sun/j2me/content/RegistryStore.unregister0.(Ljava/lang/String;)Z", 1);
 
-  Native["com/sun/j2me/content/RegistryStore.getHandler0.(Ljava/lang/String;Ljava/lang/String;I)Ljava/lang/String;"] = function(addr, callerId, id, mode) {
+  Native["com/sun/j2me/content/RegistryStore.getHandler0.(Ljava/lang/String;Ljava/lang/String;I)Ljava/lang/String;"] =
+  function(addr, callerIdAddr, idAddr, mode) {
     if (!chRegisteredClassName) {
       return J2ME.Constants.NULL;
     }
@@ -78,8 +81,8 @@ var Content = (function() {
       console.warn("com/sun/j2me/content/RegistryStore.getHandler0.(Ljava/lang/String;Ljava/lang/String;I)Ljava/lang/String; expected mode = 0");
     }
 
-    if (callerId) {
-      console.warn("com/sun/j2me/content/RegistryStore.getHandler0.(Ljava/lang/String;Ljava/lang/String;I)Ljava/lang/String; expected callerId = null");
+    if (callerIdAddr) {
+      console.warn("com/sun/j2me/content/RegistryStore.getHandler0.(Ljava/lang/String;Ljava/lang/String;I)Ljava/lang/String; expected callerIdAddr = null");
     }
 
     return J2ME.newString(serializeString([
@@ -127,7 +130,10 @@ var Content = (function() {
     }
   });
 
-  Native["com/sun/j2me/content/InvocationStore.get0.(Lcom/sun/j2me/content/InvocationImpl;ILjava/lang/String;IZ)I"] = function(addr, invoc, suiteId, className, mode, shouldBlock) {
+  Native["com/sun/j2me/content/InvocationStore.get0.(Lcom/sun/j2me/content/InvocationImpl;ILjava/lang/String;IZ)I"] =
+  function(addr, invocAddr, suiteId, classNameAddr, mode, shouldBlock) {
+    var invoc = getHandle(invocAddr);
+
     getInvocationCalled = true;
 
     if (!invocation) {

--- a/midp/content.js
+++ b/midp/content.js
@@ -81,7 +81,7 @@ var Content = (function() {
       console.warn("com/sun/j2me/content/RegistryStore.getHandler0.(Ljava/lang/String;Ljava/lang/String;I)Ljava/lang/String; expected mode = 0");
     }
 
-    if (callerIdAddr) {
+    if (callerIdAddr !== J2ME.Constants.NULL) {
       console.warn("com/sun/j2me/content/RegistryStore.getHandler0.(Ljava/lang/String;Ljava/lang/String;I)Ljava/lang/String; expected callerIdAddr = null");
     }
 

--- a/midp/crypto.js
+++ b/midp/crypto.js
@@ -3,8 +3,8 @@
 
 'use strict';
 
-Native["com/sun/midp/crypto/PRand.getRandomBytes.([BI)Z"] = function(addr, b, nbytes) {
-    window.crypto.getRandomValues(b.subarray(0, nbytes));
+Native["com/sun/midp/crypto/PRand.getRandomBytes.([BI)Z"] = function(addr, bAddr, nbytes) {
+    window.crypto.getRandomValues(J2ME.getArrayFromAddr(bAddr).subarray(0, nbytes));
     return 1;
 };
 
@@ -38,17 +38,25 @@ MIDP.bin2String = function(array) {
   return bin2StringResult.join("");
 };
 
-Native["com/sun/midp/crypto/MD5.nativeUpdate.([BII[I[I[I[I)V"] = function(addr, inBuf, inOff, inLen, state, num, count, data) {
+Native["com/sun/midp/crypto/MD5.nativeUpdate.([BII[I[I[I[I)V"] =
+function(addr, inBufAddr, inOff, inLen, stateAddr, numAddr, countAddr, dataAddr) {
+    var inBuf = J2ME.getArrayFromAddr(inBufAddr);
+    var data = J2ME.getArrayFromAddr(dataAddr);
     MIDP.getMD5Hasher(data).update(MIDP.bin2String(new Int8Array(inBuf.subarray(inOff, inOff + inLen))));
 };
 
-Native["com/sun/midp/crypto/MD5.nativeFinal.([BII[BI[I[I[I[I)V"] = function(addr, inBuf, inOff, inLen, outBuf, outOff, state, num, count, data) {
+Native["com/sun/midp/crypto/MD5.nativeFinal.([BII[BI[I[I[I[I)V"] =
+function(addr, inBufAddr, inOff, inLen, outBufAddr, outOff, stateAddr, numAddr, countAddr, dataAddr) {
+    var inBuf;
+    var outBuf = J2ME.getArrayFromAddr(outBufAddr);
+    var data = J2ME.getArrayFromAddr(dataAddr);
     var hasher = MIDP.getMD5Hasher(data);
 
-    if (inBuf) {
+    if (inBufAddr) {
         // digest passes `null` for inBuf, and there are no other callers,
         // so this should never happen; but I'm including it for completeness
         // (and in case a subclass ever uses it).
+        inBuf = J2ME.getArrayFromAddr(inBufAddr);
         hasher.update(MIDP.bin2String(inBuf.subarray(inOff, inOff + inLen)));
     }
 
@@ -64,7 +72,8 @@ Native["com/sun/midp/crypto/MD5.nativeFinal.([BII[BI[I[I[I[I)V"] = function(addr
     MIDP.hashers.delete(data);
 };
 
-Native["com/sun/midp/crypto/MD5.nativeClone.([I)V"] = function(addr, data) {
+Native["com/sun/midp/crypto/MD5.nativeClone.([I)V"] = function(addr, dataAddr) {
+    var data = J2ME.getArrayFromAddr(dataAddr);
     for (var key of MIDP.hashers.keys()) {
         if (util.compareTypedArrays(key, data)) {
             var value = MIDP.hashers.get(key);
@@ -107,10 +116,15 @@ function hexStringToBytes(hex) {
     return bytes;
 }
 
-Native["com/sun/midp/crypto/RSA.modExp.([B[B[B[B)I"] = function(addr, data, exponent, modulus, result) {
+Native["com/sun/midp/crypto/RSA.modExp.([B[B[B[B)I"] = function(addr, dataAddr, exponentAddr, modulusAddr, resultAddr) {
     // The jsbn library doesn't work well with typed arrays, so we're using this
     // hack of translating the numbers to hexadecimal strings before handing
     // them to jsbn (and we're getting the result back in a hex string).
+
+    var data = J2ME.getArrayFromAddr(dataAddr);
+    var exponent = J2ME.getArrayFromAddr(exponentAddr);
+    var modulus = J2ME.getArrayFromAddr(modulusAddr);
+    var result = J2ME.getArrayFromAddr(resultAddr);
 
     var bnBase = new BigInteger(bytesToHexString(data), 16);
     var bnExponent = new BigInteger(bytesToHexString(exponent), 16);
@@ -122,7 +136,14 @@ Native["com/sun/midp/crypto/RSA.modExp.([B[B[B[B)I"] = function(addr, data, expo
     return remainder.length;
 };
 
-Native["com/sun/midp/crypto/ARC4.nativetx.([B[I[I[BII[BI)V"] = function(addr, S, X, Y, inbuf, inoff, inlen, outbuf, outoff) {
+Native["com/sun/midp/crypto/ARC4.nativetx.([B[I[I[BII[BI)V"] =
+function(addr, SAddr, XAddr, YAddr, inbufAddr, inoff, inlen, outbufAddr, outoff) {
+    var S = J2ME.getArrayFromAddr(SAddr);
+    var X = J2ME.getArrayFromAddr(XAddr);
+    var Y = J2ME.getArrayFromAddr(YAddr);
+    var inbuf = J2ME.getArrayFromAddr(inbufAddr);
+    var outbuf = J2ME.getArrayFromAddr(outbufAddr);
+
     var x = X[0];
     var y = Y[0];
 

--- a/midp/crypto.js
+++ b/midp/crypto.js
@@ -52,7 +52,7 @@ function(addr, inBufAddr, inOff, inLen, outBufAddr, outOff, stateAddr, numAddr, 
     var data = J2ME.getArrayFromAddr(dataAddr);
     var hasher = MIDP.getMD5Hasher(data);
 
-    if (inBufAddr) {
+    if (inBufAddr !== J2ME.Constants.NULL) {
         // digest passes `null` for inBuf, and there are no other callers,
         // so this should never happen; but I'm including it for completeness
         // (and in case a subclass ever uses it).

--- a/midp/frameanimator.js
+++ b/midp/frameanimator.js
@@ -44,7 +44,7 @@ function(addr, x, y, maxFps, maxPps, listenerAddr) {
     throw $.newIllegalStateException("FrameAnimator already registered");
   }
 
-  if (!listenerAddr) {
+  if (listenerAddr === J2ME.Constants.NULL) {
     throw $.newNullPointerException("listener is null");
   }
 

--- a/midp/frameanimator.js
+++ b/midp/frameanimator.js
@@ -37,13 +37,14 @@ Native["com/nokia/mid/ui/frameanimator/FrameAnimator.init.()V"] = function(addr)
   NativeMap.set(addr, new FrameAnimator());
 };
 
-Native["com/nokia/mid/ui/frameanimator/FrameAnimator.register.(IISSLcom/nokia/mid/ui/frameanimator/FrameAnimatorListener;)Z"] = function(addr, x, y, maxFps, maxPps, listener) {
+Native["com/nokia/mid/ui/frameanimator/FrameAnimator.register.(IISSLcom/nokia/mid/ui/frameanimator/FrameAnimatorListener;)Z"] =
+function(addr, x, y, maxFps, maxPps, listenerAddr) {
   var nativeObject = NativeMap.get(addr);
   if (nativeObject.isRegistered()) {
     throw $.newIllegalStateException("FrameAnimator already registered");
   }
 
-  if (!listener) {
+  if (!listenerAddr) {
     throw $.newNullPointerException("listener is null");
   }
 
@@ -53,6 +54,7 @@ Native["com/nokia/mid/ui/frameanimator/FrameAnimator.register.(IISSLcom/nokia/mi
 
   // XXX return false if FrameAnimator.numRegistered >= FRAME_ANIMATOR_MAX_CONCURRENT
 
+  var listener = getHandle(listenerAddr);
   nativeObject.register(x, y, maxFps, maxPps, listener);
   return 1;
 };

--- a/midp/fs.js
+++ b/midp/fs.js
@@ -35,33 +35,36 @@ Native["com/sun/midp/midletsuite/MIDletSuiteStorage.getSecureFilenameBase.(I)Lja
 };
 
 Native["com/sun/midp/rms/RecordStoreUtil.exists.(Ljava/lang/String;Ljava/lang/String;I)Z"] =
-function(addr, filenameBase, name, ext) {
-    var path = RECORD_STORE_BASE + "/" + J2ME.fromJavaString(filenameBase) + "/" + J2ME.fromJavaString(name) + "." + ext;
+function(addr, filenameBaseAddr, nameAddr, ext) {
+    var path = RECORD_STORE_BASE + "/" + J2ME.fromStringAddr(filenameBaseAddr) +
+               "/" + J2ME.fromStringAddr(nameAddr) + "." + ext;
     return fs.exists(path) ? 1 : 0;
 };
 
 Native["com/sun/midp/rms/RecordStoreUtil.deleteFile.(Ljava/lang/String;Ljava/lang/String;I)V"] =
-function(addr, filenameBase, name, ext) {
-    var path = RECORD_STORE_BASE + "/" + J2ME.fromJavaString(filenameBase) + "/" + J2ME.fromJavaString(name) + "." + ext;
+function(addr, filenameBaseAddr, nameAddr, ext) {
+    var path = RECORD_STORE_BASE + "/" + J2ME.fromStringAddr(filenameBaseAddr) +
+               "/" + J2ME.fromStringAddr(nameAddr) + "." + ext;
     fs.remove(path);
 };
 
-Native["com/sun/midp/rms/RecordStoreFile.getNumberOfStores.(Ljava/lang/String;)I"] =
-function(addr, filenameBase) {
-    var path = RECORD_STORE_BASE + "/" + J2ME.fromJavaString(filenameBase);
+Native["com/sun/midp/rms/RecordStoreFile.getNumberOfStores.(Ljava/lang/String;)I"] = function(addr, filenameBaseAddr) {
+    var path = RECORD_STORE_BASE + "/" + J2ME.fromStringAddr(filenameBaseAddr);
     return fs.list(path).length;
 };
 
 Native["com/sun/midp/rms/RecordStoreFile.getRecordStoreList.(Ljava/lang/String;[Ljava/lang/String;)V"] =
-function(addr, filenameBase, names) {
-    var path = RECORD_STORE_BASE + "/" + J2ME.fromJavaString(filenameBase);
+function(addr, filenameBaseAddr, namesAddr) {
+    var names = J2ME.getArrayFromAddr(namesAddr);
+    var path = RECORD_STORE_BASE + "/" + J2ME.fromStringAddr(filenameBaseAddr);
     var files = fs.list(path);
     for (var i = 0; i < files.length; i++) {
         names[i] = J2ME.newString(files[i]);
     }
 };
 
-Native["com/sun/midp/rms/RecordStoreFile.spaceAvailableNewRecordStore0.(Ljava/lang/String;I)I"] = function(addr, filenameBase, storageId) {
+Native["com/sun/midp/rms/RecordStoreFile.spaceAvailableNewRecordStore0.(Ljava/lang/String;I)I"] =
+function(addr, filenameBaseAddr, storageId) {
     // Pretend there is 50MiB available.  Our implementation is backed
     // by IndexedDB, which has no actual limit beyond space available on device,
     // which I don't think we can determine.  But this should be sufficient
@@ -69,7 +72,8 @@ Native["com/sun/midp/rms/RecordStoreFile.spaceAvailableNewRecordStore0.(Ljava/la
     return 50 * 1024 * 1024;
 };
 
-Native["com/sun/midp/rms/RecordStoreFile.spaceAvailableRecordStore.(ILjava/lang/String;I)I"] = function(addr, handle, filenameBase, storageId) {
+Native["com/sun/midp/rms/RecordStoreFile.spaceAvailableRecordStore.(ILjava/lang/String;I)I"] =
+function(addr, handle, filenameBaseAddr, storageId) {
     // Pretend there is 50MiB available.  Our implementation is backed
     // by IndexedDB, which has no actual limit beyond space available on device,
     // which I don't think we can determine.  But this should be sufficient
@@ -78,10 +82,11 @@ Native["com/sun/midp/rms/RecordStoreFile.spaceAvailableRecordStore.(ILjava/lang/
 };
 
 Native["com/sun/midp/rms/RecordStoreFile.openRecordStoreFile.(Ljava/lang/String;Ljava/lang/String;I)I"] =
-function(addr, filenameBase, name, ext) {
+function(addr, filenameBaseAddr, nameAddr, ext) {
     var ctx = $.ctx;
 
-    var path = RECORD_STORE_BASE + "/" + J2ME.fromJavaString(filenameBase) + "/" + J2ME.fromJavaString(name) + "." + ext;
+    var path = RECORD_STORE_BASE + "/" + J2ME.fromStringAddr(filenameBaseAddr) +
+               "/" + J2ME.fromStringAddr(nameAddr) + "." + ext;
 
     function open() {
         asyncImpl("I", new Promise(function(resolve, reject) {
@@ -117,7 +122,8 @@ Native["com/sun/midp/rms/RecordStoreFile.setPosition.(II)V"] = function(addr, ha
     fs.setpos(handle, pos);
 };
 
-Native["com/sun/midp/rms/RecordStoreFile.readBytes.(I[BII)I"] = function(addr, handle, buf, offset, numBytes) {
+Native["com/sun/midp/rms/RecordStoreFile.readBytes.(I[BII)I"] = function(addr, handle, bufAddr, offset, numBytes) {
+    var buf = J2ME.getArrayFromAddr(bufAddr);
     var from = fs.getpos(handle);
     var to = from + numBytes;
     var readBytes = fs.read(handle, from, to);
@@ -133,7 +139,8 @@ Native["com/sun/midp/rms/RecordStoreFile.readBytes.(I[BII)I"] = function(addr, h
     return readBytes.byteLength;
 };
 
-Native["com/sun/midp/rms/RecordStoreFile.writeBytes.(I[BII)V"] = function(addr, handle, buf, offset, numBytes) {
+Native["com/sun/midp/rms/RecordStoreFile.writeBytes.(I[BII)V"] = function(addr, handle, bufAddr, offset, numBytes) {
+    var buf = J2ME.getArrayFromAddr(bufAddr);
     fs.write(handle, buf, offset, numBytes);
 };
 
@@ -153,8 +160,8 @@ Native["com/sun/midp/rms/RecordStoreFile.truncateFile.(II)V"] = function(addr, h
 MIDP.RecordStoreCache = [];
 
 Native["com/sun/midp/rms/RecordStoreSharedDBHeader.getLookupId0.(ILjava/lang/String;I)I"] =
-function(addr, suiteId, jStoreName, headerDataSize) {
-    var storeName = J2ME.fromJavaString(jStoreName);
+function(addr, suiteId, storeNameAddr, headerDataSize) {
+    var storeName = J2ME.fromStringAddr(storeNameAddr);
 
     var sharedHeader =
         MIDP.RecordStoreCache.filter(function(v) { return (v && v.suiteId == suiteId && v.storeName == storeName); })[0];
@@ -176,12 +183,14 @@ function(addr, suiteId, jStoreName, headerDataSize) {
     return sharedHeader.lookupId;
 };
 
-Native["com/sun/midp/rms/RecordStoreSharedDBHeader.shareCachedData0.(I[BI)I"] = function(addr, lookupId, headerData, headerDataSize) {
+Native["com/sun/midp/rms/RecordStoreSharedDBHeader.shareCachedData0.(I[BI)I"] =
+function(addr, lookupId, headerDataAddr, headerDataSize) {
     var sharedHeader = MIDP.RecordStoreCache[lookupId];
     if (!sharedHeader) {
         throw $.newIllegalStateException("invalid header lookup ID");
     }
 
+    var headerData = J2ME.getArrayFromAddr(headerDataAddr);
     if (!headerData) {
         throw $.newIllegalArgumentException("header data is null");
     }
@@ -197,12 +206,13 @@ Native["com/sun/midp/rms/RecordStoreSharedDBHeader.shareCachedData0.(I[BI)I"] = 
 };
 
 Native["com/sun/midp/rms/RecordStoreSharedDBHeader.updateCachedData0.(I[BII)I"] =
-function(addr, lookupId, headerData, headerDataSize, headerVersion) {
+function(addr, lookupId, headerDataAddr, headerDataSize, headerVersion) {
     var sharedHeader = MIDP.RecordStoreCache[lookupId];
     if (!sharedHeader) {
         throw $.newIllegalStateException("invalid header lookup ID");
     }
 
+    var headerData = J2ME.getArrayFromAddr(headerDataAddr);
     if (!headerData) {
         throw $.newIllegalArgumentException("header data is null");
     }
@@ -247,28 +257,28 @@ Native["com/sun/midp/rms/RecordStoreSharedDBHeader.finalize.()V"] =
     Native["com/sun/midp/rms/RecordStoreSharedDBHeader.cleanup0.()V"];
 
 Native["com/sun/midp/rms/RecordStoreRegistry.getRecordStoreListeners.(ILjava/lang/String;)[I"] =
-function(addr, suiteId, storeName) {
+function(addr, suiteId, storeNameAddr) {
     console.warn("RecordStoreRegistry.getRecordStoreListeners.(IL...String;)[I not implemented (" +
-                 suiteId + ", " + J2ME.fromJavaString(storeName) + ")");
+                 suiteId + ", " + J2ME.fromStringAddr(storeNameAddr) + ")");
     return J2ME.Constants.NULL;
 };
 
 Native["com/sun/midp/rms/RecordStoreRegistry.sendRecordStoreChangeEvent.(ILjava/lang/String;II)V"] =
-function(addr, suiteId, storeName, changeType, recordId) {
+function(addr, suiteId, storeNameAddr, changeType, recordId) {
     console.warn("RecordStoreRegistry.sendRecordStoreChangeEvent.(IL...String;II)V not implemented (" +
-                 suiteId + ", " + J2ME.fromJavaString(storeName) + ", " + changeType + ", " + recordId + ")");
+                 suiteId + ", " + J2ME.fromStringAddr(storeNameAddr) + ", " + changeType + ", " + recordId + ")");
 };
 
 Native["com/sun/midp/rms/RecordStoreRegistry.startRecordStoreListening.(ILjava/lang/String;)V"] =
-function(addr, suiteId, storeName) {
+function(addr, suiteId, storeNameAddr) {
     console.warn("RecordStoreRegistry.startRecordStoreListening.(IL...String;)V not implemented (" +
-                 suiteId + ", " + J2ME.fromJavaString(storeName) + ")");
+                 suiteId + ", " + J2ME.fromStringAddr(storeNameAddr) + ")");
 };
 
 Native["com/sun/midp/rms/RecordStoreRegistry.stopRecordStoreListening.(ILjava/lang/String;)V"] =
-function(addr, suiteId, storeName) {
+function(addr, suiteId, storeNameAddr) {
     console.warn("RecordStoreRegistry.stopRecordStoreListening.(IL...String;)V not implemented (" +
-                 suiteId + ", " + J2ME.fromJavaString(storeName) + ")");
+                 suiteId + ", " + J2ME.fromStringAddr(storeNameAddr) + ")");
 };
 
 Native["com/sun/midp/rms/RecordStoreRegistry.stopAllRecordStoreListeners.(I)V"] = function(addr, taskId) {
@@ -276,7 +286,7 @@ Native["com/sun/midp/rms/RecordStoreRegistry.stopAllRecordStoreListeners.(I)V"] 
 };
 
 Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.create.()V"] = function(addr) {
-    var pathname = J2ME.fromJavaString(getHandle(getHandle(addr).nativePath));
+    var pathname = J2ME.fromStringAddr(getHandle(addr).nativePath);
     DEBUG_FS && console.log("DefaultFileHandler.create: " + pathname);
     if (config.ignoredFiles.has(pathname)) {
         DEBUG_FS && console.log("DefaultFileHandler.create: ignored file");
@@ -291,7 +301,7 @@ Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.create.()V"] = function(addr
 };
 
 Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.exists.()Z"] = function(addr) {
-    var pathname = J2ME.fromJavaString(getHandle(getHandle(addr).nativePath));
+    var pathname = J2ME.fromStringAddr(getHandle(addr).nativePath);
     DEBUG_FS && console.log("DefaultFileHandler.exists: " + pathname);
     if (config.ignoredFiles.has(pathname)) {
         DEBUG_FS && console.log("DefaultFileHandler.exists: ignored file");
@@ -304,7 +314,7 @@ Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.exists.()Z"] = function(addr
 };
 
 Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.isDirectory.()Z"] = function(addr) {
-    var pathname = J2ME.fromJavaString(getHandle(getHandle(addr).nativePath));
+    var pathname = J2ME.fromStringAddr(getHandle(addr).nativePath);
     DEBUG_FS && console.log("DefaultFileHandler.isDirectory: " + pathname);
     if (config.ignoredFiles.has(pathname)) {
         DEBUG_FS && console.log("DefaultFileHandler.isDirectory: ignored file");
@@ -318,7 +328,7 @@ Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.isDirectory.()Z"] = function
 }
 
 Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.delete.()V"] = function(addr) {
-    var pathname = J2ME.fromJavaString(getHandle(getHandle(addr).nativePath));
+    var pathname = J2ME.fromStringAddr(getHandle(addr).nativePath);
     DEBUG_FS && console.log("DefaultFileHandler.delete: " + pathname);
     if (config.ignoredFiles.has(pathname)) {
         DEBUG_FS && console.log("DefaultFileHandler.delete: ignored file");
@@ -331,9 +341,9 @@ Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.delete.()V"] = function(addr
 };
 
 
-Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.rename0.(Ljava/lang/String;)V"] = function(addr, newName) {
-    var pathname = J2ME.fromJavaString(getHandle(getHandle(addr).nativePath));
-    var newPathname = J2ME.fromJavaString(newName);
+Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.rename0.(Ljava/lang/String;)V"] = function(addr, newNameAddr) {
+    var pathname = J2ME.fromStringAddr(getHandle(addr).nativePath);
+    var newPathname = J2ME.fromStringAddr(newNameAddr);
     DEBUG_FS && console.log("DefaultFileHandler.rename0: " + pathname + " to " + newPathname);
 
     if (fs.exists(newPathname)) {
@@ -346,7 +356,7 @@ Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.rename0.(Ljava/lang/String;)
 };
 
 Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.truncate.(J)V"] = function(addr, byteOffsetL, byteOffsetH) {
-    var pathname = J2ME.fromJavaString(getHandle(getHandle(addr).nativePath));
+    var pathname = J2ME.fromStringAddr(getHandle(addr).nativePath);
     DEBUG_FS && console.log("DefaultFileHandler.lastModified: " + pathname);
     if (config.ignoredFiles.has(pathname)) {
         DEBUG_FS && console.log("DefaultFileHandler.lastModified: ignored file");
@@ -369,7 +379,7 @@ Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.truncate.(J)V"] = function(a
 };
 
 Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.fileSize.()J"] = function(addr) {
-    var pathname = J2ME.fromJavaString(getHandle(getHandle(addr).nativePath));
+    var pathname = J2ME.fromStringAddr(getHandle(addr).nativePath);
     DEBUG_FS && console.log("DefaultFileHandler.fileSize: " + pathname);
     if (config.ignoredFiles.has(pathname)) {
         DEBUG_FS && console.log("DefaultFileHandler.fileSize: ignored file");
@@ -383,7 +393,7 @@ addUnimplementedNative("com/sun/cdc/io/j2me/file/DefaultFileHandler.directorySiz
                        function() { return J2ME.returnLongValue(0) });
 
 Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.canRead.()Z"] = function(addr) {
-    var pathname = J2ME.fromJavaString(getHandle(getHandle(addr).nativePath));
+    var pathname = J2ME.fromStringAddr(getHandle(addr).nativePath);
     DEBUG_FS && console.log("DefaultFileHandler.canRead: " + pathname);
     if (config.ignoredFiles.has(pathname)) {
         DEBUG_FS && console.log("DefaultFileHandler.canRead: ignored file");
@@ -394,7 +404,7 @@ Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.canRead.()Z"] = function(add
 };
 
 Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.canWrite.()Z"] = function(addr) {
-    var pathname = J2ME.fromJavaString(getHandle(getHandle(addr).nativePath));
+    var pathname = J2ME.fromStringAddr(getHandle(addr).nativePath);
     DEBUG_FS && console.log("DefaultFileHandler.canWrite: " + pathname);
     if (config.ignoredFiles.has(pathname)) {
         DEBUG_FS && console.log("DefaultFileHandler.canWrite: ignored file");
@@ -411,7 +421,7 @@ Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.isHidden0.()Z"] = function(a
 };
 
 Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.setReadable.(Z)V"] = function(addr) {
-    var pathname = J2ME.fromJavaString(getHandle(getHandle(addr).nativePath));
+    var pathname = J2ME.fromStringAddr(getHandle(addr).nativePath);
     DEBUG_FS && console.log("DefaultFileHandler.setReadable: " + pathname);
     if (config.ignoredFiles.has(pathname)) {
         DEBUG_FS && console.log("DefaultFileHandler.setReadable: ignored file");
@@ -426,7 +436,7 @@ Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.setReadable.(Z)V"] = functio
 };
 
 Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.setWritable.(Z)V"] = function(addr) {
-    var pathname = J2ME.fromJavaString(getHandle(getHandle(addr).nativePath));
+    var pathname = J2ME.fromStringAddr(getHandle(addr).nativePath);
     DEBUG_FS && console.log("DefaultFileHandler.setWritable: " + pathname);
     if (config.ignoredFiles.has(pathname)) {
         DEBUG_FS && console.log("DefaultFileHandler.setWritable: ignored file");
@@ -443,7 +453,7 @@ Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.setWritable.(Z)V"] = functio
 addUnimplementedNative("com/sun/cdc/io/j2me/file/DefaultFileHandler.setHidden0.(Z)V");
 
 Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.mkdir.()V"] = function(addr) {
-    var pathname = J2ME.fromJavaString(getHandle(getHandle(addr).nativePath));
+    var pathname = J2ME.fromStringAddr(getHandle(addr).nativePath);
     DEBUG_FS && console.log("DefaultFileHandler.mkdir: " + pathname);
 
     if (!fs.mkdir(pathname)) {
@@ -458,7 +468,7 @@ addUnimplementedNative("com/sun/cdc/io/j2me/file/DefaultFileHandler.totalSize.()
                        function() { return J2ME.returnLongValue(1024 * 1024 * 1024) });
 
 Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.lastModified.()J"] = function(addr) {
-    var pathname = J2ME.fromJavaString(getHandle(getHandle(addr).nativePath));
+    var pathname = J2ME.fromStringAddr(getHandle(addr).nativePath);
     DEBUG_FS && console.log("DefaultFileHandler.lastModified: " + pathname);
     if (config.ignoredFiles.has(pathname)) {
         DEBUG_FS && console.log("DefaultFileHandler.lastModified: ignored file");
@@ -481,7 +491,7 @@ MIDP.markFileHandler = function(fileHandler, mode, state) {
 };
 
 MIDP.openFileHandler = function(fileHandler, mode) {
-    var pathname = J2ME.fromJavaString(getHandle(fileHandler.nativePath));
+    var pathname = J2ME.fromStringAddr(fileHandler.nativePath);
     DEBUG_FS && console.log("MIDP.openFileHandler: " + pathname + " for " + mode);
     if (config.ignoredFiles.has(pathname)) {
         DEBUG_FS && console.log("MIDP.openFileHandler: ignored file");
@@ -524,7 +534,7 @@ MIDP.openFileHandler = function(fileHandler, mode) {
 };
 
 MIDP.closeFileHandler = function(fileHandler, mode) {
-    DEBUG_FS && console.log("MIDP.closeFileHandler: " + J2ME.fromJavaString(getHandle(fileHandler.nativePath)) + " for " + mode);
+    DEBUG_FS && console.log("MIDP.closeFileHandler: " + J2ME.fromStringAddr(fileHandler.nativePath) + " for " + mode);
     if (fileHandler.nativeDescriptor === -1) {
         DEBUG_FS && console.log("MIDP.closeFileHandler: ignored file");
         return;
@@ -572,9 +582,10 @@ Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.closeForReadWrite.()V"] = fu
     MIDP.closeFileHandler(getHandle(addr), "write");
 };
 
-Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.read.([BII)I"] = function(addr, b, off, len) {
+Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.read.([BII)I"] = function(addr, bAddr, off, len) {
     var self = getHandle(addr);
-    DEBUG_FS && console.log("DefaultFileHandler.read: " + J2ME.fromJavaString(getHandle(self.nativePath)) + " " + len);
+    var b = J2ME.getArrayFromAddr(bAddr);
+    DEBUG_FS && console.log("DefaultFileHandler.read: " + J2ME.fromStringAddr(self.nativePath) + " " + len);
     if (self.nativeDescriptor === -1) {
         DEBUG_FS && console.log("DefaultFileHandler.read: ignored file");
         return -1;
@@ -599,7 +610,7 @@ Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.read.([BII)I"] = function(ad
 
 Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.skip.(J)J"] = function(addr, l, h) {
     var self = getHandle(addr);
-    DEBUG_FS && console.log("DefaultFileHandler.skip: " + J2ME.fromJavaString(getHandle(self.nativePath)));
+    DEBUG_FS && console.log("DefaultFileHandler.skip: " + J2ME.fromStringAddr(self.nativePath));
     if (self.nativeDescriptor === -1) {
         DEBUG_FS && console.log("DefaultFileHandler.skip: ignored file");
         return -1;
@@ -623,9 +634,10 @@ Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.skip.(J)J"] = function(addr,
     }
 };
 
-Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.write.([BII)I"] = function(addr, b, off, len) {
+Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.write.([BII)I"] = function(addr, bAddr, off, len) {
     var self = getHandle(addr);
-    DEBUG_FS && console.log("DefaultFileHandler.write: " + J2ME.fromJavaString(getHandle(self.nativePath)) + " " + off + "+" + len);
+    var b = J2ME.getArrayFromAddr(bAddr);
+    DEBUG_FS && console.log("DefaultFileHandler.write: " + J2ME.fromStringAddr(self.nativePath) + " " + off + "+" + len);
     if (self.nativeDescriptor === -1) {
         DEBUG_FS && console.log("DefaultFileHandler.write: ignored file");
         return preemptingImpl("I", len);
@@ -640,7 +652,7 @@ Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.write.([BII)I"] = function(a
 
 Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.positionForWrite.(J)V"] = function(addr, offsetLow, offsetHigh) {
     var self = getHandle(addr);
-    DEBUG_FS && console.log("DefaultFileHandler.positionForWrite: " + J2ME.fromJavaString(getHandle(self.nativePath)));
+    DEBUG_FS && console.log("DefaultFileHandler.positionForWrite: " + J2ME.fromStringAddr(self.nativePath));
     if (self.nativeDescriptor === -1) {
         DEBUG_FS && console.log("DefaultFileHandler.positionForWrite: ignored file");
         return;
@@ -652,7 +664,7 @@ Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.positionForWrite.(J)V"] = fu
 
 Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.flush.()V"] = function(addr) {
     var self = getHandle(addr);
-    DEBUG_FS && console.log("DefaultFileHandler.flush: " + J2ME.fromJavaString(getHandle(self.nativePath)));
+    DEBUG_FS && console.log("DefaultFileHandler.flush: " + J2ME.fromStringAddr(self.nativePath));
     if (self.nativeDescriptor === -1) {
         DEBUG_FS && console.log("DefaultFileHandler.flush: ignored file");
         return;
@@ -664,7 +676,7 @@ Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.flush.()V"] = function(addr)
 
 Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.close.()V"] = function(addr) {
     var self = getHandle(addr);
-    DEBUG_FS && console.log("DefaultFileHandler.close: " + J2ME.fromJavaString(getHandle(self.nativePath)));
+    DEBUG_FS && console.log("DefaultFileHandler.close: " + J2ME.fromStringAddr(self.nativePath));
 
     MIDP.closeFileHandler(self, "read");
     MIDP.closeFileHandler(self, "write");
@@ -684,7 +696,7 @@ MIDP.openDirHandle = 0;
 
 Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.openDir.()J"] = function(addr) {
     var self = getHandle(addr);
-    var pathname = J2ME.fromJavaString(getHandle(self.nativePath));
+    var pathname = J2ME.fromStringAddr(self.nativePath);
     DEBUG_FS && console.log("DefaultFileHandler.openDir: " + pathname);
 
     try {
@@ -716,15 +728,16 @@ Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.dirGetNextFile.(JZ)Ljava/lan
 function(addr, dirHandleLow, dirHandleHigh, includeHidden) {
     var iterator = MIDP.openDirs.get(J2ME.longToNumber(dirHandleLow, dirHandleHigh));
     var nextFile = iterator.files[++iterator.index];
-DEBUG_FS && console.log(iterator.index + " " + nextFile);
+    DEBUG_FS && console.log(iterator.index + " " + nextFile);
     return nextFile ? J2ME.newString(nextFile) : J2ME.Constants.NULL;
 };
 
 Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.getNativePathForRoot.(Ljava/lang/String;)Ljava/lang/String;"] =
-function(addr, root) {
-// XXX Ensure root is in MIDP.fsRoots?
-DEBUG_FS && console.log("getNativePathForRoot: " + J2ME.fromJavaString(root));
-    var nativePath = J2ME.newString("/" + J2ME.fromJavaString(root));
+function(addr, rootAddr) {
+    var root = J2ME.fromStringAddr(rootAddr);
+    // XXX Ensure root is in MIDP.fsRoots?
+    DEBUG_FS && console.log("getNativePathForRoot: " + root);
+    var nativePath = J2ME.newString("/" + root);
     return nativePath;
 };
 
@@ -748,12 +761,13 @@ Native["com/sun/cdc/io/j2me/file/Protocol.available.()I"] = function(addr) {
     var fileHandler = getHandle(self.fileHandler);
     var fd = fileHandler.nativeDescriptor;
     var available = fs.getsize(fd) - fs.getpos(fd);
-    DEBUG_FS && console.log("Protocol.available: " + J2ME.fromJavaString(fileHandler.nativePath) + ": " + available);
+    DEBUG_FS && console.log("Protocol.available: " + J2ME.fromStringAddr(fileHandler.nativePath) + ": " + available);
     return available;
 };
 
-Native["com/sun/midp/io/j2me/storage/RandomAccessStream.open.(Ljava/lang/String;I)I"] = function(addr, fileName, mode) {
-    var path = "/" + J2ME.fromJavaString(fileName);
+Native["com/sun/midp/io/j2me/storage/RandomAccessStream.open.(Ljava/lang/String;I)I"] =
+function(addr, fileNameAddr, mode) {
+    var path = "/" + J2ME.fromStringAddr(fileNameAddr);
 
     var ctx = $.ctx;
 
@@ -782,7 +796,8 @@ Native["com/sun/midp/io/j2me/storage/RandomAccessStream.open.(Ljava/lang/String;
 };
 
 Native["com/sun/midp/io/j2me/storage/RandomAccessStream.read.(I[BII)I"] =
-function(addr, handle, buffer, offset, length) {
+function(addr, handle, bufferAddr, offset, length) {
+    var buffer = J2ME.getArrayFromAddr(bufferAddr);
     var from = fs.getpos(handle);
     var to = from + length;
     var readBytes = fs.read(handle, from, to);
@@ -799,7 +814,8 @@ function(addr, handle, buffer, offset, length) {
 };
 
 Native["com/sun/midp/io/j2me/storage/RandomAccessStream.write.(I[BII)V"] =
-function(addr, handle, buffer, offset, length) {
+function(addr, handle, bufferAddr, offset, length) {
+    var buffer = J2ME.getArrayFromAddr(bufferAddr);
     fs.write(handle, buffer, offset, length);
 };
 

--- a/midp/gfx.js
+++ b/midp/gfx.js
@@ -587,10 +587,12 @@ var currentlyFocusedTextEditor;
         return self.creator;
     };
 
-    Native["javax/microedition/lcdui/Graphics.setCreator.(Ljava/lang/Object;)V"] = function(addr, creator) {
+    Native["javax/microedition/lcdui/Graphics.setCreator.(Ljava/lang/Object;)V"] = function(addr, creatorAddr) {
         var self = getHandle(addr);
-        if (!self.creator) {
-            self.creator = creator;
+        // Per the original, non-native implementation of this method,
+        // ignore repeated attempts to set creator.
+        if (self.creator === J2ME.Constants.NULL) {
+            self.creator = creatorAddr;
         }
     };
 
@@ -957,7 +959,7 @@ var currentlyFocusedTextEditor;
         var self = getHandle(addr);
         self.displayId = displayId;
         NativeMap.set(addr, new GraphicsInfo(screenContextInfo));
-        self.creator = null;
+        self.creator = J2ME.Constants.NULL;
     };
 
     Native["javax/microedition/lcdui/Graphics.initImage0.(Ljavax/microedition/lcdui/Image;)V"] =
@@ -966,7 +968,7 @@ var currentlyFocusedTextEditor;
         var img = getHandle(imgAddr);
         self.displayId = -1;
         NativeMap.set(addr, new GraphicsInfo(getNative(getHandle(img.imageData))));
-        self.creator = null;
+        self.creator = J2ME.Constants.NULL;
     };
 
     function isScreenGraphics(g) {

--- a/midp/gfx.js
+++ b/midp/gfx.js
@@ -245,7 +245,9 @@ var currentlyFocusedTextEditor;
     }
 
     Native["javax/microedition/lcdui/ImageDataFactory.createImmutableImageDecodeImage.(Ljavax/microedition/lcdui/ImageData;[BII)V"] =
-    function(addr, imageData, bytes, offset, length) {
+    function(addr, imageDataAddr, bytesAddr, offset, length) {
+        var imageData = getHandle(imageDataAddr);
+        var bytes = J2ME.getArrayFromAddr(bytesAddr);
         var ctx = $.ctx;
         asyncImpl("V", new Promise(function(resolve, reject) {
             var blob = new Blob([bytes.subarray(offset, offset + length)], { type: "image/png" });
@@ -267,27 +269,32 @@ var currentlyFocusedTextEditor;
     };
 
     Native["javax/microedition/lcdui/ImageDataFactory.createImmutableImageDataRegion.(Ljavax/microedition/lcdui/ImageData;Ljavax/microedition/lcdui/ImageData;IIIIIZ)V"] =
-    function(addr, dataDest, dataSource, x, y, width, height, transform, isMutable) {
+    function(addr, dataDestAddr, dataSourceAddr, x, y, width, height, transform, isMutable) {
+        var dataDest = getHandle(dataDestAddr);
         var context = initImageData(dataDest, width, height, isMutable);
-        renderRegion(context, getNative(dataSource).context.canvas, x, y, width, height, transform, 0, 0, TOP|LEFT);
+        renderRegion(context, NativeMap.get(dataSourceAddr).context.canvas, x, y, width, height, transform, 0, 0, TOP|LEFT);
     };
 
     Native["javax/microedition/lcdui/ImageDataFactory.createImmutableImageDataCopy.(Ljavax/microedition/lcdui/ImageData;Ljavax/microedition/lcdui/ImageData;)V"] =
-    function(addr, dest, source) {
-        var srcCanvas = getNative(source).context.canvas;
-        var context = initImageData(dest, srcCanvas.width, srcCanvas.height, 0);
-        context.drawImage(srcCanvas, 0, 0);
+    function(addr, destAddr, sourceAddr) {
+        var dest = getHandle(destAddr);
+        var sourceCanvas = NativeMap.get(sourceAddr).context.canvas;
+        var context = initImageData(dest, sourceCanvas.width, sourceCanvas.height, 0);
+        context.drawImage(sourceCanvas, 0, 0);
     };
 
     Native["javax/microedition/lcdui/ImageDataFactory.createMutableImageData.(Ljavax/microedition/lcdui/ImageData;II)V"] =
-    function(addr, imageData, width, height) {
+    function(addr, imageDataAddr, width, height) {
+        var imageData = getHandle(imageDataAddr);
         var context = initImageData(imageData, width, height, 1);
         context.fillStyle = "rgb(255,255,255)"; // white
         context.fillRect(0, 0, width, height);
     };
 
     Native["javax/microedition/lcdui/ImageDataFactory.createImmutableImageDecodeRGBImage.(Ljavax/microedition/lcdui/ImageData;[IIIZ)V"] =
-    function(addr, imageData, rgbData, width, height, processAlpha) {
+    function(addr, imageDataAddr, rgbDataAddr, width, height, processAlpha) {
+        var imageData = getHandle(imageDataAddr);
+        var rgbData = J2ME.getArrayFromAddr(rgbDataAddr);
         var context = initImageData(imageData, width, height, 0);
         var ctxImageData = context.createImageData(width, height);
         var abgrData = new Int32Array(ctxImageData.data.buffer);
@@ -301,17 +308,20 @@ var currentlyFocusedTextEditor;
         context.putImageData(ctxImageData, 0, 0);
     };
 
-    Native["javax/microedition/lcdui/ImageData.getRGB.([IIIIIII)V"] = function(addr, rgbData, offset, scanlength, x, y, width, height) {
+    Native["javax/microedition/lcdui/ImageData.getRGB.([IIIIIII)V"] =
+    function(addr, rgbDataAddr, offset, scanlength, x, y, width, height) {
+        var rgbData = J2ME.getArrayFromAddr(rgbDataAddr);
         var abgrData = new Int32Array(NativeMap.get(addr).context.getImageData(x, y, width, height).data.buffer);
         ABGRToARGB(abgrData, rgbData, width, height, offset, scanlength);
     };
 
-    Native["com/nokia/mid/ui/DirectUtils.makeMutable.(Ljavax/microedition/lcdui/Image;)V"] = function(addr, image) {
-        var imageData = getHandle(image.imageData);
+    Native["com/nokia/mid/ui/DirectUtils.makeMutable.(Ljavax/microedition/lcdui/Image;)V"] = function(addr, imageAddr) {
+        var imageData = getHandle(getHandle(imageAddr).imageData);
         imageData.isMutable = 1;
     };
 
-    Native["com/nokia/mid/ui/DirectUtils.setPixels.(Ljavax/microedition/lcdui/Image;I)V"] = function(addr, image, argb) {
+    Native["com/nokia/mid/ui/DirectUtils.setPixels.(Ljavax/microedition/lcdui/Image;I)V"] = function(addr, imageAddr, argb) {
+        var image = getHandle(imageAddr);
         var width = image.width;
         var height = image.height;
         var imageData = getHandle(image.imageData);
@@ -420,9 +430,9 @@ var currentlyFocusedTextEditor;
         return getDefaultFont()._address;
     };
 
-    Native["javax/microedition/lcdui/Font.stringWidth.(Ljava/lang/String;)I"] = function(addr, str) {
+    Native["javax/microedition/lcdui/Font.stringWidth.(Ljava/lang/String;)I"] = function(addr, strAddr) {
         var fontContext = NativeMap.get(addr);
-        return calcStringWidth(fontContext, J2ME.fromJavaString(str));
+        return calcStringWidth(fontContext, J2ME.fromStringAddr(strAddr));
     };
 
     Native["javax/microedition/lcdui/Font.charWidth.(C)I"] = function(addr, char) {
@@ -430,14 +440,15 @@ var currentlyFocusedTextEditor;
         return fontContext.measureText(String.fromCharCode(char)).width | 0;
     };
 
-    Native["javax/microedition/lcdui/Font.charsWidth.([CII)I"] = function(addr, str, offset, len) {
+    Native["javax/microedition/lcdui/Font.charsWidth.([CII)I"] = function(addr, strAddr, offset, len) {
+        var str = J2ME.getArrayFromAddr(strAddr);
         var fontContext = NativeMap.get(addr);
         return calcStringWidth(fontContext, util.fromJavaChars(str).slice(offset, offset + len));
     };
 
-    Native["javax/microedition/lcdui/Font.substringWidth.(Ljava/lang/String;II)I"] = function(addr, str, offset, len) {
+    Native["javax/microedition/lcdui/Font.substringWidth.(Ljava/lang/String;II)I"] = function(addr, strAddr, offset, len) {
         var fontContext = NativeMap.get(addr);
-        return calcStringWidth(fontContext, J2ME.fromJavaString(str).slice(offset, offset + len));
+        return calcStringWidth(fontContext, J2ME.fromStringAddr(strAddr).slice(offset, offset + len));
     };
 
     var HCENTER = 1;
@@ -691,7 +702,8 @@ var currentlyFocusedTextEditor;
         return info.clipY2 - info.clipY1;
     };
 
-    Native["javax/microedition/lcdui/Graphics.getClip.([I)V"] = function(addr, region) {
+    Native["javax/microedition/lcdui/Graphics.getClip.([I)V"] = function(addr, regionAddr) {
+        var region = J2ME.getArrayFromAddr(regionAddr);
         var info = NativeMap.get(addr);
         region[0] = info.clipX1 - info.transX;
         region[1] = info.clipY1 - info.transY;
@@ -723,8 +735,9 @@ var currentlyFocusedTextEditor;
     };
 
     Native["com/nokia/mid/ui/DirectGraphicsImp.getPixels.([SIIIIIII)V"] =
-    function(addr, pixels, offset, scanlength, x, y, width, height, format) {
+    function(addr, pixelsAddr, offset, scanlength, x, y, width, height, format) {
         var self = getHandle(addr);
+        var pixels = J2ME.getArrayFromAddr(pixelsAddr);
 
         if (!pixels) {
             throw $.newNullPointerException("Pixels array is null");
@@ -745,8 +758,9 @@ var currentlyFocusedTextEditor;
     };
 
     Native["com/nokia/mid/ui/DirectGraphicsImp.drawPixels.([SZIIIIIIII)V"] =
-    function(addr, pixels, transparency, offset, scanlength, x, y, width, height, manipulation, format) {
+    function(addr, pixelsAddr, transparency, offset, scanlength, x, y, width, height, manipulation, format) {
         var self = getHandle(addr);
+        var pixels = J2ME.getArrayFromAddr(pixelsAddr);
 
         if (!pixels) {
             throw $.newNullPointerException("Pixels array is null");
@@ -775,26 +789,32 @@ var currentlyFocusedTextEditor;
         tempContext.canvas.height = 0;
     };
 
-    Native["javax/microedition/lcdui/Graphics.render.(Ljavax/microedition/lcdui/Image;III)Z"] = function(addr, image, x, y, anchor) {
+    Native["javax/microedition/lcdui/Graphics.render.(Ljavax/microedition/lcdui/Image;III)Z"] =
+    function(addr, imageAddr, x, y, anchor) {
+        var image = getHandle(imageAddr);
         renderRegion(NativeMap.get(addr).getGraphicsContext(), getNative(getHandle(image.imageData)).context.canvas,
                      0, 0, image.width, image.height, TRANS_NONE, x, y, anchor);
         return 1;
     };
 
-    Native["javax/microedition/lcdui/Graphics.drawRegion.(Ljavax/microedition/lcdui/Image;IIIIIIII)V"] = function(addr, src, x_src, y_src, width, height, transform, x_dest, y_dest, anchor) {
-        if (null === src) {
+    Native["javax/microedition/lcdui/Graphics.drawRegion.(Ljavax/microedition/lcdui/Image;IIIIIIII)V"] =
+    function(addr, srcAddr, x_src, y_src, width, height, transform, x_dest, y_dest, anchor) {
+        if (srcAddr === null) {
             throw $.newNullPointerException("src image is null");
         }
 
+        var src = getHandle(srcAddr);
         renderRegion(NativeMap.get(addr).getGraphicsContext(), getNative(getHandle(src.imageData)).context.canvas,
                      x_src, y_src, width, height, transform, x_dest, y_dest, anchor);
     };
 
-    Native["javax/microedition/lcdui/Graphics.drawImage.(Ljavax/microedition/lcdui/Image;III)V"] = function(addr, image, x, y, anchor) {
-        if (image === null) {
+    Native["javax/microedition/lcdui/Graphics.drawImage.(Ljavax/microedition/lcdui/Image;III)V"] =
+    function(addr, imageAddr, x, y, anchor) {
+        if (imageAddr === null) {
             throw $.newNullPointerException("image is null");
         }
 
+        var image = getHandle(imageAddr);
         var imageData = getHandle(image.imageData);
         renderRegion(NativeMap.get(addr).getGraphicsContext(), getNative(imageData).context.canvas,
                      0, 0, imageData.width, imageData.height, TRANS_NONE, x, y, anchor);
@@ -940,8 +960,10 @@ var currentlyFocusedTextEditor;
         self.creator = null;
     };
 
-    Native["javax/microedition/lcdui/Graphics.initImage0.(Ljavax/microedition/lcdui/Image;)V"] = function(addr, img) {
+    Native["javax/microedition/lcdui/Graphics.initImage0.(Ljavax/microedition/lcdui/Image;)V"] =
+    function(addr, imgAddr) {
         var self = getHandle(addr);
+        var img = getHandle(imgAddr);
         self.displayId = -1;
         NativeMap.set(addr, new GraphicsInfo(getNative(getHandle(img.imageData))));
         self.creator = null;
@@ -997,16 +1019,19 @@ var currentlyFocusedTextEditor;
         }
     }
 
-    Native["javax/microedition/lcdui/Graphics.drawString.(Ljava/lang/String;III)V"] = function(addr, str, x, y, anchor) {
-        drawString(NativeMap.get(addr), J2ME.fromJavaString(str), x, y, anchor);
+    Native["javax/microedition/lcdui/Graphics.drawString.(Ljava/lang/String;III)V"] =
+    function(addr, strAddr, x, y, anchor) {
+        drawString(NativeMap.get(addr), J2ME.fromStringAddr(strAddr), x, y, anchor);
     };
 
     Native["javax/microedition/lcdui/Graphics.drawSubstring.(Ljava/lang/String;IIIII)V"] =
-    function(addr, str, offset, len, x, y, anchor) {
-        drawString(NativeMap.get(addr), J2ME.fromJavaString(str).substr(offset, len), x, y, anchor);
+    function(addr, strAddr, offset, len, x, y, anchor) {
+        drawString(NativeMap.get(addr), J2ME.fromStringAddr(strAddr).substr(offset, len), x, y, anchor);
     };
 
-    Native["javax/microedition/lcdui/Graphics.drawChars.([CIIIII)V"] = function(addr, data, offset, len, x, y, anchor) {
+    Native["javax/microedition/lcdui/Graphics.drawChars.([CIIIII)V"] =
+    function(addr, dataAddr, offset, len, x, y, anchor) {
+        var data = J2ME.getArrayFromAddr(dataAddr);
         drawString(NativeMap.get(addr), util.fromJavaChars(data, offset, len), x, y, anchor);
     };
 
@@ -1269,7 +1294,8 @@ var currentlyFocusedTextEditor;
     };
 
     Native["javax/microedition/lcdui/Graphics.drawRGB.([IIIIIIIZ)V"] =
-    function(addr, rgbData, offset, scanlength, x, y, width, height, processAlpha) {
+    function(addr, rgbDataAddr, offset, scanlength, x, y, width, height, processAlpha) {
+        var rgbData = J2ME.getArrayFromAddr(rgbDataAddr);
         tempContext.canvas.height = height;
         tempContext.canvas.width = width;
         var imageData = tempContext.createImageData(width, height);
@@ -1323,7 +1349,7 @@ var currentlyFocusedTextEditor;
     };
 
     Native["com/nokia/mid/ui/TextEditor.init.(Ljava/lang/String;IIII)V"] =
-    function(addr, text, maxSize, constraints, width, height) {
+    function(addr, textAddr, maxSize, constraints, width, height) {
         var self = getHandle(addr);
 
         if (constraints !== 0) {
@@ -1341,7 +1367,7 @@ var currentlyFocusedTextEditor;
         var font = getHandle(self.font);
         textEditor.setFont(font);
 
-        textEditor.setContent(J2ME.fromJavaString(text));
+        textEditor.setContent(J2ME.fromStringAddr(textAddr));
         setTextEditorCaretPosition(self, textEditor.getContentSize());
 
         textEditor.oninput(function(e) {
@@ -1370,8 +1396,8 @@ var currentlyFocusedTextEditor;
         }
     };
 
-    Native["javax/microedition/lcdui/Display.setTitle.(Ljava/lang/String;)V"] = function(addr, title) {
-        document.getElementById("display_title").textContent = J2ME.fromJavaString(title);
+    Native["javax/microedition/lcdui/Display.setTitle.(Ljava/lang/String;)V"] = function(addr, titleAddr) {
+        document.getElementById("display_title").textContent = J2ME.fromStringAddr(titleAddr);
     };
 
     Native["com/nokia/mid/ui/CanvasItem.setSize.(II)V"] = function(addr, width, height) {
@@ -1467,11 +1493,11 @@ var currentlyFocusedTextEditor;
         return J2ME.newString(NativeMap.get(addr).getContent());
     };
 
-    Native["com/nokia/mid/ui/TextEditor.setContent.(Ljava/lang/String;)V"] = function(addr, jStr) {
+    Native["com/nokia/mid/ui/TextEditor.setContent.(Ljava/lang/String;)V"] = function(addr, contentAddr) {
         var self = getHandle(addr);
         var nativeTextEditor = NativeMap.get(addr);
-        var str = J2ME.fromJavaString(jStr);
-        nativeTextEditor.setContent(str);
+        var content = J2ME.fromStringAddr(contentAddr);
+        nativeTextEditor.setContent(content);
         setTextEditorCaretPosition(self, nativeTextEditor.getContentSize());
     };
 
@@ -1482,15 +1508,15 @@ var currentlyFocusedTextEditor;
         return NativeMap.get(addr).getContentHeight();
     };
 
-    Native["com/nokia/mid/ui/TextEditor.insert.(Ljava/lang/String;I)V"] = function(addr, jStr, pos) {
+    Native["com/nokia/mid/ui/TextEditor.insert.(Ljava/lang/String;I)V"] = function(addr, textAddr, pos) {
         var self = getHandle(addr);
         var nativeTextEditor = NativeMap.get(addr);
-        var str = J2ME.fromJavaString(jStr);
-        var len = util.toCodePointArray(str).length;
+        var text = J2ME.fromStringAddr(textAddr);
+        var len = util.toCodePointArray(text).length;
         if (nativeTextEditor.getContentSize() + len > nativeTextEditor.getAttribute("maxlength")) {
             throw $.newIllegalArgumentException();
         }
-        nativeTextEditor.setContent(nativeTextEditor.getSlice(0, pos) + str + nativeTextEditor.getSlice(pos));
+        nativeTextEditor.setContent(nativeTextEditor.getSlice(0, pos) + text + nativeTextEditor.getSlice(pos));
         setTextEditorCaretPosition(self, pos + len);
     };
 
@@ -1537,11 +1563,11 @@ var currentlyFocusedTextEditor;
         return NativeMap.get(addr).getContentSize();
     };
 
-    Native["com/nokia/mid/ui/TextEditor.setFont.(Ljavax/microedition/lcdui/Font;)V"] = function(addr, font) {
+    Native["com/nokia/mid/ui/TextEditor.setFont.(Ljavax/microedition/lcdui/Font;)V"] = function(addr, fontAddr) {
         var self = getHandle(addr);
-        self.font = font._address;
+        self.font = fontAddr;
         var nativeTextEditor = NativeMap.get(addr);
-        nativeTextEditor.setFont(font);
+        nativeTextEditor.setFont(getHandle(fontAddr));
     };
 
     Native["com/nokia/mid/ui/TextEditorThread.getNextDirtyEditor.()Lcom/nokia/mid/ui/TextEditor;"] = function(addr) {
@@ -1575,31 +1601,34 @@ var currentlyFocusedTextEditor;
         }
     };
 
-    Native["javax/microedition/lcdui/DisplayableLFImpl.setTitle0.(ILjava/lang/String;)V"] = function(addr, nativeId, title) {
-        document.getElementById("display_title").textContent = J2ME.fromJavaString(title);
+    Native["javax/microedition/lcdui/DisplayableLFImpl.setTitle0.(ILjava/lang/String;)V"] =
+    function(addr, nativeId, titleAddr) {
+        document.getElementById("display_title").textContent = J2ME.fromStringAddr(titleAddr);
     };
 
-    Native["javax/microedition/lcdui/CanvasLFImpl.createNativeResource0.(Ljava/lang/String;Ljava/lang/String;)I"] = function(addr, title, ticker) {
+    Native["javax/microedition/lcdui/CanvasLFImpl.createNativeResource0.(Ljava/lang/String;Ljava/lang/String;)I"] =
+    function(addr, titleAddr, tickerAddr) {
         console.warn("javax/microedition/lcdui/CanvasLFImpl.createNativeResource0.(Ljava/lang/String;Ljava/lang/String;)I not implemented");
         curDisplayableId = nextMidpDisplayableId++;
         return curDisplayableId;
     };
 
-    Native["javax/microedition/lcdui/AlertLFImpl.createNativeResource0.(Ljava/lang/String;Ljava/lang/String;I)I"] = function(addr, title, ticker, type) {
+    Native["javax/microedition/lcdui/AlertLFImpl.createNativeResource0.(Ljava/lang/String;Ljava/lang/String;I)I"] =
+    function(addr, titleAddr, tickerAddr, type) {
         var nativeId = nextMidpDisplayableId++;
         var alertTemplateNode = document.getElementById("lcdui-alert");
         var el = alertTemplateNode.cloneNode(true);
         el.id = "displayable-" + nativeId;
-        el.querySelector('h1.title').textContent = J2ME.fromJavaString(title);
+        el.querySelector('h1.title').textContent = J2ME.fromStringAddr(titleAddr);
         alertTemplateNode.parentNode.appendChild(el);
 
         return nativeId;
     };
 
     Native["javax/microedition/lcdui/AlertLFImpl.setNativeContents0.(ILjavax/microedition/lcdui/ImageData;[ILjava/lang/String;)Z"] =
-    function(addr, nativeId, imgId, indicatorBounds, text) {
+    function(addr, nativeId, imgIdAddr, indicatorBoundsAddr, textAddr) {
         var el = document.getElementById("displayable-" + nativeId);
-        el.querySelector('p.text').textContent = J2ME.fromJavaString(text);
+        el.querySelector('p.text').textContent = J2ME.fromStringAddr(textAddr);
 
         return 0;
     };
@@ -1619,8 +1648,8 @@ var currentlyFocusedTextEditor;
     var CONTINUOUS_RUNNING = 2;
 
     Native["javax/microedition/lcdui/GaugeLFImpl.createNativeResource0.(ILjava/lang/String;IZII)I"] =
-    function(addr, ownerId, label, layout, interactive, maxValue, initialValue) {
-        if (label !== null) {
+    function(addr, ownerId, labelAddr, layout, interactive, maxValue, initialValue) {
+        if (labelAddr !== null) {
             console.error("Expected null label");
         }
 
@@ -1647,13 +1676,13 @@ var currentlyFocusedTextEditor;
     };
 
     Native["javax/microedition/lcdui/TextFieldLFImpl.createNativeResource0.(ILjava/lang/String;ILcom/sun/midp/lcdui/DynamicCharacterArray;ILjava/lang/String;)I"] =
-    function(addr, ownerId, label, layout, buffer, constraints, initialInputMode) {
+    function(addr, ownerId, labelAddr, layout, bufferAddr, constraints, initialInputModeAddr) {
         console.warn("javax/microedition/lcdui/TextFieldLFImpl.createNativeResource0.(ILjava/lang/String;ILcom/sun/midp/lcdui/DynamicCharacterArray;ILjava/lang/String;)I not implemented");
         return nextMidpDisplayableId++;
     };
 
     Native["javax/microedition/lcdui/ImageItemLFImpl.createNativeResource0.(ILjava/lang/String;ILjavax/microedition/lcdui/ImageData;Ljava/lang/String;I)I"] =
-    function(addr, ownerId, label, layout, imageData, altText, appearanceMode) {
+    function(addr, ownerId, labelAddr, layout, imageDataAddr, altTextAddr, appearanceMode) {
         console.warn("javax/microedition/lcdui/ImageItemLFImpl.createNativeResource0.(ILjava/lang/String;ILjavax/microedition/lcdui/ImageData;Ljava/lang/String;I)I not implemented");
         return nextMidpDisplayableId++;
     };
@@ -1702,7 +1731,7 @@ var currentlyFocusedTextEditor;
     var STOP = 6;
 
     Native["javax/microedition/lcdui/NativeMenu.updateCommands.([Ljavax/microedition/lcdui/Command;I[Ljavax/microedition/lcdui/Command;I)V"] =
-    function(addr, itemCommands, numItemCommands, commands, numCommands) {
+    function(addr, itemCommandsAddr, numItemCommands, commandsAddr, numCommands) {
         if (numItemCommands !== 0) {
             console.error("NativeMenu.updateCommands: item commands not yet supported");
         }
@@ -1713,9 +1742,11 @@ var currentlyFocusedTextEditor;
             document.getElementById("sidebar").querySelector("nav ul").innerHTML = "";
         }
 
-        if (!commands) {
+        if (!commandsAddr) {
             return;
         }
+
+        var commands = J2ME.getArrayFromAddr(commandsAddr);
 
         var validCommands = [];
 
@@ -1741,7 +1772,7 @@ var currentlyFocusedTextEditor;
             validCommands.slice(0, 2).forEach(function(command, i) {
                 var button = el.querySelector(".button" + i);
                 button.style.display = 'inline';
-                button.textContent = J2ME.fromJavaString(getHandle(command.shortLabel));
+                button.textContent = J2ME.fromStringAddr(command.shortLabel);
 
                 var commandType = command.commandType;
                 if (numCommands === 1 || commandType === OK) {
@@ -1777,7 +1808,7 @@ var currentlyFocusedTextEditor;
                     return;
                 }
                 var li = document.createElement("li");
-                var text = J2ME.fromJavaString(getHandle(command.shortLabel));
+                var text = J2ME.fromStringAddr(command.shortLabel);
                 var a = document.createElement("a");
                 a.textContent = text;
                 li.appendChild(a);

--- a/midp/gfx.js
+++ b/midp/gfx.js
@@ -799,7 +799,7 @@ var currentlyFocusedTextEditor;
 
     Native["javax/microedition/lcdui/Graphics.drawRegion.(Ljavax/microedition/lcdui/Image;IIIIIIII)V"] =
     function(addr, srcAddr, x_src, y_src, width, height, transform, x_dest, y_dest, anchor) {
-        if (srcAddr === null) {
+        if (srcAddr === J2ME.Constants.NULL) {
             throw $.newNullPointerException("src image is null");
         }
 
@@ -810,7 +810,7 @@ var currentlyFocusedTextEditor;
 
     Native["javax/microedition/lcdui/Graphics.drawImage.(Ljavax/microedition/lcdui/Image;III)V"] =
     function(addr, imageAddr, x, y, anchor) {
-        if (imageAddr === null) {
+        if (imageAddr === J2ME.Constants.NULL) {
             throw $.newNullPointerException("image is null");
         }
 
@@ -1649,7 +1649,7 @@ var currentlyFocusedTextEditor;
 
     Native["javax/microedition/lcdui/GaugeLFImpl.createNativeResource0.(ILjava/lang/String;IZII)I"] =
     function(addr, ownerId, labelAddr, layout, interactive, maxValue, initialValue) {
-        if (labelAddr !== null) {
+        if (labelAddr !== J2ME.Constants.NULL) {
             console.error("Expected null label");
         }
 
@@ -1742,7 +1742,7 @@ var currentlyFocusedTextEditor;
             document.getElementById("sidebar").querySelector("nav ul").innerHTML = "";
         }
 
-        if (!commandsAddr) {
+        if (commandsAddr === J2ME.Constants.NULL) {
             return;
         }
 

--- a/midp/localmsg.js
+++ b/midp/localmsg.js
@@ -1037,8 +1037,8 @@ var localmsgServerWait = null;
 // XXX Consolidate the objects we store in this map with those in NativeMap.
 NativeConnectionMap = Object.create(null);
 
-Native["org/mozilla/io/LocalMsgConnection.init.(Ljava/lang/String;)V"] = function(addr, jName) {
-    var name = J2ME.fromJavaString(jName);
+Native["org/mozilla/io/LocalMsgConnection.init.(Ljava/lang/String;)V"] = function(addr, nameAddr) {
+    var name = J2ME.fromStringAddr(nameAddr);
 
     var info = {
       server: (name[2] == ":"),
@@ -1100,7 +1100,8 @@ Native["org/mozilla/io/LocalMsgConnection.waitConnection.()V"] = function(addr) 
     asyncImpl("V", connection.waitConnection());
 };
 
-Native["org/mozilla/io/LocalMsgConnection.sendData.([BII)V"] = function(addr, data, offset, length) {
+Native["org/mozilla/io/LocalMsgConnection.sendData.([BII)V"] = function(addr, dataAddr, offset, length) {
+    var data = J2ME.getArrayFromAddr(dataAddr);
     var connection = NativeConnectionMap[addr];
     var info = NativeMap.get(addr);
 
@@ -1116,7 +1117,8 @@ Native["org/mozilla/io/LocalMsgConnection.sendData.([BII)V"] = function(addr, da
     }
 };
 
-Native["org/mozilla/io/LocalMsgConnection.receiveData.([B)I"] = function(addr, data) {
+Native["org/mozilla/io/LocalMsgConnection.receiveData.([B)I"] = function(addr, dataAddr) {
+    var data = J2ME.getArrayFromAddr(dataAddr);
     var connection = NativeConnectionMap[addr];
     var info = NativeMap.get(addr);
 

--- a/midp/location.js
+++ b/midp/location.js
@@ -70,7 +70,9 @@ Native["com/sun/j2me/location/PlatformLocationProvider.getListOfLocationProvider
 
 addUnimplementedNative("com/sun/j2me/location/CriteriaImpl.initNativeClass.()V");
 
-Native["com/sun/j2me/location/PlatformLocationProvider.getBestProviderByCriteriaImpl.(Lcom/sun/j2me/location/CriteriaImpl;)Z"] = function(addr, criteria) {
+Native["com/sun/j2me/location/PlatformLocationProvider.getBestProviderByCriteriaImpl.(Lcom/sun/j2me/location/CriteriaImpl;)Z"] =
+function(addr, criteriaAddr) {
+    var criteria = getHandle(criteriaAddr);
     criteria.providerName = J2ME.newString(Location.PROVIDER_NAME);
     return 1;
 };
@@ -78,7 +80,7 @@ Native["com/sun/j2me/location/PlatformLocationProvider.getBestProviderByCriteria
 addUnimplementedNative("com/sun/j2me/location/LocationProviderInfo.initNativeClass.()V");
 addUnimplementedNative("com/sun/j2me/location/LocationInfo.initNativeClass.()V");
 
-Native["com/sun/j2me/location/PlatformLocationProvider.open.(Ljava/lang/String;)I"] = function(addr, name) {
+Native["com/sun/j2me/location/PlatformLocationProvider.open.(Ljava/lang/String;)I"] = function(addr, nameAddr) {
     var provider = new LocationProvider();
     provider.start();
     var id = Location.Providers.nextId;
@@ -93,7 +95,9 @@ Native["com/sun/j2me/location/PlatformLocationProvider.resetImpl.(I)V"] = functi
     Location.Providers[providerId] = null;
 };
 
-Native["com/sun/j2me/location/PlatformLocationProvider.getCriteria.(Ljava/lang/String;Lcom/sun/j2me/location/LocationProviderInfo;)Z"] = function(addr, name, criteria) {
+Native["com/sun/j2me/location/PlatformLocationProvider.getCriteria.(Ljava/lang/String;Lcom/sun/j2me/location/LocationProviderInfo;)Z"] =
+function(addr, nameAddr, criteriaAddr) {
+    var criteria = getHandle(criteriaAddr);
     criteria.canReportAltitude = 1;
     criteria.canReportSpeedCource = 1;
     criteria.averageResponseTime = 10000;
@@ -104,7 +108,9 @@ Native["com/sun/j2me/location/PlatformLocationProvider.setUpdateIntervalImpl.(II
     console.warn("com/sun/j2me/location/PlatformLocationProvider.setUpdateIntervalImpl.(II)V not implemented");
 };
 
-Native["com/sun/j2me/location/PlatformLocationProvider.getLastLocationImpl.(ILcom/sun/j2me/location/LocationInfo;)Z"] = function(addr, providerId, locationInfo) {
+Native["com/sun/j2me/location/PlatformLocationProvider.getLastLocationImpl.(ILcom/sun/j2me/location/LocationInfo;)Z"] =
+function(addr, providerId, locationInfoAddr) {
+    var locationInfo = getHandle(locationInfoAddr);
     var provider = Location.Providers[providerId];
     var pos = provider.position;
     locationInfo.isValid = 1;

--- a/midp/media.js
+++ b/midp/media.js
@@ -133,8 +133,9 @@ Media.convert3gpToAmr = function(inBuffer) {
     return outBuffer.subarray(0, outOffset);
 };
 
-Native["com/sun/mmedia/DefaultConfiguration.nListContentTypesOpen.(Ljava/lang/String;)I"] = function(addr, jProtocol) {
-    var protocol = J2ME.fromJavaString(jProtocol);
+Native["com/sun/mmedia/DefaultConfiguration.nListContentTypesOpen.(Ljava/lang/String;)I"] =
+function(addr, protocolAddr) {
+    var protocol = J2ME.fromStringAddr(protocolAddr);
     var types = [];
     if (protocol) {
         types = Media.ContentTypes[protocol].slice();
@@ -171,8 +172,8 @@ Native["com/sun/mmedia/DefaultConfiguration.nListContentTypesClose.(I)V"] = func
     Media.ListCache.remove(hdlr);
 };
 
-Native["com/sun/mmedia/DefaultConfiguration.nListProtocolsOpen.(Ljava/lang/String;)I"] = function(addr, jMime) {
-    var mime = J2ME.fromJavaString(jMime);
+Native["com/sun/mmedia/DefaultConfiguration.nListProtocolsOpen.(Ljava/lang/String;)I"] = function(addr, mimeAddr) {
+    var mime = J2ME.fromStringAddr(mimeAddr);
     var protocols = [];
     for (var protocol in Media.ContentTypes) {
         if (!mime || Media.ContentTypes[protocol].indexOf(mime) >= 0) {
@@ -1017,8 +1018,8 @@ AudioRecorder.prototype.close = function() {
     }.bind(this));
 };
 
-Native["com/sun/mmedia/PlayerImpl.nInit.(IILjava/lang/String;)I"] = function(addr, appId, pId, jURI) {
-    var url = J2ME.fromJavaString(jURI);
+Native["com/sun/mmedia/PlayerImpl.nInit.(IILjava/lang/String;)I"] = function(addr, appId, pId, URIAddr) {
+    var url = J2ME.fromStringAddr(URIAddr);
     var id = pId + (appId << 15);
     Media.PlayerCache[id] = new PlayerContainer(url, pId);
     return id;
@@ -1051,8 +1052,8 @@ Native["com/sun/mmedia/PlayerImpl.nIsHandledByDevice.(I)Z"] = function(addr, han
     return Media.PlayerCache[handle].isHandledByDevice() ? 1 : 0;
 };
 
-Native["com/sun/mmedia/PlayerImpl.nRealize.(ILjava/lang/String;)Z"] = function(addr, handle, jMime) {
-    var mime = J2ME.fromJavaString(jMime);
+Native["com/sun/mmedia/PlayerImpl.nRealize.(ILjava/lang/String;)Z"] = function(addr, handle, mimeAddr) {
+    var mime = J2ME.fromStringAddr(mimeAddr);
     var player = Media.PlayerCache[handle];
     asyncImpl("Z", player.realize(mime));
 };
@@ -1067,15 +1068,16 @@ Native["com/sun/mmedia/MediaDownload.nGetFirstPacketSize.(I)I"] = function(addr,
     return player.getBufferSize() >>> 1;
 };
 
-Native["com/sun/mmedia/MediaDownload.nBuffering.(I[BII)I"] = function(addr, handle, buffer, offset, size) {
+Native["com/sun/mmedia/MediaDownload.nBuffering.(I[BII)I"] = function(addr, handle, bufferAddr, offset, size) {
     var player = Media.PlayerCache[handle];
     var bufferSize = player.getBufferSize();
 
     // Check the parameters.
-    if (buffer === null || size === 0) {
+    if (bufferAddr === null || size === 0) {
         return bufferSize >>> 1;
     }
 
+    var buffer = J2ME.getArrayFromAddr(bufferAddr);
     player.writeBuffer(buffer.subarray(offset, offset + size));
 
     // Returns the package size and set it to the half of the java buffer size.
@@ -1232,7 +1234,7 @@ Native["com/sun/mmedia/DirectPlayer.nGetDuration.(I)I"] = function(addr, handle)
     }
 };
 
-Native["com/sun/mmedia/DirectRecord.nSetLocator.(ILjava/lang/String;)I"] = function(addr, handle, locator) {
+Native["com/sun/mmedia/DirectRecord.nSetLocator.(ILjava/lang/String;)I"] = function(addr, handle, locatorAddr) {
     // Let the DirectRecord class handle writing to files / uploading via HTTP
     return 0;
 };
@@ -1241,7 +1243,8 @@ Native["com/sun/mmedia/DirectRecord.nGetRecordedSize.(I)I"] = function(addr, han
     return Media.PlayerCache[handle].getRecordedSize();
 };
 
-Native["com/sun/mmedia/DirectRecord.nGetRecordedData.(III[B)I"] = function(addr, handle, offset, size, buffer) {
+Native["com/sun/mmedia/DirectRecord.nGetRecordedData.(III[B)I"] = function(addr, handle, offset, size, bufferAddr) {
+    var buffer = J2ME.getArrayFromAddr(bufferAddr);
     Media.PlayerCache[handle].getRecordedData(offset, size, buffer);
     return 1;
 };
@@ -1416,8 +1419,8 @@ Native["com/sun/mmedia/NativeTonePlayer.nStopTone.(I)Z"] = function(addr, appId)
     return 1;
 };
 
-Native["com/sun/mmedia/DirectPlayer.nStartSnapshot.(ILjava/lang/String;)V"] = function(addr, handle, imageType) {
-    Media.PlayerCache[handle].startSnapshot(J2ME.fromJavaString(imageType));
+Native["com/sun/mmedia/DirectPlayer.nStartSnapshot.(ILjava/lang/String;)V"] = function(addr, handle, imageTypeAddr) {
+    Media.PlayerCache[handle].startSnapshot(J2ME.fromStringAddr(imageTypeAddr));
 };
 
 Native["com/sun/mmedia/DirectPlayer.nGetSnapshotData.(I)[B"] = function(addr, handle) {
@@ -1429,7 +1432,7 @@ Native["com/sun/amms/GlobalMgrImpl.nCreatePeer.()I"] = function(addr) {
     return 1;
 };
 
-Native["com/sun/amms/GlobalMgrImpl.nGetControlPeer.([B)I"] = function(addr, typeName) {
+Native["com/sun/amms/GlobalMgrImpl.nGetControlPeer.([B)I"] = function(addr, typeNameAddr) {
     console.warn("com/sun/amms/GlobalMgrImpl.nGetControlPeer.([B)I not implemented.");
     return 2;
 };

--- a/midp/media.js
+++ b/midp/media.js
@@ -1073,7 +1073,7 @@ Native["com/sun/mmedia/MediaDownload.nBuffering.(I[BII)I"] = function(addr, hand
     var bufferSize = player.getBufferSize();
 
     // Check the parameters.
-    if (bufferAddr === null || size === 0) {
+    if (bufferAddr === J2ME.Constants.NULL || size === 0) {
         return bufferSize >>> 1;
     }
 

--- a/midp/midp.js
+++ b/midp/midp.js
@@ -127,12 +127,13 @@ var MIDP = (function() {
     FullscreenInfo.set(displayId, mode);
   };
 
-  Native["com/sun/midp/log/LoggingBase.report.(IILjava/lang/String;)V"] = function(addr, severity, channelID, message) {
-    console.info(J2ME.fromJavaString(message));
+  Native["com/sun/midp/log/LoggingBase.report.(IILjava/lang/String;)V"] =
+  function(addr, severity, channelID, messageAddr) {
+    console.info(J2ME.fromStringAddr(messageAddr));
   };
 
-  Native["com/sun/midp/midlet/MIDletPeer.platformRequest.(Ljava/lang/String;)Z"] = function(addr, request) {
-    request = J2ME.fromJavaString(request);
+  Native["com/sun/midp/midlet/MIDletPeer.platformRequest.(Ljava/lang/String;)Z"] = function(addr, requestAddr) {
+    request = J2ME.fromStringAddr(requestAddr);
     if (request.startsWith("http://") || request.startsWith("https://")) {
       if (request.endsWith(".jad")) {
         // The download will start after the MIDlet has terminated its execution.
@@ -166,7 +167,9 @@ var MIDP = (function() {
     return 0;
   };
 
-  Native["com/sun/midp/main/CommandState.restoreCommandState.(Lcom/sun/midp/main/CommandState;)V"] = function(addr, state) {
+  Native["com/sun/midp/main/CommandState.restoreCommandState.(Lcom/sun/midp/main/CommandState;)V"] =
+  function(addr, stateAddr) {
+    var state = getHandle(stateAddr);
     var suiteId = (config.midletClassName === "internal") ? -1 : 1;
     state.suiteId = suiteId;
     state.midletClassName = J2ME.newString(config.midletClassName);
@@ -244,9 +247,11 @@ var MIDP = (function() {
   Native["com/sun/midp/main/MIDletSuiteUtils.vmEndStartUp.(I)V"] = function(addr, midletIsolateId) {
   };
 
-  Native["com/sun/midp/main/Configuration.getProperty0.(Ljava/lang/String;)Ljava/lang/String;"] = function(addr, key) {
+  Native["com/sun/midp/main/Configuration.getProperty0.(Ljava/lang/String;)Ljava/lang/String;"] =
+  function(addr, keyAddr) {
+    var key = J2ME.fromStringAddr(keyAddr);
     var value;
-    switch (J2ME.fromJavaString(key)) {
+    switch (key) {
       case "com.sun.midp.publickeystore.WebPublicKeyStore":
         if (config.midletClassName == "RunTestsMIDlet" ||
             config.midletClassName.startsWith("benchmark")) {
@@ -286,15 +291,16 @@ var MIDP = (function() {
         value = null;
         break;
       default:
-        console.warn("UNKNOWN PROPERTY (com/sun/midp/main/Configuration): " + J2ME.fromJavaString(key));
+        console.warn("UNKNOWN PROPERTY (com/sun/midp/main/Configuration): " + key);
         value = null;
         break;
     }
     return J2ME.newString(value);
   };
 
-  Native["com/sun/midp/util/ResourceHandler.loadRomizedResource0.(Ljava/lang/String;)[B"] = function(addr, file) {
-    var fileName = "assets/0/" + J2ME.fromJavaString(file).replace("_", ".").replace("_png", ".png").replace("_raw", ".raw");
+  Native["com/sun/midp/util/ResourceHandler.loadRomizedResource0.(Ljava/lang/String;)[B"] = function(addr, fileAddr) {
+    var fileName = "assets/0/" +
+                   J2ME.fromStringAddr(fileAddr).replace("_", ".").replace("_png", ".png").replace("_raw", ".raw");
     var data = JARStore.loadFile(fileName);
     if (!data) {
       console.warn("ResourceHandler::loadRomizedResource0: file " + fileName + " not found");
@@ -613,7 +619,8 @@ var MIDP = (function() {
     return arrAddr;
   };
 
-  Native["javax/microedition/lcdui/SuiteImageCacheImpl.loadAndCreateImmutableImageDataFromCache0.(Ljavax/microedition/lcdui/ImageData;ILjava/lang/String;)Z"] = function(addr, imageData, suiteId, fileName) {
+  Native["javax/microedition/lcdui/SuiteImageCacheImpl.loadAndCreateImmutableImageDataFromCache0.(Ljavax/microedition/lcdui/ImageData;ILjava/lang/String;)Z"] =
+  function(addr, imageDataAddr, suiteId, fileNameAddr) {
     // We're not implementing the cache because looks like it isn't used much.
     // In a MIDlet I've been testing for a few minutes, there's been only one hit.
     return 0;
@@ -622,8 +629,8 @@ var MIDP = (function() {
   var interIsolateMutexes = [];
   var lastInterIsolateMutexID = -1;
 
-  Native["com/sun/midp/util/isolate/InterIsolateMutex.getID0.(Ljava/lang/String;)I"] = function(addr, jName) {
-    var name = J2ME.fromJavaString(jName);
+  Native["com/sun/midp/util/isolate/InterIsolateMutex.getID0.(Ljava/lang/String;)I"] = function(addr, mutexNameAddr) {
+    var name = J2ME.fromStringAddr(mutexNameAddr);
 
     var mutex;
     for (var i = 0; i < interIsolateMutexes.length; i++) {
@@ -921,44 +928,47 @@ var MIDP = (function() {
   };
 
   Native["com/sun/midp/events/EventQueue.sendNativeEventToIsolate.(Lcom/sun/midp/events/NativeEvent;I)V"] =
-    function(addr, obj, isolateId) {
-      var e = { type: obj.type };
+    function(addr, eventAddr, isolateId) {
+      var event = getHandle(eventAddr);
+      var e = { type: event.type };
 
-      var fields = obj.klass.classInfo.fields;
+      var fields = event.klass.classInfo.fields;
       for (var i = 0; i < fields.length; i++) {
         var field = fields[i];
-        e[J2ME.fromUTF8(field.utf8Name)] = field.get(obj);
+        e[J2ME.fromUTF8(field.utf8Name)] = field.get(event);
       }
 
       sendNativeEvent(e, isolateId);
     };
 
   Native["com/sun/midp/events/NativeEventMonitor.waitForNativeEvent.(Lcom/sun/midp/events/NativeEvent;)I"] =
-    function(addr, nativeEvent) {
+    function(addr, eventAddr) {
+      var event = getHandle(eventAddr);
       var isolateId = $.ctx.runtime.isolateId;
       var nativeEventQueue = nativeEventQueues[isolateId];
 
       if (nativeEventQueue.length !== 0) {
-        copyEvent(nativeEventQueue.shift(), nativeEvent);
+        copyEvent(nativeEventQueue.shift(), event);
         return nativeEventQueue.length;
       }
 
       asyncImpl("I", new Promise(function(resolve, reject) {
         waitingNativeEventQueue[isolateId] = {
           resolve: resolve,
-        nativeEvent: nativeEvent,
+          nativeEvent: event,
         };
       }));
     };
 
   Native["com/sun/midp/events/NativeEventMonitor.readNativeEvent.(Lcom/sun/midp/events/NativeEvent;)Z"] =
-    function(addr, obj) {
+    function(addr, eventAddr) {
       var isolateId = $.ctx.runtime.isolateId;
       var nativeEventQueue = nativeEventQueues[isolateId];
       if (!nativeEventQueue.length) {
         return 0;
       }
-      copyEvent(nativeEventQueue.shift(), obj);
+      var event = getHandle(eventAddr);
+      copyEvent(nativeEventQueue.shift(), event);
       return 1;
     };
 
@@ -996,7 +1006,8 @@ var MIDP = (function() {
     sendNativeEvent({ type: EVENT_QUEUE_SHUTDOWN }, $.ctx.runtime.isolateId);
   };
 
-  Native["com/sun/midp/main/CommandState.saveCommandState.(Lcom/sun/midp/main/CommandState;)V"] = function(addr, commandState) {
+  Native["com/sun/midp/main/CommandState.saveCommandState.(Lcom/sun/midp/main/CommandState;)V"] =
+  function(addr, commandStateAddr) {
     console.warn("CommandState.saveCommandState.(L...CommandState;)V not implemented (" + commandState + ")");
   };
 
@@ -1079,7 +1090,8 @@ var MIDP = (function() {
     return gameKeys[keyCode] || 0;
   };
 
-  Native["javax/microedition/lcdui/game/GameCanvas.setSuppressKeyEvents.(Ljavax/microedition/lcdui/Canvas;Z)V"] = function(addr, canvas, shouldSuppress) {
+  Native["javax/microedition/lcdui/game/GameCanvas.setSuppressKeyEvents.(Ljavax/microedition/lcdui/Canvas;Z)V"] =
+  function(addr, canvasAddr, shouldSuppress) {
     suppressKeyEvents = shouldSuppress;
   };
 
@@ -1143,8 +1155,8 @@ var MIDP = (function() {
     }));
   };
 
-  Native["com/sun/midp/io/j2me/push/ConnectionRegistry.add0.(Ljava/lang/String;)I"] = function(addr, connection) {
-    var values = J2ME.fromJavaString(connection).split(',');
+  Native["com/sun/midp/io/j2me/push/ConnectionRegistry.add0.(Ljava/lang/String;)I"] = function(addr, connectionAddr) {
+    var values = J2ME.fromStringAddr(connectionAddr).split(',');
 
     console.warn("ConnectionRegistry.add0.(IL...String;)I isn't completely implemented");
 
@@ -1158,8 +1170,10 @@ var MIDP = (function() {
     return 0;
   };
 
-  Native["com/sun/midp/io/j2me/push/ConnectionRegistry.addAlarm0.([BJ)J"] = function(addr, jMidlet, jTimeLow, jTimeHigh) {
-    var time = J2ME.longToNumber(jTimeLow, jTimeHigh), midlet = util.decodeUtf8(jMidlet);
+  Native["com/sun/midp/io/j2me/push/ConnectionRegistry.addAlarm0.([BJ)J"] =
+  function(addr, midletAddr, jTimeLow, jTimeHigh) {
+    var midlet = util.decodeUtf8(J2ME.getArrayFromAddr(midletAddr));
+    var time = J2ME.longToNumber(jTimeLow, jTimeHigh);
 
     var lastAlarm = 0;
     var id = null;
@@ -1199,7 +1213,9 @@ var MIDP = (function() {
     return J2ME.returnLongValue(lastAlarm);
   };
 
-  Native["com/sun/midp/io/j2me/push/ConnectionRegistry.getMIDlet0.(I[BI)I"] = function(addr, handle, regentry, entrysz) {
+  Native["com/sun/midp/io/j2me/push/ConnectionRegistry.getMIDlet0.(I[BI)I"] =
+  function(addr, handle, regentryAddr, entrysz) {
+    var regentry = J2ME.getArrayFromAddr(regentryAddr);
     var reg;
     var alarms = connectionRegistry.alarms;
     for (var i = 0; i < alarms.length; i++) {
@@ -1238,11 +1254,14 @@ var MIDP = (function() {
     return 0;
   };
 
-  Native["com/sun/midp/io/j2me/push/ConnectionRegistry.checkInByMidlet0.(ILjava/lang/String;)V"] = function(addr, suiteId, className) {
-    console.warn("ConnectionRegistry.checkInByMidlet0.(IL...String;)V not implemented (" + suiteId + ", " + J2ME.fromJavaString(className) + ")");
+  Native["com/sun/midp/io/j2me/push/ConnectionRegistry.checkInByMidlet0.(ILjava/lang/String;)V"] =
+  function(addr, suiteId, classNameAddr) {
+    console.warn("ConnectionRegistry.checkInByMidlet0.(IL...String;)V not implemented (" +
+                 suiteId + ", " + J2ME.fromStringAddr(classNameAddr) + ")");
   };
 
-  Native["com/sun/midp/io/j2me/push/ConnectionRegistry.checkInByName0.([B)I"] = function(addr, name) {
+  Native["com/sun/midp/io/j2me/push/ConnectionRegistry.checkInByName0.([B)I"] = function(addr, nameAddr) {
+    var name = J2ME.getArrayFromAddr(nameAddr);
     console.warn("ConnectionRegistry.checkInByName0.([B)V not implemented (" + util.decodeUtf8(name) + ")");
     return 0;
   };
@@ -1261,16 +1280,19 @@ var MIDP = (function() {
   addUnimplementedNative("com/nokia/mid/ui/VirtualKeyboard.hideOpenKeypadCommand.(Z)V");
   addUnimplementedNative("com/nokia/mid/ui/VirtualKeyboard.suppressSizeChanged.(Z)V");
 
-  Native["com/nokia/mid/ui/VirtualKeyboard.getCustomKeyboardControl.()Lcom/nokia/mid/ui/CustomKeyboardControl;"] = function(addr) {
-    throw $.newIllegalArgumentException("VirtualKeyboard::getCustomKeyboardControl() not implemented")
+  Native["com/nokia/mid/ui/VirtualKeyboard.getCustomKeyboardControl.()Lcom/nokia/mid/ui/CustomKeyboardControl;"] =
+  function(addr) {
+    throw $.newIllegalArgumentException("VirtualKeyboard::getCustomKeyboardControl() not implemented");
   };
 
   var keyboardVisibilityListener = J2ME.Constants.NULL;
-  Native["com/nokia/mid/ui/VirtualKeyboard.setVisibilityListener.(Lcom/nokia/mid/ui/KeyboardVisibilityListener;)V"] = function(addr, listener) {
-    keyboardVisibilityListener = listener ? listener._address : J2ME.Constants.NULL;
+  Native["com/nokia/mid/ui/VirtualKeyboard.setVisibilityListener.(Lcom/nokia/mid/ui/KeyboardVisibilityListener;)V"] =
+  function(addr, listenerAddr) {
+    keyboardVisibilityListener = listenerAddr ? listenerAddr : J2ME.Constants.NULL;
   };
 
-  Native["javax/microedition/lcdui/Display.getKeyboardVisibilityListener.()Lcom/nokia/mid/ui/KeyboardVisibilityListener;"] = function(addr) {
+  Native["javax/microedition/lcdui/Display.getKeyboardVisibilityListener.()Lcom/nokia/mid/ui/KeyboardVisibilityListener;"] =
+  function(addr) {
     return keyboardVisibilityListener;
   };
 

--- a/midp/pim.js
+++ b/midp/pim.js
@@ -57,12 +57,13 @@ Native["com/sun/j2me/pim/PIMProxy.getListNamesCount0.(I)I"] = function(addr, lis
   return 0;
 };
 
-Native["com/sun/j2me/pim/PIMProxy.getListNames0.([Ljava/lang/String;)V"] = function(addr, names) {
+Native["com/sun/j2me/pim/PIMProxy.getListNames0.([Ljava/lang/String;)V"] = function(addr, namesAddr) {
+  var names = J2ME.getArrayFromAddr(namesAddr);
   console.warn("PIMProxy.getListNames0.([Ljava/lang/String;)V incomplete");
   names[0] = J2ME.newString("ContactList");
 };
 
-Native["com/sun/j2me/pim/PIMProxy.listOpen0.(ILjava/lang/String;I)I"] = function(addr, listType, listName, mode) {
+Native["com/sun/j2me/pim/PIMProxy.listOpen0.(ILjava/lang/String;I)I"] = function(addr, listType, listNameAddr, mode) {
   console.warn("PIMProxy.listOpen0.(ILjava/lang/String;I)I incomplete");
 
   if (mode !== PIM.READ_ONLY) {
@@ -78,7 +79,8 @@ Native["com/sun/j2me/pim/PIMProxy.listOpen0.(ILjava/lang/String;I)I"] = function
   return 0;
 };
 
-Native["com/sun/j2me/pim/PIMProxy.getNextItemDescription0.(I[I)Z"] = function(addr, listHandle, description) {
+Native["com/sun/j2me/pim/PIMProxy.getNextItemDescription0.(I[I)Z"] = function(addr, listHandle, descriptionAddr) {
+  var description = J2ME.getArrayFromAddr(descriptionAddr);
   console.warn("PIMProxy.getNextItemDescription0.(I[I)Z incomplete");
 
   asyncImpl("Z", new Promise(function(resolve, reject) {
@@ -105,7 +107,8 @@ Native["com/sun/j2me/pim/PIMProxy.getNextItemDescription0.(I[I)Z"] = function(ad
   }));
 };
 
-Native["com/sun/j2me/pim/PIMProxy.getNextItemData0.(I[BI)Z"] = function(addr, itemHandle, data, dataHandle) {
+Native["com/sun/j2me/pim/PIMProxy.getNextItemData0.(I[BI)Z"] = function(addr, itemHandle, dataAddr, dataHandle) {
+  var data = J2ME.getArrayFromAddr(dataAddr);
   console.warn("PIMProxy.getNextItemData0.(I[BI)Z incomplete");
   data.set(PIM.curVcard);
   return 1;
@@ -141,7 +144,7 @@ Native["com/sun/j2me/pim/PIMProxy.getDefaultListName.(I)Ljava/lang/String;"] = f
   return J2ME.Constants.NULL;
 };
 
-Native["com/sun/j2me/pim/PIMProxy.getFieldsCount0.(I[I)I"] = function(addr, listHandle, dataHandle) {
+Native["com/sun/j2me/pim/PIMProxy.getFieldsCount0.(I[I)I"] = function(addr, listHandle, dataHandleAddr) {
   return PIM.supportedFields.length;
 };
 
@@ -150,7 +153,9 @@ Native["com/sun/j2me/pim/PIMProxy.getFieldLabelsCount0.(III)I"] = function(addr,
   return 1;
 };
 
-Native["com/sun/j2me/pim/PIMProxy.getFields0.(I[Lcom/sun/j2me/pim/PIMFieldDescriptor;I)V"] = function(addr, listHandle, desc, dataHandle) {
+Native["com/sun/j2me/pim/PIMProxy.getFields0.(I[Lcom/sun/j2me/pim/PIMFieldDescriptor;I)V"] =
+function(addr, listHandle, descAddr, dataHandle) {
+  var desc = J2ME.getArrayFromAddr(descAddr);
   console.warn("PIMProxy.getFields0.(I[Lcom/sun/j2me/pim/PIMFieldDescriptor;I)V incomplete");
 
   PIM.supportedFields.forEach(function(field, i) {
@@ -161,11 +166,12 @@ Native["com/sun/j2me/pim/PIMProxy.getFields0.(I[Lcom/sun/j2me/pim/PIMFieldDescri
   });
 };
 
-Native["com/sun/j2me/pim/PIMProxy.getAttributesCount0.(I[I)I"] = function(addr, listHandle, dataHandle) {
+Native["com/sun/j2me/pim/PIMProxy.getAttributesCount0.(I[I)I"] = function(addr, listHandle, dataHandleAddr) {
   console.warn("PIMProxy.getAttributesCount0.(I[I)I not implemented");
   return 0;
 };
 
-Native["com/sun/j2me/pim/PIMProxy.getAttributes0.(I[Lcom/sun/j2me/pim/PIMAttribute;I)V"] = function(addr, listHandle, attr, dataHandle) {
+Native["com/sun/j2me/pim/PIMProxy.getAttributes0.(I[Lcom/sun/j2me/pim/PIMAttribute;I)V"] =
+function(addr, listHandle, attrAddr, dataHandle) {
   console.warn("PIMProxy.getAttributes0.(I[Lcom/sun/j2me/pim/PIMAttribute;I)V not implemented");
 };

--- a/midp/sensor.js
+++ b/midp/sensor.js
@@ -198,11 +198,13 @@ Native["com/sun/javame/sensor/SensorRegistry.doGetNumberOfSensors.()I"] = functi
     return 1;
 };
 
-Native["com/sun/javame/sensor/Sensor.doGetSensorModel.(ILcom/sun/javame/sensor/SensorModel;)V"] = function(addr, number, model) {
+Native["com/sun/javame/sensor/Sensor.doGetSensorModel.(ILcom/sun/javame/sensor/SensorModel;)V"] =
+function(addr, number, modelAddr) {
     if (number !== 0) {
         console.error("Invalid sensor number: " + number);
         return;
     }
+    var model = getHandle(modelAddr);
     var m = AccelerometerSensor.model;
     model.description = J2ME.newString(m.description);
     model.model = J2ME.newString(m.model);
@@ -225,7 +227,8 @@ Native["com/sun/javame/sensor/Sensor.doGetSensorModel.(ILcom/sun/javame/sensor/S
     model.properties = pAddr;
 };
 
-Native["com/sun/javame/sensor/ChannelImpl.doGetChannelModel.(IILcom/sun/javame/sensor/ChannelModel;)V"] = function(addr, sensorsNumber, number, model) {
+Native["com/sun/javame/sensor/ChannelImpl.doGetChannelModel.(IILcom/sun/javame/sensor/ChannelModel;)V"] =
+function(addr, sensorsNumber, number, modelAddr) {
     if (sensorsNumber !== 0) {
         console.error("Invalid sensor number: " + sensorsNumber);
         return;
@@ -234,6 +237,7 @@ Native["com/sun/javame/sensor/ChannelImpl.doGetChannelModel.(IILcom/sun/javame/s
         console.error("Invalid channel number: " + number);
         return;
     }
+    var model = getHandle(modelAddr);
     var c = AccelerometerSensor.channels[number];
     model.scale = c.scale;
     model.name = J2ME.newString(c.name);

--- a/midp/socket.js
+++ b/midp/socket.js
@@ -11,7 +11,8 @@ var SOCKET_OPT = {
   SNDBUF: 4,
 };
 
-Native["com/sun/midp/io/j2me/socket/Protocol.getIpNumber0.(Ljava/lang/String;[B)I"] = function(addr, host, ipBytes) {
+Native["com/sun/midp/io/j2me/socket/Protocol.getIpNumber0.(Ljava/lang/String;[B)I"] =
+function(addr, hostAddr, ipBytesAddr) {
     // We're supposed to write the IP address of the host into ipBytes,
     // but we don't actually have to do that, because we can defer resolution
     // until Protocol.open0 (and delegate it to the native socket impl).
@@ -25,10 +26,10 @@ Native["com/sun/midp/io/j2me/socket/Protocol.getHost0.(Z)Ljava/lang/String;"] = 
     // and we might avoid an exception if the socket hasn't been opened yet
     // (so the native socket doesn't exist).
     // var self = getHandle(addr);
-    // var host = J2ME.fromJavaString(getHandle(self.host));
+    // var host = J2ME.fromStringAddr(self.host);
 
     var socket = NativeMap.get(addr);
-    return local ? "127.0.0.1" : socket.host;
+    return J2ME.newString(local ? "127.0.0.1" : socket.host);
 };
 
 function Socket(host, port, ctx, resolve, reject) {
@@ -100,9 +101,9 @@ Socket.prototype.close = function() {
     this.sender({ type: "close" });
 }
 
-Native["com/sun/midp/io/j2me/socket/Protocol.open0.([BI)V"] = function(addr, ipBytes, port) {
+Native["com/sun/midp/io/j2me/socket/Protocol.open0.([BI)V"] = function(addr, ipBytesAddr, port) {
     var self = getHandle(addr);
-    var host = J2ME.fromJavaString(getHandle(self.host));
+    var host = J2ME.fromStringAddr(self.host);
     // console.log("Protocol.open0: " + host + ":" + port);
     asyncImpl("V", new Promise(function(resolve, reject) {
         NativeMap.set(addr, new Socket(host, port, $.ctx, resolve, reject));
@@ -115,7 +116,8 @@ Native["com/sun/midp/io/j2me/socket/Protocol.available0.()I"] = function(addr) {
     return socket.dataLen;
 };
 
-Native["com/sun/midp/io/j2me/socket/Protocol.read0.([BII)I"] = function(addr, data, offset, length) {
+Native["com/sun/midp/io/j2me/socket/Protocol.read0.([BII)I"] = function(addr, dataAddr, offset, length) {
+    var data = J2ME.getArrayFromAddr(dataAddr);
     var socket = NativeMap.get(addr);
     // console.log("Protocol.read0: " + socket.isClosed);
 
@@ -164,7 +166,8 @@ Native["com/sun/midp/io/j2me/socket/Protocol.read0.([BII)I"] = function(addr, da
     }));
 };
 
-Native["com/sun/midp/io/j2me/socket/Protocol.write0.([BII)I"] = function(addr, data, offset, length) {
+Native["com/sun/midp/io/j2me/socket/Protocol.write0.([BII)I"] = function(addr, dataAddr, offset, length) {
+    var data = J2ME.getArrayFromAddr(dataAddr);
     var socket = NativeMap.get(addr);
     var ctx = $.ctx;
     asyncImpl("I", new Promise(function(resolve, reject) {

--- a/nat.ts
+++ b/nat.ts
@@ -154,7 +154,8 @@ module J2ME {
     return isolate._mainClass;
   };
 
-  Native["org/mozilla/internal/Sys.executeMain.(Ljava/lang/Class;)V"] = function(addr: number, main: java.lang.Class) {
+  Native["org/mozilla/internal/Sys.executeMain.(Ljava/lang/Class;)V"] = function(addr: number, mainAddr: number) {
+    var main = <java.lang.Class>getHandle(mainAddr);
     var entryPoint = CLASSES.getEntryPoint(main.runtimeKlass.templateKlass.classInfo);
     if (!entryPoint)
       throw new Error("Could not find isolate main.");

--- a/native.js
+++ b/native.js
@@ -368,8 +368,9 @@ Native["java/lang/Class.forName0.(Ljava/lang/String;)V"] = function(addr, nameAd
     var className = J2ME.fromStringAddr(nameAddr).replace(/\./g, "/");
     classInfo = CLASSES.getClass(className);
   } catch (e) {
-    if (e instanceof (J2ME.ClassNotFoundException))
+    if (e instanceof (J2ME.ClassNotFoundException)) {
       throw $.newClassNotFoundException("'" + e.message + "' not found.");
+    }
     throw e;
   }
   // The following can trigger an unwind.

--- a/native.js
+++ b/native.js
@@ -45,7 +45,7 @@ function deleteNative(javaObj) {
 
 Native["java/lang/System.arraycopy.(Ljava/lang/Object;ILjava/lang/Object;II)V"] =
 function(addr, srcAddr, srcOffset, dstAddr, dstOffset, length) {
-    if (!srcAddr || !dstAddr) {
+    if (srcAddr === J2ME.Constants.NULL || dstAddr === J2ME.Constants.NULL) {
         throw $.newNullPointerException("Cannot copy to/from a null array.");
     }
 
@@ -362,8 +362,9 @@ Native["java/lang/Class.getName.()Ljava/lang/String;"] = function(addr) {
 Native["java/lang/Class.forName0.(Ljava/lang/String;)V"] = function(addr, nameAddr) {
   var classInfo = null;
   try {
-    if (!nameAddr)
+    if (nameAddr === J2ME.Constants.NULL) {
       throw new J2ME.ClassNotFoundException();
+    }
     var className = J2ME.fromStringAddr(nameAddr).replace(/\./g, "/");
     classInfo = CLASSES.getClass(className);
   } catch (e) {
@@ -426,7 +427,7 @@ Native["java/lang/Class.isAssignableFrom.(Ljava/lang/Class;)Z"] = function(addr,
 
 Native["java/lang/Class.isInstance.(Ljava/lang/Object;)Z"] = function(addr, objAddr) {
     var self = getHandle(addr);
-    return objAddr && J2ME.isAssignableTo(getHandle(objAddr).klass, self.runtimeKlass.templateKlass) ? 1 : 0;
+    return objAddr !== J2ME.Constants.NULL && J2ME.isAssignableTo(getHandle(objAddr).klass, self.runtimeKlass.templateKlass) ? 1 : 0;
 };
 
 Native["java/lang/Float.floatToIntBits.(F)I"] = function(addr, f) {
@@ -667,8 +668,7 @@ Native["java/lang/ref/WeakReference.initializeWeakReference.(Ljava/lang/Object;)
 };
 
 Native["java/lang/ref/WeakReference.get.()Ljava/lang/Object;"] = function(addr) {
-    var targetAddr = NativeMap.get(addr);
-    return targetAddr ? targetAddr : J2ME.Constants.NULL;
+    return NativeMap.has(addr) ? NativeMap.get(addr) : J2ME.Constants.NULL;
 };
 
 Native["java/lang/ref/WeakReference.clear.()V"] = function(addr) {

--- a/native.js
+++ b/native.js
@@ -43,10 +43,14 @@ function deleteNative(javaObj) {
     NativeMap.delete(javaObj._address);
 }
 
-Native["java/lang/System.arraycopy.(Ljava/lang/Object;ILjava/lang/Object;II)V"] = function(addr, src, srcOffset, dst, dstOffset, length) {
-    if (!src || !dst) {
+Native["java/lang/System.arraycopy.(Ljava/lang/Object;ILjava/lang/Object;II)V"] =
+function(addr, srcAddr, srcOffset, dstAddr, dstOffset, length) {
+    if (!srcAddr || !dstAddr) {
         throw $.newNullPointerException("Cannot copy to/from a null array.");
     }
+
+    var src = getHandle(srcAddr);
+    var dst = getHandle(dstAddr);
 
     var srcKlass = src.klass;
     var dstKlass = dst.klass;
@@ -105,8 +109,8 @@ var stubProperties = {
   "com.nokia.mid.imei": "",
 };
 
-Native["java/lang/System.getProperty0.(Ljava/lang/String;)Ljava/lang/String;"] = function(addr, key) {
-    key = J2ME.fromJavaString(key);
+Native["java/lang/System.getProperty0.(Ljava/lang/String;)Ljava/lang/String;"] = function(addr, keyAddr) {
+    var key = J2ME.fromStringAddr(keyAddr);
     var value;
     switch (key) {
     case "microedition.encoding":
@@ -280,15 +284,25 @@ Native["java/lang/System.currentTimeMillis.()J"] = function(addr) {
     return J2ME.returnLongValue(Date.now());
 };
 
-Native["com/sun/cldchi/jvm/JVM.unchecked_char_arraycopy.([CI[CII)V"] = function(addr, src, srcOffset, dst, dstOffset, length) {
+Native["com/sun/cldchi/jvm/JVM.unchecked_char_arraycopy.([CI[CII)V"] =
+function(addr, srcAddr, srcOffset, dstAddr, dstOffset, length) {
+  var src = J2ME.getArrayFromAddr(srcAddr);
+  var dst = J2ME.getArrayFromAddr(dstAddr);
   dst.set(src.subarray(srcOffset, srcOffset + length), dstOffset);
 };
 
-Native["com/sun/cldchi/jvm/JVM.unchecked_int_arraycopy.([II[III)V"] = function(addr, src, srcOffset, dst, dstOffset, length) {
+Native["com/sun/cldchi/jvm/JVM.unchecked_int_arraycopy.([II[III)V"] =
+function(addr, srcAddr, srcOffset, dstAddr, dstOffset, length) {
+  var src = J2ME.getArrayFromAddr(srcAddr);
+  var dst = J2ME.getArrayFromAddr(dstAddr);
   dst.set(src.subarray(srcOffset, srcOffset + length), dstOffset);
 };
 
-Native["com/sun/cldchi/jvm/JVM.unchecked_obj_arraycopy.([Ljava/lang/Object;I[Ljava/lang/Object;II)V"] = function(addr, src, srcOffset, dst, dstOffset, length) {
+Native["com/sun/cldchi/jvm/JVM.unchecked_obj_arraycopy.([Ljava/lang/Object;I[Ljava/lang/Object;II)V"] =
+function(addr, srcAddr, srcOffset, dstAddr, dstOffset, length) {
+    var src = J2ME.getArrayFromAddr(srcAddr);
+    var dst = J2ME.getArrayFromAddr(dstAddr);
+
     if (dst !== src || dstOffset < srcOffset) {
         for (var n = 0; n < length; ++n) {
             dst[dstOffset++] = src[srcOffset++];
@@ -345,12 +359,12 @@ Native["java/lang/Class.getName.()Ljava/lang/String;"] = function(addr) {
     return J2ME.newString(self.runtimeKlass.templateKlass.classInfo.getClassNameSlow().replace(/\//g, "."));
 };
 
-Native["java/lang/Class.forName0.(Ljava/lang/String;)V"] = function(addr, name) {
+Native["java/lang/Class.forName0.(Ljava/lang/String;)V"] = function(addr, nameAddr) {
   var classInfo = null;
   try {
-    if (!name)
+    if (!nameAddr)
       throw new J2ME.ClassNotFoundException();
-    var className = J2ME.fromJavaString(name).replace(/\./g, "/");
+    var className = J2ME.fromStringAddr(nameAddr).replace(/\./g, "/");
     classInfo = CLASSES.getClass(className);
   } catch (e) {
     if (e instanceof (J2ME.ClassNotFoundException))
@@ -361,8 +375,8 @@ Native["java/lang/Class.forName0.(Ljava/lang/String;)V"] = function(addr, name) 
   J2ME.classInitCheck(classInfo);
 };
 
-Native["java/lang/Class.forName1.(Ljava/lang/String;)Ljava/lang/Class;"] = function(addr, name) {
-  var className = J2ME.fromJavaString(name).replace(/\./g, "/");
+Native["java/lang/Class.forName1.(Ljava/lang/String;)Ljava/lang/Class;"] = function(addr, nameAddr) {
+  var className = J2ME.fromStringAddr(nameAddr).replace(/\./g, "/");
   var classInfo = CLASSES.getClass(className);
   var classObject = classInfo.getClassObject();
   return classObject._address;
@@ -382,7 +396,8 @@ Native["java/lang/Class.newInstance0.()Ljava/lang/Object;"] = function(addr) {
   return (new self.runtimeKlass.templateKlass)._address;
 };
 
-Native["java/lang/Class.newInstance1.(Ljava/lang/Object;)V"] = function(addr, o) {
+Native["java/lang/Class.newInstance1.(Ljava/lang/Object;)V"] = function(addr, oAddr) {
+  var o = getHandle(oAddr);
   // The following can trigger an unwind.
   var methodInfo = o.klass.classInfo.getLocalMethodByNameString("<init>", "()V", false);
   if (!methodInfo) {
@@ -401,16 +416,17 @@ Native["java/lang/Class.isArray.()Z"] = function(addr) {
     return self.runtimeKlass.templateKlass.classInfo instanceof J2ME.ArrayClassInfo ? 1 : 0;
 };
 
-Native["java/lang/Class.isAssignableFrom.(Ljava/lang/Class;)Z"] = function(addr, fromClass) {
+Native["java/lang/Class.isAssignableFrom.(Ljava/lang/Class;)Z"] = function(addr, fromClassAddr) {
     var self = getHandle(addr);
+    var fromClass = getHandle(fromClassAddr);
     if (!fromClass)
         throw $.newNullPointerException();
     return J2ME.isAssignableTo(fromClass.runtimeKlass.templateKlass, self.runtimeKlass.templateKlass) ? 1 : 0;
 };
 
-Native["java/lang/Class.isInstance.(Ljava/lang/Object;)Z"] = function(addr, obj) {
+Native["java/lang/Class.isInstance.(Ljava/lang/Object;)Z"] = function(addr, objAddr) {
     var self = getHandle(addr);
-    return obj && J2ME.isAssignableTo(obj.klass, self.runtimeKlass.templateKlass) ? 1 : 0;
+    return objAddr && J2ME.isAssignableTo(getHandle(objAddr).klass, self.runtimeKlass.templateKlass) ? 1 : 0;
 };
 
 Native["java/lang/Float.floatToIntBits.(F)I"] = function(addr, f) {
@@ -589,8 +605,8 @@ Native["com/sun/cldchi/io/ConsoleOutputStream.write.(I)V"] = function(addr, ch) 
     console.print(ch);
 };
 
-Native["com/sun/cldc/io/ResourceInputStream.open.(Ljava/lang/String;)Ljava/lang/Object;"] = function(addr, name) {
-    var fileName = J2ME.fromJavaString(name);
+Native["com/sun/cldc/io/ResourceInputStream.open.(Ljava/lang/String;)Ljava/lang/Object;"] = function(addr, nameAddr) {
+    var fileName = J2ME.fromStringAddr(nameAddr);
     var data = JARStore.loadFile(fileName);
     var obj = null;
     if (data) {
@@ -603,7 +619,8 @@ Native["com/sun/cldc/io/ResourceInputStream.open.(Ljava/lang/String;)Ljava/lang/
     return obj ? obj._address : J2ME.Constants.NULL;
 };
 
-Native["com/sun/cldc/io/ResourceInputStream.clone.(Ljava/lang/Object;)Ljava/lang/Object;"] = function(addr, source) {
+Native["com/sun/cldc/io/ResourceInputStream.clone.(Ljava/lang/Object;)Ljava/lang/Object;"] = function(addr, sourceAddr) {
+    var source = getHandle(sourceAddr);
     var obj = J2ME.newObject(CLASSES.java_lang_Object.klass);
     var sourceDecoder = getNative(source);
     setNative(obj, {
@@ -613,18 +630,20 @@ Native["com/sun/cldc/io/ResourceInputStream.clone.(Ljava/lang/Object;)Ljava/lang
     return obj._address;
 };
 
-Native["com/sun/cldc/io/ResourceInputStream.bytesRemain.(Ljava/lang/Object;)I"] = function(addr, fileDecoder) {
-    var handle = getNative(fileDecoder);
+Native["com/sun/cldc/io/ResourceInputStream.bytesRemain.(Ljava/lang/Object;)I"] = function(addr, fileDecoderAddr) {
+    var handle = NativeMap.get(fileDecoderAddr);
     return handle.data.length - handle.pos;
 };
 
-Native["com/sun/cldc/io/ResourceInputStream.readByte.(Ljava/lang/Object;)I"] = function(addr, fileDecoder) {
-    var handle = getNative(fileDecoder);
+Native["com/sun/cldc/io/ResourceInputStream.readByte.(Ljava/lang/Object;)I"] = function(addr, fileDecoderAddr) {
+    var handle = NativeMap.get(fileDecoderAddr);
     return (handle.data.length - handle.pos > 0) ? handle.data[handle.pos++] : -1;
 };
 
-Native["com/sun/cldc/io/ResourceInputStream.readBytes.(Ljava/lang/Object;[BII)I"] = function(addr, fileDecoder, b, off, len) {
-    var handle = getNative(fileDecoder);
+Native["com/sun/cldc/io/ResourceInputStream.readBytes.(Ljava/lang/Object;[BII)I"] =
+function(addr, fileDecoderAddr, bAddr, off, len) {
+    var b = J2ME.getArrayFromAddr(bAddr);
+    var handle = NativeMap.get(fileDecoderAddr);
     var data = handle.data;
     var remaining = data.length - handle.pos;
     if (len > remaining)
@@ -635,14 +654,21 @@ Native["com/sun/cldc/io/ResourceInputStream.readBytes.(Ljava/lang/Object;[BII)I"
     return (len > 0) ? len : -1;
 };
 
-Native["java/lang/ref/WeakReference.initializeWeakReference.(Ljava/lang/Object;)V"] = function(addr, target) {
+Native["java/lang/ref/WeakReference.initializeWeakReference.(Ljava/lang/Object;)V"] = function(addr, targetAddr) {
+    // Store the (not actually) weak reference in NativeMap.
+    //
+    // This is technically a misuse of NativeMap, which is intended to store
+    // native objects associated with Java objects, whereas here we're storing
+    // the address of a Java object associated with another Java object.
+    //
     // XXX Make these real weak references.
-    NativeMap.set(addr, target);
+    //
+    NativeMap.set(addr, targetAddr);
 };
 
 Native["java/lang/ref/WeakReference.get.()Ljava/lang/Object;"] = function(addr) {
-    var target = NativeMap.get(addr);
-    return target ? target._address : J2ME.Constants.NULL;
+    var targetAddr = NativeMap.get(addr);
+    return targetAddr ? targetAddr : J2ME.Constants.NULL;
 };
 
 Native["java/lang/ref/WeakReference.clear.()V"] = function(addr) {
@@ -700,12 +726,12 @@ Native["com/sun/cldc/isolate/Isolate.setPriority0.(I)V"] = function(addr, newPri
     // XXX Figure out if there's anything to do here.  If not, say so.
 };
 
-Native["com/sun/j2me/content/AppProxy.midletIsAdded.(ILjava/lang/String;)V"] = function(addr, suiteId, className) {
+Native["com/sun/j2me/content/AppProxy.midletIsAdded.(ILjava/lang/String;)V"] = function(addr, suiteId, classNameAddr) {
   console.warn("com/sun/j2me/content/AppProxy.midletIsAdded.(ILjava/lang/String;)V not implemented");
 };
 
-Native["com/nokia/mid/impl/jms/core/Launcher.handleContent.(Ljava/lang/String;)V"] = function(addr, content) {
-    var fileName = J2ME.fromJavaString(content);
+Native["com/nokia/mid/impl/jms/core/Launcher.handleContent.(Ljava/lang/String;)V"] = function(addr, contentAddr) {
+    var fileName = J2ME.fromStringAddr(contentAddr);
 
     var ext = fileName.split('.').pop().toLowerCase();
     // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#Supported_image_formats
@@ -766,9 +792,9 @@ function addUnimplementedNative(signature, returnValue) {
     Native[signature] = function(addr) { return warnOnce() };
 }
 
-Native["org/mozilla/internal/Sys.eval.(Ljava/lang/String;)V"] = function(addr, src) {
+Native["org/mozilla/internal/Sys.eval.(Ljava/lang/String;)V"] = function(addr, srcAddr) {
     if (!release) {
-        eval(J2ME.fromJavaString(src));
+        eval(J2ME.fromStringAddr(srcAddr));
     }
 };
 

--- a/string.js
+++ b/string.js
@@ -9,7 +9,8 @@
 // * Any missing methods have been noted in comments.
 // *
 // * XXX If you reuse this code at some point, update it to work with the new
-// * way that natives associated with Java objects are stored in NativeMap.
+// * way that natives associated with Java objects are stored in NativeMap
+// * and object/array references are passed as addresses.
 // */
 //
 ////################################################################
@@ -311,7 +312,7 @@
 //var internedStrings = J2ME.internedStrings;
 //
 //Native["java/lang/String.intern.()Ljava/lang/String;"] = function(addr) {
-//    var string = J2ME.fromJavaString(this);
+//    var string = J2ME.fromStringAddr(this._address);
 //
 //    var internedString = internedStrings.get(string);
 //

--- a/tests/gnu/testlet/vm/NativeTest.java
+++ b/tests/gnu/testlet/vm/NativeTest.java
@@ -7,7 +7,7 @@ public class NativeTest implements Testlet {
     public int getExpectedFail() { return 0; }
     public int getExpectedKnownFail() { return 0; }
     native static int getInt();
-    native static int fromJavaString(String string);
+    native static int fromStringAddr(String string);
     native static int decodeUtf8(byte[] string);
     native static long getLongReturnLong(long val);
     native static int getLongReturnInt(long val);
@@ -24,12 +24,12 @@ public class NativeTest implements Testlet {
 
         String s = "marco";
         th.check(s.substring(0, 0), "");
-        th.check(fromJavaString(s.substring(0, 0)), fromJavaString(""));
-        th.check(fromJavaString(s.substring(0, 1)), fromJavaString("m"));
+        th.check(fromStringAddr(s.substring(0, 0)), fromStringAddr(""));
+        th.check(fromStringAddr(s.substring(0, 1)), fromStringAddr("m"));
 
-        th.check(fromJavaString("\0"), 1);
+        th.check(fromStringAddr("\0"), 1);
         th.check(decodeUtf8("\0".getBytes()), 1);
-        th.check(fromJavaString(""), 0);
+        th.check(fromStringAddr(""), 0);
         th.check(decodeUtf8("".getBytes()), 0);
 
         th.check(getLongReturnLong(2L), 42L);

--- a/tests/native.js
+++ b/tests/native.js
@@ -41,11 +41,12 @@ Native["gnu/testlet/vm/NativeTest.nonStatic.(I)I"] = function(addr, val) {
   return val + 40;
 };
 
-Native["gnu/testlet/vm/NativeTest.fromJavaString.(Ljava/lang/String;)I"] = function(addr, str) {
-  return J2ME.fromJavaString(str).length;
+Native["gnu/testlet/vm/NativeTest.fromStringAddr.(Ljava/lang/String;)I"] = function(addr, stringAddr) {
+  return J2ME.fromStringAddr(stringAddr).length;
 };
 
-Native["gnu/testlet/vm/NativeTest.decodeUtf8.([B)I"] = function(addr, str) {
+Native["gnu/testlet/vm/NativeTest.decodeUtf8.([B)I"] = function(addr, strAddr) {
+  var str = J2ME.getArrayFromAddr(strAddr);
   return util.decodeUtf8(str).length;
 };
 
@@ -90,13 +91,14 @@ Native["javax/microedition/lcdui/TestAlert.isTextEditorReallyFocused.()Z"] = fun
   return (currentlyFocusedTextEditor && currentlyFocusedTextEditor.focused) ? 1 : 0;
 };
 
-Native["javax/microedition/lcdui/TestTextEditorFocus.isTextEditorReallyFocused.(Lcom/nokia/mid/ui/TextEditor;)Z"] = function(addr, textEditor) {
-  var nativeTextEditor = getNative(textEditor);
+Native["javax/microedition/lcdui/TestTextEditorFocus.isTextEditorReallyFocused.(Lcom/nokia/mid/ui/TextEditor;)Z"] =
+function(addr, textEditorAddr) {
+  var nativeTextEditor = NativeMap.get(textEditorAddr);
   return (currentlyFocusedTextEditor == nativeTextEditor && currentlyFocusedTextEditor.focused) ? 1 : 0;
 };
 
-Native["gnu/testlet/TestHarness.getNumDifferingPixels.(Ljava/lang/String;)I"] = function(addr, pathStr) {
-  var path = J2ME.fromJavaString(pathStr);
+Native["gnu/testlet/TestHarness.getNumDifferingPixels.(Ljava/lang/String;)I"] = function(addr, referenceImagePathAddr) {
+  var path = J2ME.fromStringAddr(referenceImagePathAddr);
   asyncImpl("I", new Promise(function(resolve, reject) {
     var gotCanvas = document.getElementById("canvas");
     var gotPixels = new Uint32Array(gotCanvas.getContext("2d").getImageData(0, 0, gotCanvas.width, gotCanvas.height).data.buffer);
@@ -153,7 +155,8 @@ Native["org/mozilla/io/TestNokiaPhoneStatusServer.sendFakeOfflineEvent.()V"] = f
   window.dispatchEvent(new CustomEvent("offline"));
 };
 
-Native["javax/microedition/media/TestAudioRecorder.convert3gpToAmr.([B)[B"] = function(addr, data) {
+Native["javax/microedition/media/TestAudioRecorder.convert3gpToAmr.([B)[B"] = function(addr, dataAddr) {
+  var data = J2ME.getArrayFromAddr(dataAddr);
   var converted = Media.convert3gpToAmr(new Uint8Array(data));
   var resultAddr = J2ME.newByteArray(converted.length);
   var result = J2ME.getArrayFromAddr(resultAddr);
@@ -161,16 +164,16 @@ Native["javax/microedition/media/TestAudioRecorder.convert3gpToAmr.([B)[B"] = fu
   return resultAddr;
 };
 
-Native["com/sun/midp/i18n/TestResourceConstants.setLanguage.(Ljava/lang/String;)V"] = function(addr, language) {
+Native["com/sun/midp/i18n/TestResourceConstants.setLanguage.(Ljava/lang/String;)V"] = function(addr, languageAddr) {
   MIDP.localizedStrings = null;
-  config.language = J2ME.fromJavaString(language);
+  config.language = J2ME.fromStringAddr(languageAddr);
 }
 
 // Many tests create FileConnection objects to files with the "/" root,
 // so add it to the list of valid roots.
 MIDP.fsRoots.push("/");
 
-Native["org/mozilla/MemorySampler.sampleMemory.(Ljava/lang/String;)V"] = function(addr, label) {
+Native["org/mozilla/MemorySampler.sampleMemory.(Ljava/lang/String;)V"] = function(addr, labelAddr) {
   if (typeof Benchmark !== "undefined") {
     asyncImpl("V", Benchmark.sampleMemory().then(function(memory) {
       var keys = ["totalSize", "domSize", "styleSize", "jsObjectsSize", "jsStringsSize", "jsOtherSize", "otherSize"];
@@ -179,7 +182,7 @@ Native["org/mozilla/MemorySampler.sampleMemory.(Ljava/lang/String;)V"] = functio
       rows.push(keys.map(function(k) { return memory[k] }));
       var RIGHT = Benchmark.RIGHT;
       var alignment = [RIGHT, RIGHT, RIGHT, RIGHT, RIGHT, RIGHT, RIGHT];
-      console.log((J2ME.fromJavaString(label) || "Memory sample") + ":\n" + Benchmark.prettyTable(rows, alignment));
+      console.log((J2ME.fromStringAddr(labelAddr) || "Memory sample") + ":\n" + Benchmark.prettyTable(rows, alignment));
     }));
   }
 };
@@ -259,8 +262,9 @@ Native["tests/background/DestroyMIDlet.maybePrintDone.()V"] = function(addr) {
   }
 };
 
-Native["javax/microedition/content/TestContentHandler.addInvocation.(Ljava/lang/String;Ljava/lang/String;)V"] = function(addr, argument, action) {
-  Content.addInvocation(J2ME.fromJavaString(argument), J2ME.fromJavaString(action));
+Native["javax/microedition/content/TestContentHandler.addInvocation.(Ljava/lang/String;Ljava/lang/String;)V"] =
+function(addr, argumentAddr, actionAddr) {
+  Content.addInvocation(J2ME.fromStringAddr(argumentAddr), J2ME.fromStringAddr(actionAddr));
 };
 
 var ContentHandlerMIDletStarted = 0;

--- a/vm/runtime.ts
+++ b/vm/runtime.ts
@@ -1169,13 +1169,7 @@ module J2ME {
       switch (classInfo.getClassNameSlow()) {
         case "java/lang/Object": Klasses.java.lang.Object = klass; break;
         case "java/lang/Class" : Klasses.java.lang.Class  = klass; break;
-        case "java/lang/String": Klasses.java.lang.String = klass;
-          Object.defineProperty(klass.prototype, "viewString", {
-            get: function () {
-              return fromJavaString(this);
-            }
-          });
-          break;
+        case "java/lang/String": Klasses.java.lang.String = klass; break;
         case "java/lang/Thread": Klasses.java.lang.Thread = klass; break;
         case "java/lang/Exception": Klasses.java.lang.Exception = klass; break;
         case "java/lang/InstantiationException": Klasses.java.lang.InstantiationException = klass; break;
@@ -2055,11 +2049,14 @@ module J2ME {
     return "[" + value.klass.classInfo.getClassNameSlow() + hashcode + "]";
   }
 
-  export function fromJavaString(value: java.lang.String): string {
-    if (!value) {
+  export function fromStringAddr(stringAddr: number): string {
+    if (!stringAddr) {
       return null;
     }
-    return util.fromJavaChars(getArrayFromAddr(value.value), value.offset, value.count);
+    // XXX Retrieve the characters directly from memory, without indirecting
+    // through getHandle and getArrayFromAddr.
+    var javaString = <java.lang.String>getHandle(stringAddr);
+    return util.fromJavaChars(getArrayFromAddr(javaString.value), javaString.offset, javaString.count);
   }
 
   export function checkDivideByZero(value: number) {

--- a/vm/runtime.ts
+++ b/vm/runtime.ts
@@ -2057,7 +2057,7 @@ module J2ME {
   }
 
   export function fromStringAddr(stringAddr: number): string {
-    if (!stringAddr) {
+    if (stringAddr === Constants.NULL) {
       return null;
     }
     // XXX Retrieve the characters directly from memory, without indirecting

--- a/vm/runtime.ts
+++ b/vm/runtime.ts
@@ -2060,6 +2060,7 @@ module J2ME {
     if (stringAddr === Constants.NULL) {
       return null;
     }
+
     // XXX Retrieve the characters directly from memory, without indirecting
     // through getHandle and getArrayFromAddr.
     var javaString = <java.lang.String>getHandle(stringAddr);


### PR DESCRIPTION
This changeset makes the interpreter pass objects/arrays to natives as addresses rather than handles.

To distinguish parameters that take addresses (and reduce the scope of changes), it appends "Addr" to the names of all object/array parameters and calls *getHandle* within natives to get handles as needed, frequently assigning them to a local variable with the same name as the parameter, minus the "Addr" suffix.

This changeset also replaces *fromJavaString* with *fromStringAddr* for conversion from a Java string (address) to a JS string.

In a few cases, it renames parameters to their names in the corresponding Java native method declarations. In a few cases, it inserts line breaks to limit line widths to <= 120 characters (since the "Addr" suffixes add length to already-long native method declarations). It also removes a java.lang.String.viewString function that doesn't seem to be used anywhere.
