### PR TITLE
Revert "pass objects/arrays to natives as addresses"

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ We use `Native` object in JS to handle creation and registration of `native` fun
 
 e.g.:
 
-    Native["java/lang/System.arraycopy.(Ljava/lang/Object;ILjava/lang/Object;II)V" = function(addr, srcAddr, srcOffset, dstAddr, dstOffset, length) {...};
+    Native["java/lang/System.arraycopy.(Ljava/lang/Object;ILjava/lang/Object;II)V" = function(addr, src, srcOffset, dst, dstOffset, length) {...};
 
 The first parameter of every native, *addr*, is the address in memory of the object on which the native is being called. If the native is static, then the value of *addr* is `Constants.NULL`. Call `getHandle(addr)` to get a handle to a JavaScript object that wraps the Java object with getters/setters for its fields.
 

--- a/int.ts
+++ b/int.ts
@@ -36,7 +36,7 @@ module J2ME {
       return "[" + getObjectInfo(o) + "] " + o.runtimeKlass.templateKlass.classInfo.getClassNameSlow();
     }
     if (o && o.klass === Klasses.java.lang.String) {
-      return "[" + getObjectInfo(o) + "] \"" + fromStringAddr(o._address) + "\"";
+      return "[" + getObjectInfo(o) + "] \"" + fromJavaString(o) + "\"";
     }
     return o ? ("[" + getObjectInfo(o) + "]") : "null";
   }
@@ -1775,7 +1775,9 @@ module J2ME {
                       args.unshift(i32[--sp]);
                       break;
                     case Kind.Reference:
-                      args.unshift(i32[--sp]);
+                      // XXX Update natives to expect addresses and stop passing
+                      // handles.
+                      args.unshift(getHandle(i32[--sp]));
                       break;
                     default:
                       release || assert(false, "Invalid Kind: " + Kind[kind]);

--- a/midp/background.js
+++ b/midp/background.js
@@ -67,9 +67,8 @@ Native["com/nokia/mid/s40/bg/BGUtils.getFGMIDletNumber.()I"] = function(addr) {
 
 MIDP.additionalProperties = {};
 
-Native["com/nokia/mid/s40/bg/BGUtils.launchIEMIDlet.(Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;)Z"] =
-function(addr, midletSuiteVendorAddr, midletNameAddr, midletNumber, startupNoteTextAddr, argsAddr) {
-  J2ME.fromStringAddr(argsAddr).split(";").splice(1).forEach(function(arg) {
+Native["com/nokia/mid/s40/bg/BGUtils.launchIEMIDlet.(Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;)Z"] = function(addr, midletSuiteVendor, midletName, midletNumber, startupNoteText, args) {
+  J2ME.fromJavaString(args).split(";").splice(1).forEach(function(arg) {
     var elems = arg.split("=");
     MIDP.additionalProperties[elems[0]] = elems[1];
   });

--- a/midp/codec.js
+++ b/midp/codec.js
@@ -139,30 +139,30 @@ Native["com/nokia/mid/s40/codec/DataEncoder.init.()V"] = function(addr) {
   NativeMap.set(addr, new DataEncoder());
 };
 
-Native["com/nokia/mid/s40/codec/DataEncoder.putStart.(ILjava/lang/String;)V"] = function(addr, tag, nameAddr) {
-  NativeMap.get(addr).putStart(tag, J2ME.fromStringAddr(nameAddr));
+Native["com/nokia/mid/s40/codec/DataEncoder.putStart.(ILjava/lang/String;)V"] = function(addr, tag, name) {
+  NativeMap.get(addr).putStart(tag, J2ME.fromJavaString(name));
 };
 
-Native["com/nokia/mid/s40/codec/DataEncoder.put.(ILjava/lang/String;Ljava/lang/String;)V"] = function(addr, tag, nameAddr, valueAddr) {
-  NativeMap.get(addr).put(tag, J2ME.fromStringAddr(nameAddr), J2ME.fromStringAddr(valueAddr));
+Native["com/nokia/mid/s40/codec/DataEncoder.put.(ILjava/lang/String;Ljava/lang/String;)V"] = function(addr, tag, name, value) {
+  NativeMap.get(addr).put(tag, J2ME.fromJavaString(name), J2ME.fromJavaString(value));
 };
 
-Native["com/nokia/mid/s40/codec/DataEncoder.put.(ILjava/lang/String;J)V"] = function(addr, tag, nameAddr, valueLow, valueHigh) {
-  NativeMap.get(addr).put(tag, J2ME.fromStringAddr(nameAddr), J2ME.longToNumber(valueLow, valueHigh));
+Native["com/nokia/mid/s40/codec/DataEncoder.put.(ILjava/lang/String;J)V"] = function(addr, tag, name, valueLow, valueHigh) {
+  NativeMap.get(addr).put(tag, J2ME.fromJavaString(name), J2ME.longToNumber(valueLow, valueHigh));
 };
 
-Native["com/nokia/mid/s40/codec/DataEncoder.put.(ILjava/lang/String;Z)V"] = function(addr, tag, nameAddr, value) {
-  NativeMap.get(addr).put(tag, J2ME.fromStringAddr(nameAddr), value);
+Native["com/nokia/mid/s40/codec/DataEncoder.put.(ILjava/lang/String;Z)V"] = function(addr, tag, name, value) {
+  NativeMap.get(addr).put(tag, J2ME.fromJavaString(name), value);
 };
 
-Native["com/nokia/mid/s40/codec/DataEncoder.put.(Ljava/lang/String;[BI)V"] = function(addr, nameAddr, dataAddr, length) {
-  var array = Array.prototype.slice.call(J2ME.getArrayFromAddr(dataAddr).subarray(0, length));
+Native["com/nokia/mid/s40/codec/DataEncoder.put.(Ljava/lang/String;[BI)V"] = function(addr, name, data, length) {
+  var array = Array.prototype.slice.call(data.subarray(0, length));
   array.constructor = Array;
-  NativeMap.get(addr).putNoTag(J2ME.fromStringAddr(nameAddr), array);
+  NativeMap.get(addr).putNoTag(J2ME.fromJavaString(name), array);
 };
 
-Native["com/nokia/mid/s40/codec/DataEncoder.putEnd.(ILjava/lang/String;)V"] = function(addr, tag, nameAddr) {
-  NativeMap.get(addr).putEnd(tag, J2ME.fromStringAddr(nameAddr));
+Native["com/nokia/mid/s40/codec/DataEncoder.putEnd.(ILjava/lang/String;)V"] = function(addr, tag, name) {
+  NativeMap.get(addr).putEnd(tag, J2ME.fromJavaString(name));
 };
 
 Native["com/nokia/mid/s40/codec/DataEncoder.getData.()[B"] = function(addr) {
@@ -177,8 +177,8 @@ Native["com/nokia/mid/s40/codec/DataEncoder.getData.()[B"] = function(addr) {
   return arrayAddr;
 };
 
-Native["com/nokia/mid/s40/codec/DataDecoder.init.([BII)V"] = function(addr, dataAddr, offset, length) {
-  NativeMap.set(addr, new DataDecoder(J2ME.getArrayFromAddr(dataAddr), offset, length));
+Native["com/nokia/mid/s40/codec/DataDecoder.init.([BII)V"] = function(addr, data, offset, length) {
+  NativeMap.set(addr, new DataDecoder(data, offset, length));
 };
 
 Native["com/nokia/mid/s40/codec/DataDecoder.getStart.(I)V"] = function(addr, tag) {

--- a/midp/content.js
+++ b/midp/content.js
@@ -36,15 +36,13 @@ var Content = (function() {
 
   addUnimplementedNative("com/sun/j2me/content/RegistryStore.findHandler0.(Ljava/lang/String;ILjava/lang/String;)Ljava/lang/String;", J2ME.Constants.NULL);
 
-  Native["com/sun/j2me/content/RegistryStore.register0.(ILjava/lang/String;Lcom/sun/j2me/content/ContentHandlerRegData;)Z"] =
-  function(addr, storageId, classNameAddr, handlerDataAddr) {
-    var handlerData = getHandle(handlerDataAddr);
-    var registerID = J2ME.fromStringAddr(handlerData.ID);
+  Native["com/sun/j2me/content/RegistryStore.register0.(ILjava/lang/String;Lcom/sun/j2me/content/ContentHandlerRegData;)Z"] = function(addr, storageId, className, handlerData) {
+    var registerID = J2ME.fromJavaString(getHandle(handlerData.ID));
     if (chRegisteredID && chRegisteredID != registerID) {
       console.warn("Dynamic registration ID doesn't match the configuration");
     }
 
-    var registerClassName = J2ME.fromStringAddr(classNameAddr);
+    var registerClassName = J2ME.fromJavaString(className);
     if (chRegisteredClassName && chRegisteredClassName != registerClassName) {
       console.warn("Dynamic registration class name doesn't match the configuration");
     }
@@ -71,8 +69,7 @@ var Content = (function() {
   // registered and unregisters it.
   addUnimplementedNative("com/sun/j2me/content/RegistryStore.unregister0.(Ljava/lang/String;)Z", 1);
 
-  Native["com/sun/j2me/content/RegistryStore.getHandler0.(Ljava/lang/String;Ljava/lang/String;I)Ljava/lang/String;"] =
-  function(addr, callerIdAddr, idAddr, mode) {
+  Native["com/sun/j2me/content/RegistryStore.getHandler0.(Ljava/lang/String;Ljava/lang/String;I)Ljava/lang/String;"] = function(addr, callerId, id, mode) {
     if (!chRegisteredClassName) {
       return J2ME.Constants.NULL;
     }
@@ -81,8 +78,8 @@ var Content = (function() {
       console.warn("com/sun/j2me/content/RegistryStore.getHandler0.(Ljava/lang/String;Ljava/lang/String;I)Ljava/lang/String; expected mode = 0");
     }
 
-    if (callerIdAddr !== J2ME.Constants.NULL) {
-      console.warn("com/sun/j2me/content/RegistryStore.getHandler0.(Ljava/lang/String;Ljava/lang/String;I)Ljava/lang/String; expected callerIdAddr = null");
+    if (callerId) {
+      console.warn("com/sun/j2me/content/RegistryStore.getHandler0.(Ljava/lang/String;Ljava/lang/String;I)Ljava/lang/String; expected callerId = null");
     }
 
     return J2ME.newString(serializeString([
@@ -130,10 +127,7 @@ var Content = (function() {
     }
   });
 
-  Native["com/sun/j2me/content/InvocationStore.get0.(Lcom/sun/j2me/content/InvocationImpl;ILjava/lang/String;IZ)I"] =
-  function(addr, invocAddr, suiteId, classNameAddr, mode, shouldBlock) {
-    var invoc = getHandle(invocAddr);
-
+  Native["com/sun/j2me/content/InvocationStore.get0.(Lcom/sun/j2me/content/InvocationImpl;ILjava/lang/String;IZ)I"] = function(addr, invoc, suiteId, className, mode, shouldBlock) {
     getInvocationCalled = true;
 
     if (!invocation) {

--- a/midp/crypto.js
+++ b/midp/crypto.js
@@ -3,8 +3,8 @@
 
 'use strict';
 
-Native["com/sun/midp/crypto/PRand.getRandomBytes.([BI)Z"] = function(addr, bAddr, nbytes) {
-    window.crypto.getRandomValues(J2ME.getArrayFromAddr(bAddr).subarray(0, nbytes));
+Native["com/sun/midp/crypto/PRand.getRandomBytes.([BI)Z"] = function(addr, b, nbytes) {
+    window.crypto.getRandomValues(b.subarray(0, nbytes));
     return 1;
 };
 
@@ -38,25 +38,17 @@ MIDP.bin2String = function(array) {
   return bin2StringResult.join("");
 };
 
-Native["com/sun/midp/crypto/MD5.nativeUpdate.([BII[I[I[I[I)V"] =
-function(addr, inBufAddr, inOff, inLen, stateAddr, numAddr, countAddr, dataAddr) {
-    var inBuf = J2ME.getArrayFromAddr(inBufAddr);
-    var data = J2ME.getArrayFromAddr(dataAddr);
+Native["com/sun/midp/crypto/MD5.nativeUpdate.([BII[I[I[I[I)V"] = function(addr, inBuf, inOff, inLen, state, num, count, data) {
     MIDP.getMD5Hasher(data).update(MIDP.bin2String(new Int8Array(inBuf.subarray(inOff, inOff + inLen))));
 };
 
-Native["com/sun/midp/crypto/MD5.nativeFinal.([BII[BI[I[I[I[I)V"] =
-function(addr, inBufAddr, inOff, inLen, outBufAddr, outOff, stateAddr, numAddr, countAddr, dataAddr) {
-    var inBuf;
-    var outBuf = J2ME.getArrayFromAddr(outBufAddr);
-    var data = J2ME.getArrayFromAddr(dataAddr);
+Native["com/sun/midp/crypto/MD5.nativeFinal.([BII[BI[I[I[I[I)V"] = function(addr, inBuf, inOff, inLen, outBuf, outOff, state, num, count, data) {
     var hasher = MIDP.getMD5Hasher(data);
 
-    if (inBufAddr !== J2ME.Constants.NULL) {
+    if (inBuf) {
         // digest passes `null` for inBuf, and there are no other callers,
         // so this should never happen; but I'm including it for completeness
         // (and in case a subclass ever uses it).
-        inBuf = J2ME.getArrayFromAddr(inBufAddr);
         hasher.update(MIDP.bin2String(inBuf.subarray(inOff, inOff + inLen)));
     }
 
@@ -72,8 +64,7 @@ function(addr, inBufAddr, inOff, inLen, outBufAddr, outOff, stateAddr, numAddr, 
     MIDP.hashers.delete(data);
 };
 
-Native["com/sun/midp/crypto/MD5.nativeClone.([I)V"] = function(addr, dataAddr) {
-    var data = J2ME.getArrayFromAddr(dataAddr);
+Native["com/sun/midp/crypto/MD5.nativeClone.([I)V"] = function(addr, data) {
     for (var key of MIDP.hashers.keys()) {
         if (util.compareTypedArrays(key, data)) {
             var value = MIDP.hashers.get(key);
@@ -116,15 +107,10 @@ function hexStringToBytes(hex) {
     return bytes;
 }
 
-Native["com/sun/midp/crypto/RSA.modExp.([B[B[B[B)I"] = function(addr, dataAddr, exponentAddr, modulusAddr, resultAddr) {
+Native["com/sun/midp/crypto/RSA.modExp.([B[B[B[B)I"] = function(addr, data, exponent, modulus, result) {
     // The jsbn library doesn't work well with typed arrays, so we're using this
     // hack of translating the numbers to hexadecimal strings before handing
     // them to jsbn (and we're getting the result back in a hex string).
-
-    var data = J2ME.getArrayFromAddr(dataAddr);
-    var exponent = J2ME.getArrayFromAddr(exponentAddr);
-    var modulus = J2ME.getArrayFromAddr(modulusAddr);
-    var result = J2ME.getArrayFromAddr(resultAddr);
 
     var bnBase = new BigInteger(bytesToHexString(data), 16);
     var bnExponent = new BigInteger(bytesToHexString(exponent), 16);
@@ -136,14 +122,7 @@ Native["com/sun/midp/crypto/RSA.modExp.([B[B[B[B)I"] = function(addr, dataAddr, 
     return remainder.length;
 };
 
-Native["com/sun/midp/crypto/ARC4.nativetx.([B[I[I[BII[BI)V"] =
-function(addr, SAddr, XAddr, YAddr, inbufAddr, inoff, inlen, outbufAddr, outoff) {
-    var S = J2ME.getArrayFromAddr(SAddr);
-    var X = J2ME.getArrayFromAddr(XAddr);
-    var Y = J2ME.getArrayFromAddr(YAddr);
-    var inbuf = J2ME.getArrayFromAddr(inbufAddr);
-    var outbuf = J2ME.getArrayFromAddr(outbufAddr);
-
+Native["com/sun/midp/crypto/ARC4.nativetx.([B[I[I[BII[BI)V"] = function(addr, S, X, Y, inbuf, inoff, inlen, outbuf, outoff) {
     var x = X[0];
     var y = Y[0];
 

--- a/midp/frameanimator.js
+++ b/midp/frameanimator.js
@@ -37,14 +37,13 @@ Native["com/nokia/mid/ui/frameanimator/FrameAnimator.init.()V"] = function(addr)
   NativeMap.set(addr, new FrameAnimator());
 };
 
-Native["com/nokia/mid/ui/frameanimator/FrameAnimator.register.(IISSLcom/nokia/mid/ui/frameanimator/FrameAnimatorListener;)Z"] =
-function(addr, x, y, maxFps, maxPps, listenerAddr) {
+Native["com/nokia/mid/ui/frameanimator/FrameAnimator.register.(IISSLcom/nokia/mid/ui/frameanimator/FrameAnimatorListener;)Z"] = function(addr, x, y, maxFps, maxPps, listener) {
   var nativeObject = NativeMap.get(addr);
   if (nativeObject.isRegistered()) {
     throw $.newIllegalStateException("FrameAnimator already registered");
   }
 
-  if (listenerAddr === J2ME.Constants.NULL) {
+  if (!listener) {
     throw $.newNullPointerException("listener is null");
   }
 
@@ -54,7 +53,6 @@ function(addr, x, y, maxFps, maxPps, listenerAddr) {
 
   // XXX return false if FrameAnimator.numRegistered >= FRAME_ANIMATOR_MAX_CONCURRENT
 
-  var listener = getHandle(listenerAddr);
   nativeObject.register(x, y, maxFps, maxPps, listener);
   return 1;
 };

--- a/midp/fs.js
+++ b/midp/fs.js
@@ -35,36 +35,33 @@ Native["com/sun/midp/midletsuite/MIDletSuiteStorage.getSecureFilenameBase.(I)Lja
 };
 
 Native["com/sun/midp/rms/RecordStoreUtil.exists.(Ljava/lang/String;Ljava/lang/String;I)Z"] =
-function(addr, filenameBaseAddr, nameAddr, ext) {
-    var path = RECORD_STORE_BASE + "/" + J2ME.fromStringAddr(filenameBaseAddr) +
-               "/" + J2ME.fromStringAddr(nameAddr) + "." + ext;
+function(addr, filenameBase, name, ext) {
+    var path = RECORD_STORE_BASE + "/" + J2ME.fromJavaString(filenameBase) + "/" + J2ME.fromJavaString(name) + "." + ext;
     return fs.exists(path) ? 1 : 0;
 };
 
 Native["com/sun/midp/rms/RecordStoreUtil.deleteFile.(Ljava/lang/String;Ljava/lang/String;I)V"] =
-function(addr, filenameBaseAddr, nameAddr, ext) {
-    var path = RECORD_STORE_BASE + "/" + J2ME.fromStringAddr(filenameBaseAddr) +
-               "/" + J2ME.fromStringAddr(nameAddr) + "." + ext;
+function(addr, filenameBase, name, ext) {
+    var path = RECORD_STORE_BASE + "/" + J2ME.fromJavaString(filenameBase) + "/" + J2ME.fromJavaString(name) + "." + ext;
     fs.remove(path);
 };
 
-Native["com/sun/midp/rms/RecordStoreFile.getNumberOfStores.(Ljava/lang/String;)I"] = function(addr, filenameBaseAddr) {
-    var path = RECORD_STORE_BASE + "/" + J2ME.fromStringAddr(filenameBaseAddr);
+Native["com/sun/midp/rms/RecordStoreFile.getNumberOfStores.(Ljava/lang/String;)I"] =
+function(addr, filenameBase) {
+    var path = RECORD_STORE_BASE + "/" + J2ME.fromJavaString(filenameBase);
     return fs.list(path).length;
 };
 
 Native["com/sun/midp/rms/RecordStoreFile.getRecordStoreList.(Ljava/lang/String;[Ljava/lang/String;)V"] =
-function(addr, filenameBaseAddr, namesAddr) {
-    var names = J2ME.getArrayFromAddr(namesAddr);
-    var path = RECORD_STORE_BASE + "/" + J2ME.fromStringAddr(filenameBaseAddr);
+function(addr, filenameBase, names) {
+    var path = RECORD_STORE_BASE + "/" + J2ME.fromJavaString(filenameBase);
     var files = fs.list(path);
     for (var i = 0; i < files.length; i++) {
         names[i] = J2ME.newString(files[i]);
     }
 };
 
-Native["com/sun/midp/rms/RecordStoreFile.spaceAvailableNewRecordStore0.(Ljava/lang/String;I)I"] =
-function(addr, filenameBaseAddr, storageId) {
+Native["com/sun/midp/rms/RecordStoreFile.spaceAvailableNewRecordStore0.(Ljava/lang/String;I)I"] = function(addr, filenameBase, storageId) {
     // Pretend there is 50MiB available.  Our implementation is backed
     // by IndexedDB, which has no actual limit beyond space available on device,
     // which I don't think we can determine.  But this should be sufficient
@@ -72,8 +69,7 @@ function(addr, filenameBaseAddr, storageId) {
     return 50 * 1024 * 1024;
 };
 
-Native["com/sun/midp/rms/RecordStoreFile.spaceAvailableRecordStore.(ILjava/lang/String;I)I"] =
-function(addr, handle, filenameBaseAddr, storageId) {
+Native["com/sun/midp/rms/RecordStoreFile.spaceAvailableRecordStore.(ILjava/lang/String;I)I"] = function(addr, handle, filenameBase, storageId) {
     // Pretend there is 50MiB available.  Our implementation is backed
     // by IndexedDB, which has no actual limit beyond space available on device,
     // which I don't think we can determine.  But this should be sufficient
@@ -82,11 +78,10 @@ function(addr, handle, filenameBaseAddr, storageId) {
 };
 
 Native["com/sun/midp/rms/RecordStoreFile.openRecordStoreFile.(Ljava/lang/String;Ljava/lang/String;I)I"] =
-function(addr, filenameBaseAddr, nameAddr, ext) {
+function(addr, filenameBase, name, ext) {
     var ctx = $.ctx;
 
-    var path = RECORD_STORE_BASE + "/" + J2ME.fromStringAddr(filenameBaseAddr) +
-               "/" + J2ME.fromStringAddr(nameAddr) + "." + ext;
+    var path = RECORD_STORE_BASE + "/" + J2ME.fromJavaString(filenameBase) + "/" + J2ME.fromJavaString(name) + "." + ext;
 
     function open() {
         asyncImpl("I", new Promise(function(resolve, reject) {
@@ -122,8 +117,7 @@ Native["com/sun/midp/rms/RecordStoreFile.setPosition.(II)V"] = function(addr, ha
     fs.setpos(handle, pos);
 };
 
-Native["com/sun/midp/rms/RecordStoreFile.readBytes.(I[BII)I"] = function(addr, handle, bufAddr, offset, numBytes) {
-    var buf = J2ME.getArrayFromAddr(bufAddr);
+Native["com/sun/midp/rms/RecordStoreFile.readBytes.(I[BII)I"] = function(addr, handle, buf, offset, numBytes) {
     var from = fs.getpos(handle);
     var to = from + numBytes;
     var readBytes = fs.read(handle, from, to);
@@ -139,8 +133,7 @@ Native["com/sun/midp/rms/RecordStoreFile.readBytes.(I[BII)I"] = function(addr, h
     return readBytes.byteLength;
 };
 
-Native["com/sun/midp/rms/RecordStoreFile.writeBytes.(I[BII)V"] = function(addr, handle, bufAddr, offset, numBytes) {
-    var buf = J2ME.getArrayFromAddr(bufAddr);
+Native["com/sun/midp/rms/RecordStoreFile.writeBytes.(I[BII)V"] = function(addr, handle, buf, offset, numBytes) {
     fs.write(handle, buf, offset, numBytes);
 };
 
@@ -160,8 +153,8 @@ Native["com/sun/midp/rms/RecordStoreFile.truncateFile.(II)V"] = function(addr, h
 MIDP.RecordStoreCache = [];
 
 Native["com/sun/midp/rms/RecordStoreSharedDBHeader.getLookupId0.(ILjava/lang/String;I)I"] =
-function(addr, suiteId, storeNameAddr, headerDataSize) {
-    var storeName = J2ME.fromStringAddr(storeNameAddr);
+function(addr, suiteId, jStoreName, headerDataSize) {
+    var storeName = J2ME.fromJavaString(jStoreName);
 
     var sharedHeader =
         MIDP.RecordStoreCache.filter(function(v) { return (v && v.suiteId == suiteId && v.storeName == storeName); })[0];
@@ -183,14 +176,12 @@ function(addr, suiteId, storeNameAddr, headerDataSize) {
     return sharedHeader.lookupId;
 };
 
-Native["com/sun/midp/rms/RecordStoreSharedDBHeader.shareCachedData0.(I[BI)I"] =
-function(addr, lookupId, headerDataAddr, headerDataSize) {
+Native["com/sun/midp/rms/RecordStoreSharedDBHeader.shareCachedData0.(I[BI)I"] = function(addr, lookupId, headerData, headerDataSize) {
     var sharedHeader = MIDP.RecordStoreCache[lookupId];
     if (!sharedHeader) {
         throw $.newIllegalStateException("invalid header lookup ID");
     }
 
-    var headerData = J2ME.getArrayFromAddr(headerDataAddr);
     if (!headerData) {
         throw $.newIllegalArgumentException("header data is null");
     }
@@ -206,13 +197,12 @@ function(addr, lookupId, headerDataAddr, headerDataSize) {
 };
 
 Native["com/sun/midp/rms/RecordStoreSharedDBHeader.updateCachedData0.(I[BII)I"] =
-function(addr, lookupId, headerDataAddr, headerDataSize, headerVersion) {
+function(addr, lookupId, headerData, headerDataSize, headerVersion) {
     var sharedHeader = MIDP.RecordStoreCache[lookupId];
     if (!sharedHeader) {
         throw $.newIllegalStateException("invalid header lookup ID");
     }
 
-    var headerData = J2ME.getArrayFromAddr(headerDataAddr);
     if (!headerData) {
         throw $.newIllegalArgumentException("header data is null");
     }
@@ -257,28 +247,28 @@ Native["com/sun/midp/rms/RecordStoreSharedDBHeader.finalize.()V"] =
     Native["com/sun/midp/rms/RecordStoreSharedDBHeader.cleanup0.()V"];
 
 Native["com/sun/midp/rms/RecordStoreRegistry.getRecordStoreListeners.(ILjava/lang/String;)[I"] =
-function(addr, suiteId, storeNameAddr) {
+function(addr, suiteId, storeName) {
     console.warn("RecordStoreRegistry.getRecordStoreListeners.(IL...String;)[I not implemented (" +
-                 suiteId + ", " + J2ME.fromStringAddr(storeNameAddr) + ")");
+                 suiteId + ", " + J2ME.fromJavaString(storeName) + ")");
     return J2ME.Constants.NULL;
 };
 
 Native["com/sun/midp/rms/RecordStoreRegistry.sendRecordStoreChangeEvent.(ILjava/lang/String;II)V"] =
-function(addr, suiteId, storeNameAddr, changeType, recordId) {
+function(addr, suiteId, storeName, changeType, recordId) {
     console.warn("RecordStoreRegistry.sendRecordStoreChangeEvent.(IL...String;II)V not implemented (" +
-                 suiteId + ", " + J2ME.fromStringAddr(storeNameAddr) + ", " + changeType + ", " + recordId + ")");
+                 suiteId + ", " + J2ME.fromJavaString(storeName) + ", " + changeType + ", " + recordId + ")");
 };
 
 Native["com/sun/midp/rms/RecordStoreRegistry.startRecordStoreListening.(ILjava/lang/String;)V"] =
-function(addr, suiteId, storeNameAddr) {
+function(addr, suiteId, storeName) {
     console.warn("RecordStoreRegistry.startRecordStoreListening.(IL...String;)V not implemented (" +
-                 suiteId + ", " + J2ME.fromStringAddr(storeNameAddr) + ")");
+                 suiteId + ", " + J2ME.fromJavaString(storeName) + ")");
 };
 
 Native["com/sun/midp/rms/RecordStoreRegistry.stopRecordStoreListening.(ILjava/lang/String;)V"] =
-function(addr, suiteId, storeNameAddr) {
+function(addr, suiteId, storeName) {
     console.warn("RecordStoreRegistry.stopRecordStoreListening.(IL...String;)V not implemented (" +
-                 suiteId + ", " + J2ME.fromStringAddr(storeNameAddr) + ")");
+                 suiteId + ", " + J2ME.fromJavaString(storeName) + ")");
 };
 
 Native["com/sun/midp/rms/RecordStoreRegistry.stopAllRecordStoreListeners.(I)V"] = function(addr, taskId) {
@@ -286,7 +276,7 @@ Native["com/sun/midp/rms/RecordStoreRegistry.stopAllRecordStoreListeners.(I)V"] 
 };
 
 Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.create.()V"] = function(addr) {
-    var pathname = J2ME.fromStringAddr(getHandle(addr).nativePath);
+    var pathname = J2ME.fromJavaString(getHandle(getHandle(addr).nativePath));
     DEBUG_FS && console.log("DefaultFileHandler.create: " + pathname);
     if (config.ignoredFiles.has(pathname)) {
         DEBUG_FS && console.log("DefaultFileHandler.create: ignored file");
@@ -301,7 +291,7 @@ Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.create.()V"] = function(addr
 };
 
 Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.exists.()Z"] = function(addr) {
-    var pathname = J2ME.fromStringAddr(getHandle(addr).nativePath);
+    var pathname = J2ME.fromJavaString(getHandle(getHandle(addr).nativePath));
     DEBUG_FS && console.log("DefaultFileHandler.exists: " + pathname);
     if (config.ignoredFiles.has(pathname)) {
         DEBUG_FS && console.log("DefaultFileHandler.exists: ignored file");
@@ -314,7 +304,7 @@ Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.exists.()Z"] = function(addr
 };
 
 Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.isDirectory.()Z"] = function(addr) {
-    var pathname = J2ME.fromStringAddr(getHandle(addr).nativePath);
+    var pathname = J2ME.fromJavaString(getHandle(getHandle(addr).nativePath));
     DEBUG_FS && console.log("DefaultFileHandler.isDirectory: " + pathname);
     if (config.ignoredFiles.has(pathname)) {
         DEBUG_FS && console.log("DefaultFileHandler.isDirectory: ignored file");
@@ -328,7 +318,7 @@ Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.isDirectory.()Z"] = function
 }
 
 Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.delete.()V"] = function(addr) {
-    var pathname = J2ME.fromStringAddr(getHandle(addr).nativePath);
+    var pathname = J2ME.fromJavaString(getHandle(getHandle(addr).nativePath));
     DEBUG_FS && console.log("DefaultFileHandler.delete: " + pathname);
     if (config.ignoredFiles.has(pathname)) {
         DEBUG_FS && console.log("DefaultFileHandler.delete: ignored file");
@@ -341,9 +331,9 @@ Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.delete.()V"] = function(addr
 };
 
 
-Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.rename0.(Ljava/lang/String;)V"] = function(addr, newNameAddr) {
-    var pathname = J2ME.fromStringAddr(getHandle(addr).nativePath);
-    var newPathname = J2ME.fromStringAddr(newNameAddr);
+Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.rename0.(Ljava/lang/String;)V"] = function(addr, newName) {
+    var pathname = J2ME.fromJavaString(getHandle(getHandle(addr).nativePath));
+    var newPathname = J2ME.fromJavaString(newName);
     DEBUG_FS && console.log("DefaultFileHandler.rename0: " + pathname + " to " + newPathname);
 
     if (fs.exists(newPathname)) {
@@ -356,7 +346,7 @@ Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.rename0.(Ljava/lang/String;)
 };
 
 Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.truncate.(J)V"] = function(addr, byteOffsetL, byteOffsetH) {
-    var pathname = J2ME.fromStringAddr(getHandle(addr).nativePath);
+    var pathname = J2ME.fromJavaString(getHandle(getHandle(addr).nativePath));
     DEBUG_FS && console.log("DefaultFileHandler.lastModified: " + pathname);
     if (config.ignoredFiles.has(pathname)) {
         DEBUG_FS && console.log("DefaultFileHandler.lastModified: ignored file");
@@ -379,7 +369,7 @@ Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.truncate.(J)V"] = function(a
 };
 
 Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.fileSize.()J"] = function(addr) {
-    var pathname = J2ME.fromStringAddr(getHandle(addr).nativePath);
+    var pathname = J2ME.fromJavaString(getHandle(getHandle(addr).nativePath));
     DEBUG_FS && console.log("DefaultFileHandler.fileSize: " + pathname);
     if (config.ignoredFiles.has(pathname)) {
         DEBUG_FS && console.log("DefaultFileHandler.fileSize: ignored file");
@@ -393,7 +383,7 @@ addUnimplementedNative("com/sun/cdc/io/j2me/file/DefaultFileHandler.directorySiz
                        function() { return J2ME.returnLongValue(0) });
 
 Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.canRead.()Z"] = function(addr) {
-    var pathname = J2ME.fromStringAddr(getHandle(addr).nativePath);
+    var pathname = J2ME.fromJavaString(getHandle(getHandle(addr).nativePath));
     DEBUG_FS && console.log("DefaultFileHandler.canRead: " + pathname);
     if (config.ignoredFiles.has(pathname)) {
         DEBUG_FS && console.log("DefaultFileHandler.canRead: ignored file");
@@ -404,7 +394,7 @@ Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.canRead.()Z"] = function(add
 };
 
 Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.canWrite.()Z"] = function(addr) {
-    var pathname = J2ME.fromStringAddr(getHandle(addr).nativePath);
+    var pathname = J2ME.fromJavaString(getHandle(getHandle(addr).nativePath));
     DEBUG_FS && console.log("DefaultFileHandler.canWrite: " + pathname);
     if (config.ignoredFiles.has(pathname)) {
         DEBUG_FS && console.log("DefaultFileHandler.canWrite: ignored file");
@@ -421,7 +411,7 @@ Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.isHidden0.()Z"] = function(a
 };
 
 Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.setReadable.(Z)V"] = function(addr) {
-    var pathname = J2ME.fromStringAddr(getHandle(addr).nativePath);
+    var pathname = J2ME.fromJavaString(getHandle(getHandle(addr).nativePath));
     DEBUG_FS && console.log("DefaultFileHandler.setReadable: " + pathname);
     if (config.ignoredFiles.has(pathname)) {
         DEBUG_FS && console.log("DefaultFileHandler.setReadable: ignored file");
@@ -436,7 +426,7 @@ Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.setReadable.(Z)V"] = functio
 };
 
 Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.setWritable.(Z)V"] = function(addr) {
-    var pathname = J2ME.fromStringAddr(getHandle(addr).nativePath);
+    var pathname = J2ME.fromJavaString(getHandle(getHandle(addr).nativePath));
     DEBUG_FS && console.log("DefaultFileHandler.setWritable: " + pathname);
     if (config.ignoredFiles.has(pathname)) {
         DEBUG_FS && console.log("DefaultFileHandler.setWritable: ignored file");
@@ -453,7 +443,7 @@ Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.setWritable.(Z)V"] = functio
 addUnimplementedNative("com/sun/cdc/io/j2me/file/DefaultFileHandler.setHidden0.(Z)V");
 
 Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.mkdir.()V"] = function(addr) {
-    var pathname = J2ME.fromStringAddr(getHandle(addr).nativePath);
+    var pathname = J2ME.fromJavaString(getHandle(getHandle(addr).nativePath));
     DEBUG_FS && console.log("DefaultFileHandler.mkdir: " + pathname);
 
     if (!fs.mkdir(pathname)) {
@@ -468,7 +458,7 @@ addUnimplementedNative("com/sun/cdc/io/j2me/file/DefaultFileHandler.totalSize.()
                        function() { return J2ME.returnLongValue(1024 * 1024 * 1024) });
 
 Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.lastModified.()J"] = function(addr) {
-    var pathname = J2ME.fromStringAddr(getHandle(addr).nativePath);
+    var pathname = J2ME.fromJavaString(getHandle(getHandle(addr).nativePath));
     DEBUG_FS && console.log("DefaultFileHandler.lastModified: " + pathname);
     if (config.ignoredFiles.has(pathname)) {
         DEBUG_FS && console.log("DefaultFileHandler.lastModified: ignored file");
@@ -491,7 +481,7 @@ MIDP.markFileHandler = function(fileHandler, mode, state) {
 };
 
 MIDP.openFileHandler = function(fileHandler, mode) {
-    var pathname = J2ME.fromStringAddr(fileHandler.nativePath);
+    var pathname = J2ME.fromJavaString(getHandle(fileHandler.nativePath));
     DEBUG_FS && console.log("MIDP.openFileHandler: " + pathname + " for " + mode);
     if (config.ignoredFiles.has(pathname)) {
         DEBUG_FS && console.log("MIDP.openFileHandler: ignored file");
@@ -534,7 +524,7 @@ MIDP.openFileHandler = function(fileHandler, mode) {
 };
 
 MIDP.closeFileHandler = function(fileHandler, mode) {
-    DEBUG_FS && console.log("MIDP.closeFileHandler: " + J2ME.fromStringAddr(fileHandler.nativePath) + " for " + mode);
+    DEBUG_FS && console.log("MIDP.closeFileHandler: " + J2ME.fromJavaString(getHandle(fileHandler.nativePath)) + " for " + mode);
     if (fileHandler.nativeDescriptor === -1) {
         DEBUG_FS && console.log("MIDP.closeFileHandler: ignored file");
         return;
@@ -582,10 +572,9 @@ Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.closeForReadWrite.()V"] = fu
     MIDP.closeFileHandler(getHandle(addr), "write");
 };
 
-Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.read.([BII)I"] = function(addr, bAddr, off, len) {
+Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.read.([BII)I"] = function(addr, b, off, len) {
     var self = getHandle(addr);
-    var b = J2ME.getArrayFromAddr(bAddr);
-    DEBUG_FS && console.log("DefaultFileHandler.read: " + J2ME.fromStringAddr(self.nativePath) + " " + len);
+    DEBUG_FS && console.log("DefaultFileHandler.read: " + J2ME.fromJavaString(getHandle(self.nativePath)) + " " + len);
     if (self.nativeDescriptor === -1) {
         DEBUG_FS && console.log("DefaultFileHandler.read: ignored file");
         return -1;
@@ -610,7 +599,7 @@ Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.read.([BII)I"] = function(ad
 
 Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.skip.(J)J"] = function(addr, l, h) {
     var self = getHandle(addr);
-    DEBUG_FS && console.log("DefaultFileHandler.skip: " + J2ME.fromStringAddr(self.nativePath));
+    DEBUG_FS && console.log("DefaultFileHandler.skip: " + J2ME.fromJavaString(getHandle(self.nativePath)));
     if (self.nativeDescriptor === -1) {
         DEBUG_FS && console.log("DefaultFileHandler.skip: ignored file");
         return -1;
@@ -634,10 +623,9 @@ Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.skip.(J)J"] = function(addr,
     }
 };
 
-Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.write.([BII)I"] = function(addr, bAddr, off, len) {
+Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.write.([BII)I"] = function(addr, b, off, len) {
     var self = getHandle(addr);
-    var b = J2ME.getArrayFromAddr(bAddr);
-    DEBUG_FS && console.log("DefaultFileHandler.write: " + J2ME.fromStringAddr(self.nativePath) + " " + off + "+" + len);
+    DEBUG_FS && console.log("DefaultFileHandler.write: " + J2ME.fromJavaString(getHandle(self.nativePath)) + " " + off + "+" + len);
     if (self.nativeDescriptor === -1) {
         DEBUG_FS && console.log("DefaultFileHandler.write: ignored file");
         return preemptingImpl("I", len);
@@ -652,7 +640,7 @@ Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.write.([BII)I"] = function(a
 
 Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.positionForWrite.(J)V"] = function(addr, offsetLow, offsetHigh) {
     var self = getHandle(addr);
-    DEBUG_FS && console.log("DefaultFileHandler.positionForWrite: " + J2ME.fromStringAddr(self.nativePath));
+    DEBUG_FS && console.log("DefaultFileHandler.positionForWrite: " + J2ME.fromJavaString(getHandle(self.nativePath)));
     if (self.nativeDescriptor === -1) {
         DEBUG_FS && console.log("DefaultFileHandler.positionForWrite: ignored file");
         return;
@@ -664,7 +652,7 @@ Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.positionForWrite.(J)V"] = fu
 
 Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.flush.()V"] = function(addr) {
     var self = getHandle(addr);
-    DEBUG_FS && console.log("DefaultFileHandler.flush: " + J2ME.fromStringAddr(self.nativePath));
+    DEBUG_FS && console.log("DefaultFileHandler.flush: " + J2ME.fromJavaString(getHandle(self.nativePath)));
     if (self.nativeDescriptor === -1) {
         DEBUG_FS && console.log("DefaultFileHandler.flush: ignored file");
         return;
@@ -676,7 +664,7 @@ Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.flush.()V"] = function(addr)
 
 Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.close.()V"] = function(addr) {
     var self = getHandle(addr);
-    DEBUG_FS && console.log("DefaultFileHandler.close: " + J2ME.fromStringAddr(self.nativePath));
+    DEBUG_FS && console.log("DefaultFileHandler.close: " + J2ME.fromJavaString(getHandle(self.nativePath)));
 
     MIDP.closeFileHandler(self, "read");
     MIDP.closeFileHandler(self, "write");
@@ -696,7 +684,7 @@ MIDP.openDirHandle = 0;
 
 Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.openDir.()J"] = function(addr) {
     var self = getHandle(addr);
-    var pathname = J2ME.fromStringAddr(self.nativePath);
+    var pathname = J2ME.fromJavaString(getHandle(self.nativePath));
     DEBUG_FS && console.log("DefaultFileHandler.openDir: " + pathname);
 
     try {
@@ -728,16 +716,15 @@ Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.dirGetNextFile.(JZ)Ljava/lan
 function(addr, dirHandleLow, dirHandleHigh, includeHidden) {
     var iterator = MIDP.openDirs.get(J2ME.longToNumber(dirHandleLow, dirHandleHigh));
     var nextFile = iterator.files[++iterator.index];
-    DEBUG_FS && console.log(iterator.index + " " + nextFile);
+DEBUG_FS && console.log(iterator.index + " " + nextFile);
     return nextFile ? J2ME.newString(nextFile) : J2ME.Constants.NULL;
 };
 
 Native["com/sun/cdc/io/j2me/file/DefaultFileHandler.getNativePathForRoot.(Ljava/lang/String;)Ljava/lang/String;"] =
-function(addr, rootAddr) {
-    var root = J2ME.fromStringAddr(rootAddr);
-    // XXX Ensure root is in MIDP.fsRoots?
-    DEBUG_FS && console.log("getNativePathForRoot: " + root);
-    var nativePath = J2ME.newString("/" + root);
+function(addr, root) {
+// XXX Ensure root is in MIDP.fsRoots?
+DEBUG_FS && console.log("getNativePathForRoot: " + J2ME.fromJavaString(root));
+    var nativePath = J2ME.newString("/" + J2ME.fromJavaString(root));
     return nativePath;
 };
 
@@ -761,13 +748,12 @@ Native["com/sun/cdc/io/j2me/file/Protocol.available.()I"] = function(addr) {
     var fileHandler = getHandle(self.fileHandler);
     var fd = fileHandler.nativeDescriptor;
     var available = fs.getsize(fd) - fs.getpos(fd);
-    DEBUG_FS && console.log("Protocol.available: " + J2ME.fromStringAddr(fileHandler.nativePath) + ": " + available);
+    DEBUG_FS && console.log("Protocol.available: " + J2ME.fromJavaString(fileHandler.nativePath) + ": " + available);
     return available;
 };
 
-Native["com/sun/midp/io/j2me/storage/RandomAccessStream.open.(Ljava/lang/String;I)I"] =
-function(addr, fileNameAddr, mode) {
-    var path = "/" + J2ME.fromStringAddr(fileNameAddr);
+Native["com/sun/midp/io/j2me/storage/RandomAccessStream.open.(Ljava/lang/String;I)I"] = function(addr, fileName, mode) {
+    var path = "/" + J2ME.fromJavaString(fileName);
 
     var ctx = $.ctx;
 
@@ -796,8 +782,7 @@ function(addr, fileNameAddr, mode) {
 };
 
 Native["com/sun/midp/io/j2me/storage/RandomAccessStream.read.(I[BII)I"] =
-function(addr, handle, bufferAddr, offset, length) {
-    var buffer = J2ME.getArrayFromAddr(bufferAddr);
+function(addr, handle, buffer, offset, length) {
     var from = fs.getpos(handle);
     var to = from + length;
     var readBytes = fs.read(handle, from, to);
@@ -814,8 +799,7 @@ function(addr, handle, bufferAddr, offset, length) {
 };
 
 Native["com/sun/midp/io/j2me/storage/RandomAccessStream.write.(I[BII)V"] =
-function(addr, handle, bufferAddr, offset, length) {
-    var buffer = J2ME.getArrayFromAddr(bufferAddr);
+function(addr, handle, buffer, offset, length) {
     fs.write(handle, buffer, offset, length);
 };
 

--- a/midp/localmsg.js
+++ b/midp/localmsg.js
@@ -1037,8 +1037,8 @@ var localmsgServerWait = null;
 // XXX Consolidate the objects we store in this map with those in NativeMap.
 NativeConnectionMap = Object.create(null);
 
-Native["org/mozilla/io/LocalMsgConnection.init.(Ljava/lang/String;)V"] = function(addr, nameAddr) {
-    var name = J2ME.fromStringAddr(nameAddr);
+Native["org/mozilla/io/LocalMsgConnection.init.(Ljava/lang/String;)V"] = function(addr, jName) {
+    var name = J2ME.fromJavaString(jName);
 
     var info = {
       server: (name[2] == ":"),
@@ -1100,8 +1100,7 @@ Native["org/mozilla/io/LocalMsgConnection.waitConnection.()V"] = function(addr) 
     asyncImpl("V", connection.waitConnection());
 };
 
-Native["org/mozilla/io/LocalMsgConnection.sendData.([BII)V"] = function(addr, dataAddr, offset, length) {
-    var data = J2ME.getArrayFromAddr(dataAddr);
+Native["org/mozilla/io/LocalMsgConnection.sendData.([BII)V"] = function(addr, data, offset, length) {
     var connection = NativeConnectionMap[addr];
     var info = NativeMap.get(addr);
 
@@ -1117,8 +1116,7 @@ Native["org/mozilla/io/LocalMsgConnection.sendData.([BII)V"] = function(addr, da
     }
 };
 
-Native["org/mozilla/io/LocalMsgConnection.receiveData.([B)I"] = function(addr, dataAddr) {
-    var data = J2ME.getArrayFromAddr(dataAddr);
+Native["org/mozilla/io/LocalMsgConnection.receiveData.([B)I"] = function(addr, data) {
     var connection = NativeConnectionMap[addr];
     var info = NativeMap.get(addr);
 

--- a/midp/location.js
+++ b/midp/location.js
@@ -70,9 +70,7 @@ Native["com/sun/j2me/location/PlatformLocationProvider.getListOfLocationProvider
 
 addUnimplementedNative("com/sun/j2me/location/CriteriaImpl.initNativeClass.()V");
 
-Native["com/sun/j2me/location/PlatformLocationProvider.getBestProviderByCriteriaImpl.(Lcom/sun/j2me/location/CriteriaImpl;)Z"] =
-function(addr, criteriaAddr) {
-    var criteria = getHandle(criteriaAddr);
+Native["com/sun/j2me/location/PlatformLocationProvider.getBestProviderByCriteriaImpl.(Lcom/sun/j2me/location/CriteriaImpl;)Z"] = function(addr, criteria) {
     criteria.providerName = J2ME.newString(Location.PROVIDER_NAME);
     return 1;
 };
@@ -80,7 +78,7 @@ function(addr, criteriaAddr) {
 addUnimplementedNative("com/sun/j2me/location/LocationProviderInfo.initNativeClass.()V");
 addUnimplementedNative("com/sun/j2me/location/LocationInfo.initNativeClass.()V");
 
-Native["com/sun/j2me/location/PlatformLocationProvider.open.(Ljava/lang/String;)I"] = function(addr, nameAddr) {
+Native["com/sun/j2me/location/PlatformLocationProvider.open.(Ljava/lang/String;)I"] = function(addr, name) {
     var provider = new LocationProvider();
     provider.start();
     var id = Location.Providers.nextId;
@@ -95,9 +93,7 @@ Native["com/sun/j2me/location/PlatformLocationProvider.resetImpl.(I)V"] = functi
     Location.Providers[providerId] = null;
 };
 
-Native["com/sun/j2me/location/PlatformLocationProvider.getCriteria.(Ljava/lang/String;Lcom/sun/j2me/location/LocationProviderInfo;)Z"] =
-function(addr, nameAddr, criteriaAddr) {
-    var criteria = getHandle(criteriaAddr);
+Native["com/sun/j2me/location/PlatformLocationProvider.getCriteria.(Ljava/lang/String;Lcom/sun/j2me/location/LocationProviderInfo;)Z"] = function(addr, name, criteria) {
     criteria.canReportAltitude = 1;
     criteria.canReportSpeedCource = 1;
     criteria.averageResponseTime = 10000;
@@ -108,9 +104,7 @@ Native["com/sun/j2me/location/PlatformLocationProvider.setUpdateIntervalImpl.(II
     console.warn("com/sun/j2me/location/PlatformLocationProvider.setUpdateIntervalImpl.(II)V not implemented");
 };
 
-Native["com/sun/j2me/location/PlatformLocationProvider.getLastLocationImpl.(ILcom/sun/j2me/location/LocationInfo;)Z"] =
-function(addr, providerId, locationInfoAddr) {
-    var locationInfo = getHandle(locationInfoAddr);
+Native["com/sun/j2me/location/PlatformLocationProvider.getLastLocationImpl.(ILcom/sun/j2me/location/LocationInfo;)Z"] = function(addr, providerId, locationInfo) {
     var provider = Location.Providers[providerId];
     var pos = provider.position;
     locationInfo.isValid = 1;

--- a/midp/media.js
+++ b/midp/media.js
@@ -133,9 +133,8 @@ Media.convert3gpToAmr = function(inBuffer) {
     return outBuffer.subarray(0, outOffset);
 };
 
-Native["com/sun/mmedia/DefaultConfiguration.nListContentTypesOpen.(Ljava/lang/String;)I"] =
-function(addr, protocolAddr) {
-    var protocol = J2ME.fromStringAddr(protocolAddr);
+Native["com/sun/mmedia/DefaultConfiguration.nListContentTypesOpen.(Ljava/lang/String;)I"] = function(addr, jProtocol) {
+    var protocol = J2ME.fromJavaString(jProtocol);
     var types = [];
     if (protocol) {
         types = Media.ContentTypes[protocol].slice();
@@ -172,8 +171,8 @@ Native["com/sun/mmedia/DefaultConfiguration.nListContentTypesClose.(I)V"] = func
     Media.ListCache.remove(hdlr);
 };
 
-Native["com/sun/mmedia/DefaultConfiguration.nListProtocolsOpen.(Ljava/lang/String;)I"] = function(addr, mimeAddr) {
-    var mime = J2ME.fromStringAddr(mimeAddr);
+Native["com/sun/mmedia/DefaultConfiguration.nListProtocolsOpen.(Ljava/lang/String;)I"] = function(addr, jMime) {
+    var mime = J2ME.fromJavaString(jMime);
     var protocols = [];
     for (var protocol in Media.ContentTypes) {
         if (!mime || Media.ContentTypes[protocol].indexOf(mime) >= 0) {
@@ -1018,8 +1017,8 @@ AudioRecorder.prototype.close = function() {
     }.bind(this));
 };
 
-Native["com/sun/mmedia/PlayerImpl.nInit.(IILjava/lang/String;)I"] = function(addr, appId, pId, URIAddr) {
-    var url = J2ME.fromStringAddr(URIAddr);
+Native["com/sun/mmedia/PlayerImpl.nInit.(IILjava/lang/String;)I"] = function(addr, appId, pId, jURI) {
+    var url = J2ME.fromJavaString(jURI);
     var id = pId + (appId << 15);
     Media.PlayerCache[id] = new PlayerContainer(url, pId);
     return id;
@@ -1052,8 +1051,8 @@ Native["com/sun/mmedia/PlayerImpl.nIsHandledByDevice.(I)Z"] = function(addr, han
     return Media.PlayerCache[handle].isHandledByDevice() ? 1 : 0;
 };
 
-Native["com/sun/mmedia/PlayerImpl.nRealize.(ILjava/lang/String;)Z"] = function(addr, handle, mimeAddr) {
-    var mime = J2ME.fromStringAddr(mimeAddr);
+Native["com/sun/mmedia/PlayerImpl.nRealize.(ILjava/lang/String;)Z"] = function(addr, handle, jMime) {
+    var mime = J2ME.fromJavaString(jMime);
     var player = Media.PlayerCache[handle];
     asyncImpl("Z", player.realize(mime));
 };
@@ -1068,16 +1067,15 @@ Native["com/sun/mmedia/MediaDownload.nGetFirstPacketSize.(I)I"] = function(addr,
     return player.getBufferSize() >>> 1;
 };
 
-Native["com/sun/mmedia/MediaDownload.nBuffering.(I[BII)I"] = function(addr, handle, bufferAddr, offset, size) {
+Native["com/sun/mmedia/MediaDownload.nBuffering.(I[BII)I"] = function(addr, handle, buffer, offset, size) {
     var player = Media.PlayerCache[handle];
     var bufferSize = player.getBufferSize();
 
     // Check the parameters.
-    if (bufferAddr === J2ME.Constants.NULL || size === 0) {
+    if (buffer === null || size === 0) {
         return bufferSize >>> 1;
     }
 
-    var buffer = J2ME.getArrayFromAddr(bufferAddr);
     player.writeBuffer(buffer.subarray(offset, offset + size));
 
     // Returns the package size and set it to the half of the java buffer size.
@@ -1234,7 +1232,7 @@ Native["com/sun/mmedia/DirectPlayer.nGetDuration.(I)I"] = function(addr, handle)
     }
 };
 
-Native["com/sun/mmedia/DirectRecord.nSetLocator.(ILjava/lang/String;)I"] = function(addr, handle, locatorAddr) {
+Native["com/sun/mmedia/DirectRecord.nSetLocator.(ILjava/lang/String;)I"] = function(addr, handle, locator) {
     // Let the DirectRecord class handle writing to files / uploading via HTTP
     return 0;
 };
@@ -1243,8 +1241,7 @@ Native["com/sun/mmedia/DirectRecord.nGetRecordedSize.(I)I"] = function(addr, han
     return Media.PlayerCache[handle].getRecordedSize();
 };
 
-Native["com/sun/mmedia/DirectRecord.nGetRecordedData.(III[B)I"] = function(addr, handle, offset, size, bufferAddr) {
-    var buffer = J2ME.getArrayFromAddr(bufferAddr);
+Native["com/sun/mmedia/DirectRecord.nGetRecordedData.(III[B)I"] = function(addr, handle, offset, size, buffer) {
     Media.PlayerCache[handle].getRecordedData(offset, size, buffer);
     return 1;
 };
@@ -1419,8 +1416,8 @@ Native["com/sun/mmedia/NativeTonePlayer.nStopTone.(I)Z"] = function(addr, appId)
     return 1;
 };
 
-Native["com/sun/mmedia/DirectPlayer.nStartSnapshot.(ILjava/lang/String;)V"] = function(addr, handle, imageTypeAddr) {
-    Media.PlayerCache[handle].startSnapshot(J2ME.fromStringAddr(imageTypeAddr));
+Native["com/sun/mmedia/DirectPlayer.nStartSnapshot.(ILjava/lang/String;)V"] = function(addr, handle, imageType) {
+    Media.PlayerCache[handle].startSnapshot(J2ME.fromJavaString(imageType));
 };
 
 Native["com/sun/mmedia/DirectPlayer.nGetSnapshotData.(I)[B"] = function(addr, handle) {
@@ -1432,7 +1429,7 @@ Native["com/sun/amms/GlobalMgrImpl.nCreatePeer.()I"] = function(addr) {
     return 1;
 };
 
-Native["com/sun/amms/GlobalMgrImpl.nGetControlPeer.([B)I"] = function(addr, typeNameAddr) {
+Native["com/sun/amms/GlobalMgrImpl.nGetControlPeer.([B)I"] = function(addr, typeName) {
     console.warn("com/sun/amms/GlobalMgrImpl.nGetControlPeer.([B)I not implemented.");
     return 2;
 };

--- a/midp/pim.js
+++ b/midp/pim.js
@@ -57,13 +57,12 @@ Native["com/sun/j2me/pim/PIMProxy.getListNamesCount0.(I)I"] = function(addr, lis
   return 0;
 };
 
-Native["com/sun/j2me/pim/PIMProxy.getListNames0.([Ljava/lang/String;)V"] = function(addr, namesAddr) {
-  var names = J2ME.getArrayFromAddr(namesAddr);
+Native["com/sun/j2me/pim/PIMProxy.getListNames0.([Ljava/lang/String;)V"] = function(addr, names) {
   console.warn("PIMProxy.getListNames0.([Ljava/lang/String;)V incomplete");
   names[0] = J2ME.newString("ContactList");
 };
 
-Native["com/sun/j2me/pim/PIMProxy.listOpen0.(ILjava/lang/String;I)I"] = function(addr, listType, listNameAddr, mode) {
+Native["com/sun/j2me/pim/PIMProxy.listOpen0.(ILjava/lang/String;I)I"] = function(addr, listType, listName, mode) {
   console.warn("PIMProxy.listOpen0.(ILjava/lang/String;I)I incomplete");
 
   if (mode !== PIM.READ_ONLY) {
@@ -79,8 +78,7 @@ Native["com/sun/j2me/pim/PIMProxy.listOpen0.(ILjava/lang/String;I)I"] = function
   return 0;
 };
 
-Native["com/sun/j2me/pim/PIMProxy.getNextItemDescription0.(I[I)Z"] = function(addr, listHandle, descriptionAddr) {
-  var description = J2ME.getArrayFromAddr(descriptionAddr);
+Native["com/sun/j2me/pim/PIMProxy.getNextItemDescription0.(I[I)Z"] = function(addr, listHandle, description) {
   console.warn("PIMProxy.getNextItemDescription0.(I[I)Z incomplete");
 
   asyncImpl("Z", new Promise(function(resolve, reject) {
@@ -107,8 +105,7 @@ Native["com/sun/j2me/pim/PIMProxy.getNextItemDescription0.(I[I)Z"] = function(ad
   }));
 };
 
-Native["com/sun/j2me/pim/PIMProxy.getNextItemData0.(I[BI)Z"] = function(addr, itemHandle, dataAddr, dataHandle) {
-  var data = J2ME.getArrayFromAddr(dataAddr);
+Native["com/sun/j2me/pim/PIMProxy.getNextItemData0.(I[BI)Z"] = function(addr, itemHandle, data, dataHandle) {
   console.warn("PIMProxy.getNextItemData0.(I[BI)Z incomplete");
   data.set(PIM.curVcard);
   return 1;
@@ -144,7 +141,7 @@ Native["com/sun/j2me/pim/PIMProxy.getDefaultListName.(I)Ljava/lang/String;"] = f
   return J2ME.Constants.NULL;
 };
 
-Native["com/sun/j2me/pim/PIMProxy.getFieldsCount0.(I[I)I"] = function(addr, listHandle, dataHandleAddr) {
+Native["com/sun/j2me/pim/PIMProxy.getFieldsCount0.(I[I)I"] = function(addr, listHandle, dataHandle) {
   return PIM.supportedFields.length;
 };
 
@@ -153,9 +150,7 @@ Native["com/sun/j2me/pim/PIMProxy.getFieldLabelsCount0.(III)I"] = function(addr,
   return 1;
 };
 
-Native["com/sun/j2me/pim/PIMProxy.getFields0.(I[Lcom/sun/j2me/pim/PIMFieldDescriptor;I)V"] =
-function(addr, listHandle, descAddr, dataHandle) {
-  var desc = J2ME.getArrayFromAddr(descAddr);
+Native["com/sun/j2me/pim/PIMProxy.getFields0.(I[Lcom/sun/j2me/pim/PIMFieldDescriptor;I)V"] = function(addr, listHandle, desc, dataHandle) {
   console.warn("PIMProxy.getFields0.(I[Lcom/sun/j2me/pim/PIMFieldDescriptor;I)V incomplete");
 
   PIM.supportedFields.forEach(function(field, i) {
@@ -166,12 +161,11 @@ function(addr, listHandle, descAddr, dataHandle) {
   });
 };
 
-Native["com/sun/j2me/pim/PIMProxy.getAttributesCount0.(I[I)I"] = function(addr, listHandle, dataHandleAddr) {
+Native["com/sun/j2me/pim/PIMProxy.getAttributesCount0.(I[I)I"] = function(addr, listHandle, dataHandle) {
   console.warn("PIMProxy.getAttributesCount0.(I[I)I not implemented");
   return 0;
 };
 
-Native["com/sun/j2me/pim/PIMProxy.getAttributes0.(I[Lcom/sun/j2me/pim/PIMAttribute;I)V"] =
-function(addr, listHandle, attrAddr, dataHandle) {
+Native["com/sun/j2me/pim/PIMProxy.getAttributes0.(I[Lcom/sun/j2me/pim/PIMAttribute;I)V"] = function(addr, listHandle, attr, dataHandle) {
   console.warn("PIMProxy.getAttributes0.(I[Lcom/sun/j2me/pim/PIMAttribute;I)V not implemented");
 };

--- a/midp/sensor.js
+++ b/midp/sensor.js
@@ -198,13 +198,11 @@ Native["com/sun/javame/sensor/SensorRegistry.doGetNumberOfSensors.()I"] = functi
     return 1;
 };
 
-Native["com/sun/javame/sensor/Sensor.doGetSensorModel.(ILcom/sun/javame/sensor/SensorModel;)V"] =
-function(addr, number, modelAddr) {
+Native["com/sun/javame/sensor/Sensor.doGetSensorModel.(ILcom/sun/javame/sensor/SensorModel;)V"] = function(addr, number, model) {
     if (number !== 0) {
         console.error("Invalid sensor number: " + number);
         return;
     }
-    var model = getHandle(modelAddr);
     var m = AccelerometerSensor.model;
     model.description = J2ME.newString(m.description);
     model.model = J2ME.newString(m.model);
@@ -227,8 +225,7 @@ function(addr, number, modelAddr) {
     model.properties = pAddr;
 };
 
-Native["com/sun/javame/sensor/ChannelImpl.doGetChannelModel.(IILcom/sun/javame/sensor/ChannelModel;)V"] =
-function(addr, sensorsNumber, number, modelAddr) {
+Native["com/sun/javame/sensor/ChannelImpl.doGetChannelModel.(IILcom/sun/javame/sensor/ChannelModel;)V"] = function(addr, sensorsNumber, number, model) {
     if (sensorsNumber !== 0) {
         console.error("Invalid sensor number: " + sensorsNumber);
         return;
@@ -237,7 +234,6 @@ function(addr, sensorsNumber, number, modelAddr) {
         console.error("Invalid channel number: " + number);
         return;
     }
-    var model = getHandle(modelAddr);
     var c = AccelerometerSensor.channels[number];
     model.scale = c.scale;
     model.name = J2ME.newString(c.name);

--- a/midp/sms.js
+++ b/midp/sms.js
@@ -124,19 +124,18 @@ function promptForMessageText() {
     }, MIDlet.SMSDialogTimeout);
 }
 
-Native["com/sun/midp/io/j2me/sms/Protocol.open0.(Ljava/lang/String;II)I"] = function(addr, hostAddr, msid, port) {
+Native["com/sun/midp/io/j2me/sms/Protocol.open0.(Ljava/lang/String;II)I"] = function(addr, host, msid, port) {
     MIDP.smsConnections[++MIDP.lastSMSConnection] = {
       port: port,
       msid: msid,
-      host: J2ME.fromStringAddr(hostAddr),
+      host: J2ME.fromJavaString(host),
     };
 
     return ++MIDP.lastSMSConnection;
 };
 
 Native["com/sun/midp/io/j2me/sms/Protocol.receive0.(IIILcom/sun/midp/io/j2me/sms/Protocol$SMSPacket;)I"] =
-function(addr, port, msid, handle, smsPacketAddr) {
-    var smsPacket = getHandle(smsPacketAddr);
+function(addr, port, msid, handle, smsPacket) {
     asyncImpl("I", new Promise(function(resolve, reject) {
         function receiveSMS() {
             var sms = MIDP.j2meSMSMessages.shift();
@@ -180,22 +179,20 @@ Native["com/sun/midp/io/j2me/sms/Protocol.close0.(III)I"] = function(addr, port,
     return 0;
 };
 
-Native["com/sun/midp/io/j2me/sms/Protocol.numberOfSegments0.([BIIZ)I"] =
-function(addr, msgBufferAddr, msgLen, msgType, hasPort) {
+Native["com/sun/midp/io/j2me/sms/Protocol.numberOfSegments0.([BIIZ)I"] = function(addr, msgBuffer, msgLen, msgType, hasPort) {
     console.warn("com/sun/midp/io/j2me/sms/Protocol.numberOfSegments0.([BIIZ)I not implemented");
     return 1;
 };
 
 Native["com/sun/midp/io/j2me/sms/Protocol.send0.(IILjava/lang/String;II[B)I"] =
-function(addr, handle, type, hostAddr, destPort, sourcePort, messageAddr) {
-    var message = J2ME.getArrayFromAddr(messageAddr);
+function(addr, handle, type, host, destPort, sourcePort, message) {
     var ctx = $.ctx;
     asyncImpl("I", new Promise(function(resolve, reject) {
         var pipe = DumbPipe.open("mozActivity", {
             name: "new",
             data: {
                 type: "websms/sms",
-                number: J2ME.fromStringAddr(hostAddr),
+                number: J2ME.fromJavaString(host),
                 body: new TextDecoder('utf-16be').decode(message),
             },
         }, function(message) {

--- a/midp/socket.js
+++ b/midp/socket.js
@@ -11,8 +11,7 @@ var SOCKET_OPT = {
   SNDBUF: 4,
 };
 
-Native["com/sun/midp/io/j2me/socket/Protocol.getIpNumber0.(Ljava/lang/String;[B)I"] =
-function(addr, hostAddr, ipBytesAddr) {
+Native["com/sun/midp/io/j2me/socket/Protocol.getIpNumber0.(Ljava/lang/String;[B)I"] = function(addr, host, ipBytes) {
     // We're supposed to write the IP address of the host into ipBytes,
     // but we don't actually have to do that, because we can defer resolution
     // until Protocol.open0 (and delegate it to the native socket impl).
@@ -26,10 +25,10 @@ Native["com/sun/midp/io/j2me/socket/Protocol.getHost0.(Z)Ljava/lang/String;"] = 
     // and we might avoid an exception if the socket hasn't been opened yet
     // (so the native socket doesn't exist).
     // var self = getHandle(addr);
-    // var host = J2ME.fromStringAddr(self.host);
+    // var host = J2ME.fromJavaString(getHandle(self.host));
 
     var socket = NativeMap.get(addr);
-    return J2ME.newString(local ? "127.0.0.1" : socket.host);
+    return local ? "127.0.0.1" : socket.host;
 };
 
 function Socket(host, port, ctx, resolve, reject) {
@@ -101,9 +100,9 @@ Socket.prototype.close = function() {
     this.sender({ type: "close" });
 }
 
-Native["com/sun/midp/io/j2me/socket/Protocol.open0.([BI)V"] = function(addr, ipBytesAddr, port) {
+Native["com/sun/midp/io/j2me/socket/Protocol.open0.([BI)V"] = function(addr, ipBytes, port) {
     var self = getHandle(addr);
-    var host = J2ME.fromStringAddr(self.host);
+    var host = J2ME.fromJavaString(getHandle(self.host));
     // console.log("Protocol.open0: " + host + ":" + port);
     asyncImpl("V", new Promise(function(resolve, reject) {
         NativeMap.set(addr, new Socket(host, port, $.ctx, resolve, reject));
@@ -116,8 +115,7 @@ Native["com/sun/midp/io/j2me/socket/Protocol.available0.()I"] = function(addr) {
     return socket.dataLen;
 };
 
-Native["com/sun/midp/io/j2me/socket/Protocol.read0.([BII)I"] = function(addr, dataAddr, offset, length) {
-    var data = J2ME.getArrayFromAddr(dataAddr);
+Native["com/sun/midp/io/j2me/socket/Protocol.read0.([BII)I"] = function(addr, data, offset, length) {
     var socket = NativeMap.get(addr);
     // console.log("Protocol.read0: " + socket.isClosed);
 
@@ -166,8 +164,7 @@ Native["com/sun/midp/io/j2me/socket/Protocol.read0.([BII)I"] = function(addr, da
     }));
 };
 
-Native["com/sun/midp/io/j2me/socket/Protocol.write0.([BII)I"] = function(addr, dataAddr, offset, length) {
-    var data = J2ME.getArrayFromAddr(dataAddr);
+Native["com/sun/midp/io/j2me/socket/Protocol.write0.([BII)I"] = function(addr, data, offset, length) {
     var socket = NativeMap.get(addr);
     var ctx = $.ctx;
     asyncImpl("I", new Promise(function(resolve, reject) {

--- a/nat.ts
+++ b/nat.ts
@@ -151,8 +151,7 @@ module J2ME {
     return isolate._mainClass;
   };
 
-  Native["org/mozilla/internal/Sys.executeMain.(Ljava/lang/Class;)V"] = function(addr: number, mainAddr: number) {
-    var main = <java.lang.Class>getHandle(mainAddr);
+  Native["org/mozilla/internal/Sys.executeMain.(Ljava/lang/Class;)V"] = function(addr: number, main: java.lang.Class) {
     var entryPoint = CLASSES.getEntryPoint(main.runtimeKlass.templateKlass.classInfo);
     if (!entryPoint)
       throw new Error("Could not find isolate main.");

--- a/native.js
+++ b/native.js
@@ -43,14 +43,10 @@ function deleteNative(javaObj) {
     NativeMap.delete(javaObj._address);
 }
 
-Native["java/lang/System.arraycopy.(Ljava/lang/Object;ILjava/lang/Object;II)V"] =
-function(addr, srcAddr, srcOffset, dstAddr, dstOffset, length) {
-    if (srcAddr === J2ME.Constants.NULL || dstAddr === J2ME.Constants.NULL) {
+Native["java/lang/System.arraycopy.(Ljava/lang/Object;ILjava/lang/Object;II)V"] = function(addr, src, srcOffset, dst, dstOffset, length) {
+    if (!src || !dst) {
         throw $.newNullPointerException("Cannot copy to/from a null array.");
     }
-
-    var src = getHandle(srcAddr);
-    var dst = getHandle(dstAddr);
 
     var srcKlass = src.klass;
     var dstKlass = dst.klass;
@@ -109,8 +105,8 @@ var stubProperties = {
   "com.nokia.mid.imei": "",
 };
 
-Native["java/lang/System.getProperty0.(Ljava/lang/String;)Ljava/lang/String;"] = function(addr, keyAddr) {
-    var key = J2ME.fromStringAddr(keyAddr);
+Native["java/lang/System.getProperty0.(Ljava/lang/String;)Ljava/lang/String;"] = function(addr, key) {
+    key = J2ME.fromJavaString(key);
     var value;
     switch (key) {
     case "microedition.encoding":
@@ -284,25 +280,15 @@ Native["java/lang/System.currentTimeMillis.()J"] = function(addr) {
     return J2ME.returnLongValue(Date.now());
 };
 
-Native["com/sun/cldchi/jvm/JVM.unchecked_char_arraycopy.([CI[CII)V"] =
-function(addr, srcAddr, srcOffset, dstAddr, dstOffset, length) {
-  var src = J2ME.getArrayFromAddr(srcAddr);
-  var dst = J2ME.getArrayFromAddr(dstAddr);
+Native["com/sun/cldchi/jvm/JVM.unchecked_char_arraycopy.([CI[CII)V"] = function(addr, src, srcOffset, dst, dstOffset, length) {
   dst.set(src.subarray(srcOffset, srcOffset + length), dstOffset);
 };
 
-Native["com/sun/cldchi/jvm/JVM.unchecked_int_arraycopy.([II[III)V"] =
-function(addr, srcAddr, srcOffset, dstAddr, dstOffset, length) {
-  var src = J2ME.getArrayFromAddr(srcAddr);
-  var dst = J2ME.getArrayFromAddr(dstAddr);
+Native["com/sun/cldchi/jvm/JVM.unchecked_int_arraycopy.([II[III)V"] = function(addr, src, srcOffset, dst, dstOffset, length) {
   dst.set(src.subarray(srcOffset, srcOffset + length), dstOffset);
 };
 
-Native["com/sun/cldchi/jvm/JVM.unchecked_obj_arraycopy.([Ljava/lang/Object;I[Ljava/lang/Object;II)V"] =
-function(addr, srcAddr, srcOffset, dstAddr, dstOffset, length) {
-    var src = J2ME.getArrayFromAddr(srcAddr);
-    var dst = J2ME.getArrayFromAddr(dstAddr);
-
+Native["com/sun/cldchi/jvm/JVM.unchecked_obj_arraycopy.([Ljava/lang/Object;I[Ljava/lang/Object;II)V"] = function(addr, src, srcOffset, dst, dstOffset, length) {
     if (dst !== src || dstOffset < srcOffset) {
         for (var n = 0; n < length; ++n) {
             dst[dstOffset++] = src[srcOffset++];
@@ -359,26 +345,24 @@ Native["java/lang/Class.getName.()Ljava/lang/String;"] = function(addr) {
     return J2ME.newString(self.runtimeKlass.templateKlass.classInfo.getClassNameSlow().replace(/\//g, "."));
 };
 
-Native["java/lang/Class.forName0.(Ljava/lang/String;)V"] = function(addr, nameAddr) {
+Native["java/lang/Class.forName0.(Ljava/lang/String;)V"] = function(addr, name) {
   var classInfo = null;
   try {
-    if (nameAddr === J2ME.Constants.NULL) {
+    if (!name)
       throw new J2ME.ClassNotFoundException();
-    }
-    var className = J2ME.fromStringAddr(nameAddr).replace(/\./g, "/");
+    var className = J2ME.fromJavaString(name).replace(/\./g, "/");
     classInfo = CLASSES.getClass(className);
   } catch (e) {
-    if (e instanceof (J2ME.ClassNotFoundException)) {
+    if (e instanceof (J2ME.ClassNotFoundException))
       throw $.newClassNotFoundException("'" + e.message + "' not found.");
-    }
     throw e;
   }
   // The following can trigger an unwind.
   J2ME.classInitCheck(classInfo);
 };
 
-Native["java/lang/Class.forName1.(Ljava/lang/String;)Ljava/lang/Class;"] = function(addr, nameAddr) {
-  var className = J2ME.fromStringAddr(nameAddr).replace(/\./g, "/");
+Native["java/lang/Class.forName1.(Ljava/lang/String;)Ljava/lang/Class;"] = function(addr, name) {
+  var className = J2ME.fromJavaString(name).replace(/\./g, "/");
   var classInfo = CLASSES.getClass(className);
   var classObject = classInfo.getClassObject();
   return classObject._address;
@@ -398,8 +382,7 @@ Native["java/lang/Class.newInstance0.()Ljava/lang/Object;"] = function(addr) {
   return (new self.runtimeKlass.templateKlass)._address;
 };
 
-Native["java/lang/Class.newInstance1.(Ljava/lang/Object;)V"] = function(addr, oAddr) {
-  var o = getHandle(oAddr);
+Native["java/lang/Class.newInstance1.(Ljava/lang/Object;)V"] = function(addr, o) {
   // The following can trigger an unwind.
   var methodInfo = o.klass.classInfo.getLocalMethodByNameString("<init>", "()V", false);
   if (!methodInfo) {
@@ -418,17 +401,16 @@ Native["java/lang/Class.isArray.()Z"] = function(addr) {
     return self.runtimeKlass.templateKlass.classInfo instanceof J2ME.ArrayClassInfo ? 1 : 0;
 };
 
-Native["java/lang/Class.isAssignableFrom.(Ljava/lang/Class;)Z"] = function(addr, fromClassAddr) {
+Native["java/lang/Class.isAssignableFrom.(Ljava/lang/Class;)Z"] = function(addr, fromClass) {
     var self = getHandle(addr);
-    var fromClass = getHandle(fromClassAddr);
     if (!fromClass)
         throw $.newNullPointerException();
     return J2ME.isAssignableTo(fromClass.runtimeKlass.templateKlass, self.runtimeKlass.templateKlass) ? 1 : 0;
 };
 
-Native["java/lang/Class.isInstance.(Ljava/lang/Object;)Z"] = function(addr, objAddr) {
+Native["java/lang/Class.isInstance.(Ljava/lang/Object;)Z"] = function(addr, obj) {
     var self = getHandle(addr);
-    return objAddr !== J2ME.Constants.NULL && J2ME.isAssignableTo(getHandle(objAddr).klass, self.runtimeKlass.templateKlass) ? 1 : 0;
+    return obj && J2ME.isAssignableTo(obj.klass, self.runtimeKlass.templateKlass) ? 1 : 0;
 };
 
 Native["java/lang/Float.floatToIntBits.(F)I"] = function(addr, f) {
@@ -607,8 +589,8 @@ Native["com/sun/cldchi/io/ConsoleOutputStream.write.(I)V"] = function(addr, ch) 
     console.print(ch);
 };
 
-Native["com/sun/cldc/io/ResourceInputStream.open.(Ljava/lang/String;)Ljava/lang/Object;"] = function(addr, nameAddr) {
-    var fileName = J2ME.fromStringAddr(nameAddr);
+Native["com/sun/cldc/io/ResourceInputStream.open.(Ljava/lang/String;)Ljava/lang/Object;"] = function(addr, name) {
+    var fileName = J2ME.fromJavaString(name);
     var data = JARStore.loadFile(fileName);
     var obj = null;
     if (data) {
@@ -621,8 +603,7 @@ Native["com/sun/cldc/io/ResourceInputStream.open.(Ljava/lang/String;)Ljava/lang/
     return obj ? obj._address : J2ME.Constants.NULL;
 };
 
-Native["com/sun/cldc/io/ResourceInputStream.clone.(Ljava/lang/Object;)Ljava/lang/Object;"] = function(addr, sourceAddr) {
-    var source = getHandle(sourceAddr);
+Native["com/sun/cldc/io/ResourceInputStream.clone.(Ljava/lang/Object;)Ljava/lang/Object;"] = function(addr, source) {
     var obj = J2ME.newObject(CLASSES.java_lang_Object.klass);
     var sourceDecoder = getNative(source);
     setNative(obj, {
@@ -632,20 +613,18 @@ Native["com/sun/cldc/io/ResourceInputStream.clone.(Ljava/lang/Object;)Ljava/lang
     return obj._address;
 };
 
-Native["com/sun/cldc/io/ResourceInputStream.bytesRemain.(Ljava/lang/Object;)I"] = function(addr, fileDecoderAddr) {
-    var handle = NativeMap.get(fileDecoderAddr);
+Native["com/sun/cldc/io/ResourceInputStream.bytesRemain.(Ljava/lang/Object;)I"] = function(addr, fileDecoder) {
+    var handle = getNative(fileDecoder);
     return handle.data.length - handle.pos;
 };
 
-Native["com/sun/cldc/io/ResourceInputStream.readByte.(Ljava/lang/Object;)I"] = function(addr, fileDecoderAddr) {
-    var handle = NativeMap.get(fileDecoderAddr);
+Native["com/sun/cldc/io/ResourceInputStream.readByte.(Ljava/lang/Object;)I"] = function(addr, fileDecoder) {
+    var handle = getNative(fileDecoder);
     return (handle.data.length - handle.pos > 0) ? handle.data[handle.pos++] : -1;
 };
 
-Native["com/sun/cldc/io/ResourceInputStream.readBytes.(Ljava/lang/Object;[BII)I"] =
-function(addr, fileDecoderAddr, bAddr, off, len) {
-    var b = J2ME.getArrayFromAddr(bAddr);
-    var handle = NativeMap.get(fileDecoderAddr);
+Native["com/sun/cldc/io/ResourceInputStream.readBytes.(Ljava/lang/Object;[BII)I"] = function(addr, fileDecoder, b, off, len) {
+    var handle = getNative(fileDecoder);
     var data = handle.data;
     var remaining = data.length - handle.pos;
     if (len > remaining)
@@ -656,20 +635,14 @@ function(addr, fileDecoderAddr, bAddr, off, len) {
     return (len > 0) ? len : -1;
 };
 
-Native["java/lang/ref/WeakReference.initializeWeakReference.(Ljava/lang/Object;)V"] = function(addr, targetAddr) {
-    // Store the (not actually) weak reference in NativeMap.
-    //
-    // This is technically a misuse of NativeMap, which is intended to store
-    // native objects associated with Java objects, whereas here we're storing
-    // the address of a Java object associated with another Java object.
-    //
+Native["java/lang/ref/WeakReference.initializeWeakReference.(Ljava/lang/Object;)V"] = function(addr, target) {
     // XXX Make these real weak references.
-    //
-    NativeMap.set(addr, targetAddr);
+    NativeMap.set(addr, target);
 };
 
 Native["java/lang/ref/WeakReference.get.()Ljava/lang/Object;"] = function(addr) {
-    return NativeMap.has(addr) ? NativeMap.get(addr) : J2ME.Constants.NULL;
+    var target = NativeMap.get(addr);
+    return target ? target._address : J2ME.Constants.NULL;
 };
 
 Native["java/lang/ref/WeakReference.clear.()V"] = function(addr) {
@@ -727,12 +700,12 @@ Native["com/sun/cldc/isolate/Isolate.setPriority0.(I)V"] = function(addr, newPri
     // XXX Figure out if there's anything to do here.  If not, say so.
 };
 
-Native["com/sun/j2me/content/AppProxy.midletIsAdded.(ILjava/lang/String;)V"] = function(addr, suiteId, classNameAddr) {
+Native["com/sun/j2me/content/AppProxy.midletIsAdded.(ILjava/lang/String;)V"] = function(addr, suiteId, className) {
   console.warn("com/sun/j2me/content/AppProxy.midletIsAdded.(ILjava/lang/String;)V not implemented");
 };
 
-Native["com/nokia/mid/impl/jms/core/Launcher.handleContent.(Ljava/lang/String;)V"] = function(addr, contentAddr) {
-    var fileName = J2ME.fromStringAddr(contentAddr);
+Native["com/nokia/mid/impl/jms/core/Launcher.handleContent.(Ljava/lang/String;)V"] = function(addr, content) {
+    var fileName = J2ME.fromJavaString(content);
 
     var ext = fileName.split('.').pop().toLowerCase();
     // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#Supported_image_formats
@@ -793,9 +766,9 @@ function addUnimplementedNative(signature, returnValue) {
     Native[signature] = function(addr) { return warnOnce() };
 }
 
-Native["org/mozilla/internal/Sys.eval.(Ljava/lang/String;)V"] = function(addr, srcAddr) {
+Native["org/mozilla/internal/Sys.eval.(Ljava/lang/String;)V"] = function(addr, src) {
     if (!release) {
-        eval(J2ME.fromStringAddr(srcAddr));
+        eval(J2ME.fromJavaString(src));
     }
 };
 

--- a/string.js
+++ b/string.js
@@ -9,8 +9,7 @@
 // * Any missing methods have been noted in comments.
 // *
 // * XXX If you reuse this code at some point, update it to work with the new
-// * way that natives associated with Java objects are stored in NativeMap
-// * and object/array references are passed as addresses.
+// * way that natives associated with Java objects are stored in NativeMap.
 // */
 //
 ////################################################################
@@ -312,7 +311,7 @@
 //var internedStrings = J2ME.internedStrings;
 //
 //Native["java/lang/String.intern.()Ljava/lang/String;"] = function(addr) {
-//    var string = J2ME.fromStringAddr(this._address);
+//    var string = J2ME.fromJavaString(this);
 //
 //    var internedString = internedStrings.get(string);
 //

--- a/tests/gnu/testlet/vm/NativeTest.java
+++ b/tests/gnu/testlet/vm/NativeTest.java
@@ -7,7 +7,7 @@ public class NativeTest implements Testlet {
     public int getExpectedFail() { return 0; }
     public int getExpectedKnownFail() { return 0; }
     native static int getInt();
-    native static int fromStringAddr(String string);
+    native static int fromJavaString(String string);
     native static int decodeUtf8(byte[] string);
     native static long getLongReturnLong(long val);
     native static int getLongReturnInt(long val);
@@ -24,12 +24,12 @@ public class NativeTest implements Testlet {
 
         String s = "marco";
         th.check(s.substring(0, 0), "");
-        th.check(fromStringAddr(s.substring(0, 0)), fromStringAddr(""));
-        th.check(fromStringAddr(s.substring(0, 1)), fromStringAddr("m"));
+        th.check(fromJavaString(s.substring(0, 0)), fromJavaString(""));
+        th.check(fromJavaString(s.substring(0, 1)), fromJavaString("m"));
 
-        th.check(fromStringAddr("\0"), 1);
+        th.check(fromJavaString("\0"), 1);
         th.check(decodeUtf8("\0".getBytes()), 1);
-        th.check(fromStringAddr(""), 0);
+        th.check(fromJavaString(""), 0);
         th.check(decodeUtf8("".getBytes()), 0);
 
         th.check(getLongReturnLong(2L), 42L);

--- a/tests/native.js
+++ b/tests/native.js
@@ -41,12 +41,11 @@ Native["gnu/testlet/vm/NativeTest.nonStatic.(I)I"] = function(addr, val) {
   return val + 40;
 };
 
-Native["gnu/testlet/vm/NativeTest.fromStringAddr.(Ljava/lang/String;)I"] = function(addr, stringAddr) {
-  return J2ME.fromStringAddr(stringAddr).length;
+Native["gnu/testlet/vm/NativeTest.fromJavaString.(Ljava/lang/String;)I"] = function(addr, str) {
+  return J2ME.fromJavaString(str).length;
 };
 
-Native["gnu/testlet/vm/NativeTest.decodeUtf8.([B)I"] = function(addr, strAddr) {
-  var str = J2ME.getArrayFromAddr(strAddr);
+Native["gnu/testlet/vm/NativeTest.decodeUtf8.([B)I"] = function(addr, str) {
   return util.decodeUtf8(str).length;
 };
 
@@ -91,14 +90,13 @@ Native["javax/microedition/lcdui/TestAlert.isTextEditorReallyFocused.()Z"] = fun
   return (currentlyFocusedTextEditor && currentlyFocusedTextEditor.focused) ? 1 : 0;
 };
 
-Native["javax/microedition/lcdui/TestTextEditorFocus.isTextEditorReallyFocused.(Lcom/nokia/mid/ui/TextEditor;)Z"] =
-function(addr, textEditorAddr) {
-  var nativeTextEditor = NativeMap.get(textEditorAddr);
+Native["javax/microedition/lcdui/TestTextEditorFocus.isTextEditorReallyFocused.(Lcom/nokia/mid/ui/TextEditor;)Z"] = function(addr, textEditor) {
+  var nativeTextEditor = getNative(textEditor);
   return (currentlyFocusedTextEditor == nativeTextEditor && currentlyFocusedTextEditor.focused) ? 1 : 0;
 };
 
-Native["gnu/testlet/TestHarness.getNumDifferingPixels.(Ljava/lang/String;)I"] = function(addr, referenceImagePathAddr) {
-  var path = J2ME.fromStringAddr(referenceImagePathAddr);
+Native["gnu/testlet/TestHarness.getNumDifferingPixels.(Ljava/lang/String;)I"] = function(addr, pathStr) {
+  var path = J2ME.fromJavaString(pathStr);
   asyncImpl("I", new Promise(function(resolve, reject) {
     var gotCanvas = document.getElementById("canvas");
     var gotPixels = new Uint32Array(gotCanvas.getContext("2d").getImageData(0, 0, gotCanvas.width, gotCanvas.height).data.buffer);
@@ -155,8 +153,7 @@ Native["org/mozilla/io/TestNokiaPhoneStatusServer.sendFakeOfflineEvent.()V"] = f
   window.dispatchEvent(new CustomEvent("offline"));
 };
 
-Native["javax/microedition/media/TestAudioRecorder.convert3gpToAmr.([B)[B"] = function(addr, dataAddr) {
-  var data = J2ME.getArrayFromAddr(dataAddr);
+Native["javax/microedition/media/TestAudioRecorder.convert3gpToAmr.([B)[B"] = function(addr, data) {
   var converted = Media.convert3gpToAmr(new Uint8Array(data));
   var resultAddr = J2ME.newByteArray(converted.length);
   var result = J2ME.getArrayFromAddr(resultAddr);
@@ -164,16 +161,16 @@ Native["javax/microedition/media/TestAudioRecorder.convert3gpToAmr.([B)[B"] = fu
   return resultAddr;
 };
 
-Native["com/sun/midp/i18n/TestResourceConstants.setLanguage.(Ljava/lang/String;)V"] = function(addr, languageAddr) {
+Native["com/sun/midp/i18n/TestResourceConstants.setLanguage.(Ljava/lang/String;)V"] = function(addr, language) {
   MIDP.localizedStrings = null;
-  config.language = J2ME.fromStringAddr(languageAddr);
+  config.language = J2ME.fromJavaString(language);
 }
 
 // Many tests create FileConnection objects to files with the "/" root,
 // so add it to the list of valid roots.
 MIDP.fsRoots.push("/");
 
-Native["org/mozilla/MemorySampler.sampleMemory.(Ljava/lang/String;)V"] = function(addr, labelAddr) {
+Native["org/mozilla/MemorySampler.sampleMemory.(Ljava/lang/String;)V"] = function(addr, label) {
   if (typeof Benchmark !== "undefined") {
     asyncImpl("V", Benchmark.sampleMemory().then(function(memory) {
       var keys = ["totalSize", "domSize", "styleSize", "jsObjectsSize", "jsStringsSize", "jsOtherSize", "otherSize"];
@@ -182,7 +179,7 @@ Native["org/mozilla/MemorySampler.sampleMemory.(Ljava/lang/String;)V"] = functio
       rows.push(keys.map(function(k) { return memory[k] }));
       var RIGHT = Benchmark.RIGHT;
       var alignment = [RIGHT, RIGHT, RIGHT, RIGHT, RIGHT, RIGHT, RIGHT];
-      console.log((J2ME.fromStringAddr(labelAddr) || "Memory sample") + ":\n" + Benchmark.prettyTable(rows, alignment));
+      console.log((J2ME.fromJavaString(label) || "Memory sample") + ":\n" + Benchmark.prettyTable(rows, alignment));
     }));
   }
 };
@@ -262,9 +259,8 @@ Native["tests/background/DestroyMIDlet.maybePrintDone.()V"] = function(addr) {
   }
 };
 
-Native["javax/microedition/content/TestContentHandler.addInvocation.(Ljava/lang/String;Ljava/lang/String;)V"] =
-function(addr, argumentAddr, actionAddr) {
-  Content.addInvocation(J2ME.fromStringAddr(argumentAddr), J2ME.fromStringAddr(actionAddr));
+Native["javax/microedition/content/TestContentHandler.addInvocation.(Ljava/lang/String;Ljava/lang/String;)V"] = function(addr, argument, action) {
+  Content.addInvocation(J2ME.fromJavaString(argument), J2ME.fromJavaString(action));
 };
 
 var ContentHandlerMIDletStarted = 0;

--- a/vm/runtime.ts
+++ b/vm/runtime.ts
@@ -1169,7 +1169,13 @@ module J2ME {
       switch (classInfo.getClassNameSlow()) {
         case "java/lang/Object": Klasses.java.lang.Object = klass; break;
         case "java/lang/Class" : Klasses.java.lang.Class  = klass; break;
-        case "java/lang/String": Klasses.java.lang.String = klass; break;
+        case "java/lang/String": Klasses.java.lang.String = klass;
+          Object.defineProperty(klass.prototype, "viewString", {
+            get: function () {
+              return fromJavaString(this);
+            }
+          });
+          break;
         case "java/lang/Thread": Klasses.java.lang.Thread = klass; break;
         case "java/lang/Exception": Klasses.java.lang.Exception = klass; break;
         case "java/lang/InstantiationException": Klasses.java.lang.InstantiationException = klass; break;
@@ -2056,15 +2062,11 @@ module J2ME {
     return "[" + value.klass.classInfo.getClassNameSlow() + hashcode + "]";
   }
 
-  export function fromStringAddr(stringAddr: number): string {
-    if (stringAddr === Constants.NULL) {
+  export function fromJavaString(value: java.lang.String): string {
+    if (!value) {
       return null;
     }
-
-    // XXX Retrieve the characters directly from memory, without indirecting
-    // through getHandle and getArrayFromAddr.
-    var javaString = <java.lang.String>getHandle(stringAddr);
-    return util.fromJavaChars(getArrayFromAddr(javaString.value), javaString.offset, javaString.count);
+    return util.fromJavaChars(getArrayFromAddr(value.value), value.offset, value.count);
   }
 
   export function checkDivideByZero(value: number) {


### PR DESCRIPTION
Reverts mozilla/pluotsorbet#1712

#1712 breaks WhatsApp and WeChat.

In WhatsApp, I see a long series of:
```
2.3:8.10 | java.lang.NullPointerException: klass is null 
2.3:8.10 |    (stack trace incomplete) 
```

In WeChat:
```
10(07-9:00:05:13:833 EDT)-e/CrashMgr:exception:java.lang.NullPointerException: getNative(...) is undefined
```