### PR TITLE
Notify threads based on priority instead of FIFO

### DIFF
--- a/contextQueue.ts
+++ b/contextQueue.ts
@@ -1,0 +1,79 @@
+module J2ME {
+  class WaitingContext {
+    ctx: Context;
+    private weight: number = 0;
+
+    constructor(ctx: Context) {
+      this.ctx = ctx;
+      this.updateWeight(1);
+    }
+
+    updateWeight(elapsed: number) {
+      this.weight += elapsed * this.ctx.priority;
+    }
+
+    static compare(a: WaitingContext, b: WaitingContext) {
+      return a.weight - b.weight;
+    }
+  }
+
+  export class ContextQueue {
+    private arr: WaitingContext [] = [];
+    private lastTime: number = 0;
+
+    constructor() {
+    }
+
+    put(ctx: Context) {
+      this.updateWeights(performance.now());
+      this.arr.push(new WaitingContext(ctx));
+    }
+
+    private updateWeights(time: number) {
+      var elapsed = time - this.lastTime;
+      this.lastTime = time;
+      for (var i = 0; i < this.arr.length; i++) {
+        this.arr[i].updateWeight(elapsed);
+      }
+    }
+
+    get(time: number): Context {
+      if (this.arr.length === 0) {
+        return null;
+      }
+
+      if (this.arr.length !== 1) {
+        this.updateWeights(time);
+        this.arr.sort(WaitingContext.compare);
+      }
+
+      return this.arr.pop().ctx;
+    }
+
+    getAll(): Context [] {
+      this.updateWeights(performance.now());
+      this.arr.sort(WaitingContext.compare);
+
+      var ret = new Array(this.arr.length);
+      for (var i = 0; i < this.arr.length; i++) {
+        ret[i] = this.arr[i].ctx;
+      }
+
+      this.arr.length = 0;
+      return ret;
+    }
+
+    remove(ctx: Context) {
+      for (var i = 0; i < this.arr.length; i++) {
+        if (ctx === this.arr[i].ctx) {
+          this.arr.splice(i, 1);
+          return;
+        }
+      }
+    }
+
+    hasMore() : boolean {
+      return (this.arr.length !== 0);
+    }
+  }
+}

--- a/interpreter.ts
+++ b/interpreter.ts
@@ -28,7 +28,7 @@ module J2ME {
 
   function classInitAndUnwindCheck(classInfo: ClassInfo, pc: number) {
     classInitCheck(classInfo);
-    if (U) {
+    if ($.ctx.U) {
       $.ctx.current().pc = pc;
       return;
     } 
@@ -77,7 +77,7 @@ module J2ME {
    * Debugging helper to make sure native methods were implemented correctly.
    */
   function checkReturnValue(methodInfo: MethodInfo, returnValue: any) {
-    if (U) {
+    if ($.ctx.U) {
       if (typeof returnValue !== "undefined") {
         assert(false, "Expected undefined return value during unwind, got " + returnValue + " in " + methodInfo.implKey);
       }
@@ -276,7 +276,7 @@ module J2ME {
 
               // Perform OSR, the callee reads the frame stored in |O| and updates its own state.
               returnValue = O.methodInfo.fn();
-              if (U) {
+              if (ctx.U) {
                 return;
               }
 
@@ -991,7 +991,7 @@ module J2ME {
             index = frame.read16();
             fieldInfo = mi.classInfo.constantPool.resolveField(index, true);
             classInitAndUnwindCheck(fieldInfo.classInfo, frame.pc - 3);
-            if (U) {
+            if (ctx.U) {
               return;
             }
             value = fieldInfo.getStatic();
@@ -1001,7 +1001,7 @@ module J2ME {
             index = frame.read16();
             fieldInfo = mi.classInfo.constantPool.resolveField(index, true);
             classInitAndUnwindCheck(fieldInfo.classInfo, frame.pc - 3);
-            if (U) {
+            if (ctx.U) {
               return;
             }
             fieldInfo.setStatic(stack.popKind(fieldInfo.kind));
@@ -1010,7 +1010,7 @@ module J2ME {
             index = frame.read16();
             classInfo = resolveClass(index, mi.classInfo);
             classInitAndUnwindCheck(classInfo, frame.pc - 3);
-            if (U) {
+            if (ctx.U) {
               return;
             }
             stack.push(newObject(classInfo.klass));
@@ -1042,7 +1042,7 @@ module J2ME {
           case Bytecodes.MONITORENTER:
             object = stack.pop();
             ctx.monitorEnter(object);
-            if (U === VMState.Pausing || U === VMState.Stopping) {
+            if (ctx.U === VMState.Pausing || ctx.U === VMState.Stopping) {
               return;
             }
             break;
@@ -1108,7 +1108,7 @@ module J2ME {
             if (!release) {
               checkReturnValue(calleeMethodInfo, returnValue);
             }
-            if (U) {
+            if (ctx.U) {
               return;
             }
             if (calleeMethodInfo.returnKind !== Kind.Void) {
@@ -1141,7 +1141,7 @@ module J2ME {
 
             if (isStatic) {
               classInitAndUnwindCheck(calleeMethodInfo.classInfo, lastPC);
-              if (U) {
+              if (ctx.U) {
                 return;
               }
             }
@@ -1190,7 +1190,7 @@ module J2ME {
                     : frame.local[0];
                 }
                 ctx.monitorEnter(calleeFrame.lockObject);
-                if (U === VMState.Pausing || U === VMState.Stopping) {
+                if (ctx.U === VMState.Pausing || ctx.U === VMState.Stopping) {
                   return;
                 }
               }
@@ -1236,7 +1236,7 @@ module J2ME {
               checkReturnValue(calleeMethodInfo, returnValue);
             }
 
-            if (U) {
+            if (ctx.U) {
               return;
             }
 

--- a/interpreter.ts
+++ b/interpreter.ts
@@ -177,12 +177,11 @@ module J2ME {
 
     if (ctx.current() === Frame.Start) {
       ctx.kill();
-      if (ctx.thread && ctx.thread._lock && ctx.thread._lock.waiting.length > 0) {
+      if (ctx.thread && ctx.thread._lock && ctx.thread._lock.waiting.hasMore()) {
         console.error(buildExceptionLog(e, stackTrace));
-        for (var i = 0; i < ctx.thread._lock.waiting.length; i++) {
-          var waitingCtx = ctx.thread._lock.waiting[i];
-          ctx.thread._lock.waiting[i] = null;
-          waitingCtx.wakeup(ctx.thread);
+        var ctxs = ctx.thread._lock.waiting.getAll();
+        for (var i = ctxs.length - 1; i >= 0; i--) {
+          ctxs[i].wakeup(ctx.thread);
         }
       }
       throw new Error(buildExceptionLog(e, stackTrace));

--- a/jit/baseline.ts
+++ b/jit/baseline.ts
@@ -334,9 +334,9 @@ module J2ME {
     static localNames = ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z"];
 
     /**
-     * Make sure that none of these shadow global names, like "U" and "O".
+     * Make sure that none of these shadow global names, like "O".
      */
-    static stackNames = ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "_O", "P", "Q", "R", "S", "T", "_U", "V", "W", "X", "Y", "Z"];
+    static stackNames = ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "_O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z"];
 
     /**
      * Indicates whether a unwind throw was emitted.
@@ -466,7 +466,7 @@ module J2ME {
         if (this.hasUnwindThrow) {
           var local = this.local.join(",");
           var stack = this.stack.join(",");
-          this.bodyEmitter.writeLn("if(U){$.T(ex,[" + local + "],[" + stack + "]," + this.lockObject + ");return;}");
+          this.bodyEmitter.writeLn("if($.ctx.U){$.T(ex,[" + local + "],[" + stack + "]," + this.lockObject + ");return;}");
         }
         this.bodyEmitter.writeLn(this.getStackName(0) + "=TE(ex);");
         this.blockStack = [this.getStackName(0)];
@@ -1096,25 +1096,25 @@ module J2ME {
           this.stack.length < 8) {
         this.flushBlockStack();
         if (<any>nextPC - <any>pc === 3) {
-          emitter.writeLn("U&&B" + this.sp + "(" + pc + ");");
+          emitter.writeLn("$.ctx.U&&B" + this.sp + "(" + pc + ");");
         } else {
-          emitter.writeLn("U&&B" + this.sp + "(" + pc + "," + nextPC + ");");
+          emitter.writeLn("$.ctx.U&&B" + this.sp + "(" + pc + "," + nextPC + ");");
         }
         this.hasUnwindThrow = true;
       } else {
         var local = this.local.join(",");
         var stack = this.blockStack.slice(0, this.sp).join(",");
-        emitter.writeLn("if(U){$.B(" + pc + "," + nextPC + ",[" + local + "],[" + stack + "]," + this.lockObject + ");return;}");
+        emitter.writeLn("if($.ctx.U){$.B(" + pc + "," + nextPC + ",[" + local + "],[" + stack + "]," + this.lockObject + ");return;}");
       }
       baselineCounter && baselineCounter.count("emitUnwind");
     }
 
     emitNoUnwindAssertion() {
-      this.blockEmitter.writeLn("if(U){J2ME.Debug.assert(false,'Unexpected unwind.');}");
+      this.blockEmitter.writeLn("if($.ctx.U){J2ME.Debug.assert(false,'Unexpected unwind.');}");
     }
 
     emitUndefinedReturnAssertion() {
-      this.blockEmitter.writeLn("if (U && re !== undefined) { J2ME.Debug.assert(false, 'Unexpected return value during unwind.'); }");
+      this.blockEmitter.writeLn("if($.ctx.U && re !== undefined) { J2ME.Debug.assert(false, 'Unexpected return value during unwind.'); }");
     }
 
     private emitMonitorEnter(emitter: Emitter, nextPC: number, object: string) {

--- a/midp/gfx.js
+++ b/midp/gfx.js
@@ -400,7 +400,7 @@ var currentlyFocusedTextEditor;
             var methodInfo = classInfo.getMethodByNameString("<init>", "(III)V", false);
             J2ME.preemptionLockLevel++;
             J2ME.getLinkedMethod(methodInfo).call(defaultFont, 0, 0, 0);
-            release || J2ME.Debug.assert(!U, "Unexpected unwind during createException.");
+            release || J2ME.Debug.assert(!$.ctx.U, "Unexpected unwind during createException.");
             J2ME.preemptionLockLevel--;
         }
         return defaultFont;

--- a/midp/gfx.js
+++ b/midp/gfx.js
@@ -114,7 +114,7 @@ var currentlyFocusedTextEditor;
             window.requestAnimationFrame(gotNewFrame);
         } else {
             ctxs.unshift($.ctx);
-            $.pause(asyncImplStringAsync);
+            $.ctx.pause(asyncImplStringAsync);
         }
     }
 

--- a/midp/midp.js
+++ b/midp/midp.js
@@ -705,7 +705,7 @@ var MIDP = (function() {
   };
 
   function exit(code) {
-    $.stop();
+    $.ctx.stop();
     DumbPipe.open("exit", null, function(message) {});
     showExitScreen();
   }

--- a/native.js
+++ b/native.js
@@ -22,7 +22,7 @@ function asyncImpl(returnKind, promise) {
     ctx.pushFrame(Frame.create(methodInfo, [exception]));
     J2ME.Scheduler.enqueue(ctx);
   });
-  $.pause(asyncImplStringAsync);
+  $.ctx.pause(asyncImplStringAsync);
 }
 
 function preemptingImpl(returnKind, returnValue) {
@@ -563,7 +563,7 @@ Native["java/lang/Thread.sleep.(J)V"] = function(delay) {
 };
 
 Native["java/lang/Thread.yield.()V"] = function() {
-    $.yield("Thread.yield");
+    $.ctx.yield("Thread.yield");
 };
 
 Native["java/lang/Thread.activeCount.()I"] = function() {

--- a/native.js
+++ b/native.js
@@ -534,6 +534,9 @@ Native["java/lang/Thread.currentThread.()Ljava/lang/Thread;"] = function() {
 };
 
 Native["java/lang/Thread.setPriority0.(II)V"] = function(oldPriority, newPriority) {
+    if (this.ctx) {
+        this.ctx.priority = newPriority;
+    }
 };
 
 Native["java/lang/Thread.start0.()V"] = function() {
@@ -546,6 +549,8 @@ Native["java/lang/Thread.start0.()V"] = function() {
     // Create a context for the thread and start it.
     var newCtx = new Context($.ctx.runtime);
     newCtx.thread = this;
+    this.ctx = newCtx;
+    newCtx.priority = this.priority;
 
     var classInfo = CLASSES.getClass("org/mozilla/internal/Sys");
     var run = classInfo.getMethodByNameString("runThread", "(Ljava/lang/Thread;)V", true);

--- a/references-jsc.ts
+++ b/references-jsc.ts
@@ -19,6 +19,7 @@
 ///<reference path='vm/runtime.ts' />
 ///<reference path='interpreter.ts' />
 ///<reference path='vm/context.ts' />
+///<reference path='contextQueue.ts' />
 
 // JIT
 

--- a/references.ts
+++ b/references.ts
@@ -18,6 +18,7 @@
 ///<reference path='vm/runtime.ts' />
 ///<reference path='interpreter.ts' />
 ///<reference path='vm/context.ts' />
+///<reference path='contextQueue.ts' />
 
 // JIT
 

--- a/scheduler.ts
+++ b/scheduler.ts
@@ -125,7 +125,7 @@ module J2ME {
              * norm    norm   0.72x
              * high    high   .1x
              */
-            currentTimeScale = -0.03103448276 * (ctx.getPriority() * ctx.runtime.priority) + 1.031034483;
+            currentTimeScale = -0.03103448276 * (ctx.priority * ctx.runtime.priority) + 1.031034483;
             ctx.execute();
             Scheduler.updateCurrentRuntime();
             current = null;

--- a/vm/context.ts
+++ b/vm/context.ts
@@ -551,7 +551,7 @@ module J2ME {
     block(obj, queue, lockLevel) {
       obj._lock[queue].push(this);
       this.lockLevel = lockLevel;
-      $.pause("block");
+      this.pause("block");
     }
 
     unblock(obj, queue, notifyAll) {
@@ -707,6 +707,27 @@ module J2ME {
       if (profiling) {
         this.methodTimeline.leave(key, MethodType[methodType]);
       }
+    }
+
+
+    yield(reason: string) {
+      unwindCount ++;
+      threadWriter && threadWriter.writeLn("yielding " + reason);
+      runtimeCounter && runtimeCounter.count("yielding " + reason);
+      this.U = VMState.Yielding;
+      profile && this.pauseMethodTimeline();
+    }
+
+    pause(reason: string) {
+      unwindCount ++;
+      threadWriter && threadWriter.writeLn("pausing " + reason);
+      runtimeCounter && runtimeCounter.count("pausing " + reason);
+      this.U = VMState.Pausing;
+      profile && this.pauseMethodTimeline();
+    }
+
+    stop() {
+      this.U = VMState.Stopping;
     }
   }
 }

--- a/vm/context.ts
+++ b/vm/context.ts
@@ -318,6 +318,11 @@ module J2ME {
     id: number;
 
     /**
+     * Are we currently unwinding the stack because of a Yield?
+     */
+    U: J2ME.VMState = J2ME.VMState.Running;
+
+    /**
      * Whether or not the context is currently paused.  The profiler uses this
      * to distinguish execution time from paused time in an async method.
      */
@@ -433,6 +438,8 @@ module J2ME {
       release || assert (Frame.isMarker(marker));
     }
 
+    // NB: This does not set this Context as the current context. This must only
+    // be called on the current context.
     executeFrame(frame: Frame) {
       var frames = this.frames;
       frames.push(Frame.Marker);
@@ -440,7 +447,7 @@ module J2ME {
 
       try {
         var returnValue = VM.execute();
-        if (U) {
+        if (this.U) {
           // Prepend all frames up until the first marker to the bailout frames.
           while (true) {
             var frame = frames.pop();
@@ -466,13 +473,13 @@ module J2ME {
       message = "" + message;
       var classInfo = CLASSES.loadAndLinkClass(className);
       classInitCheck(classInfo);
-      release || Debug.assert(!U, "Unexpected unwind during createException.");
+      release || Debug.assert(!this.U, "Unexpected unwind during createException.");
       runtimeCounter && runtimeCounter.count("createException " + className);
       var exception = new classInfo.klass();
       var methodInfo = classInfo.getMethodByNameString("<init>", "(Ljava/lang/String;)V");
       preemptionLockLevel++;
       getLinkedMethod(methodInfo).call(exception, message ? newString(message) : null);
-      release || Debug.assert(!U, "Unexpected unwind during createException.");
+      release || Debug.assert(!this.U, "Unexpected unwind during createException.");
       preemptionLockLevel--;
       return exception;
     }
@@ -511,13 +518,13 @@ module J2ME {
       profile && this.resumeMethodTimeline();
       do {
         VM.execute();
-        if (U) {
+        if (this.U) {
           if (this.bailoutFrames.length) {
             Array.prototype.push.apply(this.frames, this.bailoutFrames);
             this.bailoutFrames = [];
           }
           var frames = this.frames;
-          switch (U) {
+          switch (this.U) {
             case VMState.Yielding:
               this.resume();
               break;
@@ -528,7 +535,7 @@ module J2ME {
               this.kill();
               return;
           }
-          U = VMState.Running;
+          this.U = VMState.Running;
           this.clearCurrentContext();
           return;
         }
@@ -568,7 +575,7 @@ module J2ME {
       } else {
         while (this.lockLevel-- > 0) {
           this.monitorEnter(obj);
-          if (U === VMState.Pausing || U === VMState.Stopping) {
+          if (this.U === VMState.Pausing || this.U === VMState.Stopping) {
             return;
           }
         }

--- a/vm/jvm.ts
+++ b/vm/jvm.ts
@@ -42,7 +42,7 @@ module J2ME {
         Frame.create(isolateClassInfo.getMethodByNameString("<init>", "(Ljava/lang/String;[Ljava/lang/String;)V"),
                                        [ isolate, J2ME.newString(className.replace(/\./g, "/")), array ])
       ]);
-      release || Debug.assert(!U, "Unexpected unwind during isolate initialization.");
+      release || Debug.assert(!ctx.U, "Unexpected unwind during isolate initialization.");
     }
 
     startIsolate(isolate: Isolate) {
@@ -81,7 +81,7 @@ module J2ME {
                                [ runtime.mainThread, J2ME.newString("main") ]));
 
       ctx.start(frames);
-      release || Debug.assert(!U, "Unexpected unwind during isolate initialization.");
+      release || Debug.assert(!ctx.U, "Unexpected unwind during isolate initialization.");
     }
 
   }

--- a/vm/runtime.ts
+++ b/vm/runtime.ts
@@ -454,7 +454,7 @@ module J2ME {
         var methodInfo = runtimeKlass.classObject.klass.classInfo.getMethodByNameString("initialize", "()V");
         runtimeKlass.classObject[methodInfo.virtualName]();
         // runtimeKlass.classObject.initialize();
-        release || Debug.assert(!U, "Unexpected unwind during preInitializeClasses.");
+        release || Debug.assert(!ctx.U, "Unexpected unwind during preInitializeClasses.");
         preemptionLockLevel-- ;
       }
       ctx.clearCurrentContext();
@@ -679,7 +679,7 @@ module J2ME {
       unwindCount ++;
       threadWriter && threadWriter.writeLn("yielding " + reason);
       runtimeCounter && runtimeCounter.count("yielding " + reason);
-      U = VMState.Yielding;
+      this.ctx.U = VMState.Yielding;
       profile && $.ctx.pauseMethodTimeline();
     }
 
@@ -687,12 +687,12 @@ module J2ME {
       unwindCount ++;
       threadWriter && threadWriter.writeLn("pausing " + reason);
       runtimeCounter && runtimeCounter.count("pausing " + reason);
-      U = VMState.Pausing;
+      this.ctx.U = VMState.Pausing;
       profile && $.ctx.pauseMethodTimeline();
     }
 
     stop() {
-      U = VMState.Stopping;
+      this.ctx.U = VMState.Stopping;
     }
 
     constructor(jvm: JVM) {
@@ -1217,7 +1217,7 @@ module J2ME {
             : frame.local[0];
         }
         $.ctx.monitorEnter(frame.lockObject);
-        if (U === VMState.Pausing) {
+        if ($.ctx.U === VMState.Pausing) {
           $.ctx.pushFrame(frame);
           return;
         }
@@ -1336,7 +1336,7 @@ module J2ME {
           default:
             r = fn.apply(this, arguments);
         }
-        if (U) {
+        if ($.ctx.U) {
           release || assert(ctx.paused, "context is paused");
 
           if (methodInfo.isNative) {
@@ -2055,13 +2055,6 @@ module J2ME {
 var Runtime = J2ME.Runtime;
 
 var AOTMD = J2ME.aotMetaData;
-
-/**
- * Are we currently unwinding the stack because of a Yield? This technically
- * belonges to a context but we store it in the global object because it is
- * read very often.
- */
-var U: J2ME.VMState = J2ME.VMState.Running;
 
 // Several unwind throws for different stack heights.
 

--- a/vm/runtime.ts
+++ b/vm/runtime.ts
@@ -675,26 +675,6 @@ module J2ME {
       $.ctx.bailout(methodInfo, location.getPC(), location.getNextPC(), local, stack.slice(0, location.getSP()), lockObject);
     }
 
-    yield(reason: string) {
-      unwindCount ++;
-      threadWriter && threadWriter.writeLn("yielding " + reason);
-      runtimeCounter && runtimeCounter.count("yielding " + reason);
-      this.ctx.U = VMState.Yielding;
-      profile && $.ctx.pauseMethodTimeline();
-    }
-
-    pause(reason: string) {
-      unwindCount ++;
-      threadWriter && threadWriter.writeLn("pausing " + reason);
-      runtimeCounter && runtimeCounter.count("pausing " + reason);
-      this.ctx.U = VMState.Pausing;
-      profile && $.ctx.pauseMethodTimeline();
-    }
-
-    stop() {
-      this.ctx.U = VMState.Stopping;
-    }
-
     constructor(jvm: JVM) {
       super(jvm);
       this.id = Runtime._nextId ++;
@@ -1977,7 +1957,7 @@ module J2ME {
 
   export function preempt() {
     if (Scheduler.shouldPreempt()) {
-      $.yield("preemption");
+      $.ctx.yield("preemption");
     }
   }
 

--- a/vm/runtime.ts
+++ b/vm/runtime.ts
@@ -774,12 +774,10 @@ module J2ME {
   }
 
   export class Lock {
-    ready: Context [];
-    waiting: Context [];
+    ready: ContextQueue = new ContextQueue();
+    waiting: ContextQueue = new ContextQueue();
 
-    constructor(public thread: java.lang.Thread, public level: number) {
-      this.ready = [];
-      this.waiting = [];
+    constructor(public ctx: Context, public level: number) {
     }
   }
 


### PR DESCRIPTION
This PR applies over changes from #1711 so those currently show up in the diff.

ContextQueue is a prioritized queue of `Context` objects. Contexts are
returned from the ContextQueue based on their priority and how long they
have been waiting.

This patch implements ContextQueue and uses it to maintain prioritized
queues of contexts in lock objects. This way, when notify is called, we
give the lock to a context that makes sense due to its priority and how
long it has been waiting.

Results from startup benchmark tests indicate that this has an effect for slower devices but not for faster ones.

On a Macbook Pro:

|         Test         | Baseline Mean |   Mean  |   +/-  |    %   |   P  |     Min    |     Max     | 
|:---------------------|--------------:|--------:|-------:|-------:|-----:|-----------:|------------:|
| startupTime          |       2,739ms | 2,624ms | -116ms |  -4.22 | SAME |    2,114ms |     5,348ms | 
| vmStartupTime        |         335ms |   362ms |   27ms |   7.96 | SAME |      221ms |     2,630ms | 
| bgStartupTime        |          48ms |    48ms |    0ms |   0.35 | SAME |       45ms |        59ms | 
| fgStartupTime        |       2,037ms | 1,813ms | -224ms | -10.98 | SAME |    1,587ms |     2,264ms | 
| fgRefreshStartupTime |         319ms |   401ms |   81ms |  25.47 | SAME |      232ms |     3,107ms | 
| fgRestartTime        |           n/a |   NaNms |    n/a |    n/a |  n/a | Infinityms | -Infinityms |

|         Test         | Baseline Mean |   Mean  |  +/-  |   %  |   P   |     Min    |     Max     | 
|:---------------------|--------------:|--------:|------:|-----:|------:|-----------:|------------:|
| startupTime          |       2,739ms | 2,955ms | 216ms | 7.88 |  SAME |    2,134ms |    14,698ms | 
| vmStartupTime        |         335ms |   339ms |   4ms | 1.09 |  SAME |      227ms |     1,844ms | 
| bgStartupTime        |          48ms |    52ms |   4ms | 7.72 | WORSE |       45ms |        63ms | 
| fgStartupTime        |       2,037ms | 2,215ms | 178ms | 8.73 |  SAME |    1,568ms |    14,320ms | 
| fgRefreshStartupTime |         319ms |   350ms |  31ms | 9.60 |  SAME |       72ms |     4,135ms | 
| fgRestartTime        |           n/a |   NaNms |   n/a |  n/a |   n/a | Infinityms | -Infinityms |




On my Sony Xperia Z3:

|         Test         | Baseline Mean |   Mean   |   +/-  |    %   |   P  |     Min    |     Max     | 
|:---------------------|--------------:|---------:|-------:|-------:|-----:|-----------:|------------:|
| startupTime          |      10,023ms | 10,529ms |  506ms |   5.05 | SAME |    8,624ms |    17,211ms | 
| vmStartupTime        |       1,969ms |  1,747ms | -222ms | -11.26 | SAME |    1,284ms |     2,175ms | 
| bgStartupTime        |         403ms |    462ms |   59ms |  14.70 | SAME |      337ms |       994ms | 
| fgStartupTime        |       6,949ms |  7,619ms |  669ms |   9.63 | SAME |    5,771ms |    14,683ms | 
| fgRefreshStartupTime |         701ms |    700ms |   -1ms |  -0.15 | SAME |      329ms |     1,831ms | 
| fgRestartTime        |           n/a |    NaNms |    n/a |    n/a |  n/a | Infinityms | -Infinityms |

|         Test         | Baseline Mean |   Mean   |  +/-  |   %   |   P  |     Min    |     Max     | 
|:---------------------|--------------:|---------:|------:|------:|-----:|-----------:|------------:|
| startupTime          |      10,023ms | 10,659ms | 636ms |  6.34 | SAME |    7,925ms |    15,299ms | 
| vmStartupTime        |       1,969ms |  1,960ms |  -9ms | -0.46 | SAME |    1,311ms |     2,692ms | 
| bgStartupTime        |         403ms |    403ms |   0ms | -0.10 | SAME |      351ms |       504ms | 
| fgStartupTime        |       6,949ms |  7,504ms | 555ms |  7.98 | SAME |    5,119ms |    11,858ms | 
| fgRefreshStartupTime |         701ms |    792ms |  91ms | 12.94 | SAME |      294ms |     2,982ms | 
| fgRestartTime        |           n/a |    NaNms |   n/a |   n/a |  n/a | Infinityms | -Infinityms | 




On a Flame:

|         Test         | Baseline Mean |    Mean    |     +/-    |     %    |     P    |     Min    |     Max     | 
|:---------------------|--------------:|-----------:|-----------:|---------:|---------:|-----------:|------------:|
| startupTime          |      18,071ms |   17,387ms |     -684ms |    -3.79 |   BETTER |   15,337ms |    18,531ms | 
| vmStartupTime        |       2,596ms |    2,594ms |       -2ms |    -0.08 |     SAME |    2,162ms |     2,846ms | 
| bgStartupTime        |         866ms |      927ms |       61ms |     7.03 |    WORSE |      651ms |     1,077ms | 
| fgStartupTime        |      12,676ms |   12,595ms |      -81ms |    -0.64 |     SAME |   10,604ms |    13,799ms | 
| fgRefreshStartupTime |       1,933ms |    1,271ms |     -662ms |   -34.23 |   BETTER |      704ms |     1,928ms | 
| fgRestartTime        |           n/a |      NaNms |        n/a |      n/a |      n/a | Infinityms | -Infinityms | 

|         Test         | Baseline Mean |    Mean    |     +/-     |     %    |     P    |     Min    |     Max     | 
|:---------------------|--------------:|-----------:|------------:|---------:|---------:|-----------:|------------:|
| startupTime          |      18,071ms |   17,134ms |      -936ms |    -5.18 |   BETTER |   15,378ms |    18,530ms | 
| vmStartupTime        |       2,596ms |    2,562ms |       -34ms |    -1.31 |     SAME |    2,467ms |     2,729ms | 
| bgStartupTime        |         866ms |      836ms |       -30ms |    -3.43 |     SAME |      683ms |       951ms | 
| fgStartupTime        |      12,676ms |   12,447ms |      -229ms |    -1.81 |     SAME |   10,917ms |    14,057ms | 
| fgRefreshStartupTime |       1,933ms |    1,289ms |      -643ms |   -33.29 |   BETTER |      858ms |     2,430ms | 
| fgRestartTime        |           n/a |      NaNms |         n/a |      n/a |      n/a | Infinityms | -Infinityms | 
