### PR TITLE
Use requestAnimationFrame in DisplayDevice.refresh

### DIFF
--- a/java/custom/com/sun/midp/lcdui/RepaintEventProducer.java
+++ b/java/custom/com/sun/midp/lcdui/RepaintEventProducer.java
@@ -174,10 +174,6 @@ public class RepaintEventProducer implements EventListener {
         return true;
     }
 
-    // Called from `process` to ensure that we don't try to repaint
-    // more than once per animation frame
-    private native void waitForAnimationFrame();
-
     /**
      * Process an event.
      *
@@ -185,8 +181,6 @@ public class RepaintEventProducer implements EventListener {
      */
     public void process(Event genericEvent) {
         RepaintEvent event = (RepaintEvent)genericEvent;
-
-        waitForAnimationFrame();
 
         synchronized (this) {
             queuedEvent = null;

--- a/jit/analyze.ts
+++ b/jit/analyze.ts
@@ -25,7 +25,7 @@ module J2ME {
    * at the right spots.
    */
   export var yieldMap = {
-    "com/sun/midp/lcdui/RepaintEventProducer.waitForAnimationFrame.()V": YieldReason.Root,
+    "com/sun/midp/lcdui/DisplayDevice.refresh0.(IIIIII)V": YieldReason.Root,
     "com/sun/midp/main/MIDletSuiteUtils.vmBeginStartUp.(I)V": YieldReason.Root,
     "com/sun/midp/lcdui/DisplayDevice.gainedForeground0.(II)V": YieldReason.Root,
     "com/sun/cdc/io/j2me/file/DefaultFileHandler.openForRead.()V": YieldReason.Root,


### PR DESCRIPTION
This way we only paint when it actually makes sense (i.e. we use
requestAnimationFrame how it was intended).

This patch removes the waitForAnimationFrame function but still accomplishes the throttling that that function intended to provide. This patch also ensures that we paint at the appropriate time. Previously we were queuing a thread for execution during the requestAnimationFrame callback, but then we weren't actually painting, so we were probably painting at inopportune times.

On my Macbook Pro, this drew smoother animations for the Asteroids MIDlet.

This is the result of the startup bench on a Flame device. 100 rounds, 25000ms delay, GC enabled:

|         Test         | Baseline Mean |    Mean    |    +/-    |    %    |     P    |     Min    |     Max     | 
|:---------------------|--------------:|-----------:|----------:|--------:|---------:|-----------:|------------:|
| startupTime          |      16,598ms |   16,874ms |     276ms |    1.66 |     SAME |   14,529ms |    19,236ms | 
| vmStartupTime        |       2,783ms |    2,543ms |    -240ms |   -8.62 |   BETTER |    2,049ms |     2,895ms | 
| bgStartupTime        |         897ms |      874ms |     -23ms |   -2.52 |     SAME |      630ms |     1,086ms | 
| fgStartupTime        |      11,483ms |   12,016ms |     532ms |    4.64 |    WORSE |   10,040ms |    14,775ms | 
| fgRefreshStartupTime |       1,435ms |    1,441ms |       6ms |    0.42 |     SAME |      648ms |     2,706ms | 