### PR TITLE
ensure processJAD called only for jad or downloadJAD (fixes #1666)

### DIFF
--- a/libs/jarstore.js
+++ b/libs/jarstore.js
@@ -86,6 +86,7 @@ var JARStore = (function() {
             directory: zip.directory,
             isBuiltIn: false,
           });
+          jad = jadData;
           resolve();
         };
       });

--- a/main.js
+++ b/main.js
@@ -64,10 +64,6 @@ function processJAD(data) {
   });
 }
 
-if (config.jad) {
-  loadingMIDletPromises.push(load(config.jad, "text").then(processJAD).then(backgroundCheck));
-}
-
 function performDownload(url, callback) {
   showDownloadScreen();
   var progressBar = downloadDialog.querySelector('progress.pack-activity');
@@ -107,7 +103,9 @@ function performDownload(url, callback) {
   });
 }
 
-if (config.downloadJAD) {
+if (config.jad) {
+  loadingMIDletPromises.push(load(config.jad, "text").then(processJAD).then(backgroundCheck));
+} else if (config.downloadJAD) {
   loadingMIDletPromises.push(new Promise(function(resolve, reject) {
     JARStore.loadJAR("midlet.jar").then(function(loaded) {
       if (loaded) {
@@ -125,7 +123,7 @@ if (config.downloadJAD) {
         showSplashScreen();
 
         JARStore.installJAR("midlet.jar", data.jarData, data.jadData).then(function() {
-          processJAD(data.jadData);
+          processJAD(JARStore.getJAD());
           resolve();
         });
       });

--- a/tests/automation.js
+++ b/tests/automation.js
@@ -518,7 +518,7 @@ casper.test.begin("unit tests", 33 + gfxTests.length, function(test) {
     });
 
     casper
-    .thenOpen("http://localhost:8000/index.html?downloadJAD=http://localhost:8000/tests/Manifest1.jad&midletClassName=tests.jaddownloader.AMIDlet&logConsole=web,page&args=1.0.0&logLevel=log")
+    .thenOpen("http://localhost:8000/index.html?jad=&downloadJAD=http://localhost:8000/tests/Manifest1.jad&midletClassName=tests.jaddownloader.AMIDlet&logConsole=web,page&args=1.0.0&logLevel=log")
     .withFrame(0, function() {
         casper.waitForText("DONE", function() {
             test.assertTextExists("SUCCESS 3/3", "test JAD downloader - Download");
@@ -528,7 +528,7 @@ casper.test.begin("unit tests", 33 + gfxTests.length, function(test) {
 
     // Run the test a second time to ensure loading the JAR stored in the JARStore works correctly.
     casper
-    .thenOpen("http://localhost:8000/index.html?downloadJAD=http://localhost:8000/tests/Manifest1.jad&midletClassName=tests.jaddownloader.AMIDlet&logConsole=web,page&args=1.0.0&logLevel=log")
+    .thenOpen("http://localhost:8000/index.html?jad=&downloadJAD=http://localhost:8000/tests/Manifest1.jad&midletClassName=tests.jaddownloader.AMIDlet&logConsole=web,page&args=1.0.0&logLevel=log")
     .withFrame(0, function() {
         casper.waitForText("DONE", function() {
             test.assertTextExists("SUCCESS 3/3", "test JAD downloader - Load");
@@ -539,7 +539,7 @@ casper.test.begin("unit tests", 33 + gfxTests.length, function(test) {
 
     // Run the test that updates the MIDlet
     casper
-    .thenOpen("http://localhost:8000/index.html?downloadJAD=http://localhost:8000/tests/Manifest1.jad&midletClassName=tests.jaddownloader.AMIDletUpdater&logConsole=web,page&logLevel=log")
+    .thenOpen("http://localhost:8000/index.html?jad=&downloadJAD=http://localhost:8000/tests/Manifest1.jad&midletClassName=tests.jaddownloader.AMIDletUpdater&logConsole=web,page&logLevel=log")
     .withFrame(0, function() {
         var alertText = null;
         casper.on('remote.alert', function onAlert(message) {
@@ -557,7 +557,7 @@ casper.test.begin("unit tests", 33 + gfxTests.length, function(test) {
 
     // Verify that the update has been applied
     casper
-    .thenOpen("http://localhost:8000/index.html?downloadJAD=http://localhost:8000/tests/Manifest1.jad&midletClassName=tests.jaddownloader.AMIDlet&logConsole=web,page&args=3.0.0&logLevel=log")
+    .thenOpen("http://localhost:8000/index.html?jad=&downloadJAD=http://localhost:8000/tests/Manifest1.jad&midletClassName=tests.jaddownloader.AMIDlet&logConsole=web,page&args=3.0.0&logLevel=log")
     .withFrame(0, function() {
         casper.waitForText("DONE", function() {
             test.assertTextExists("SUCCESS 3/3", "test JAD downloader - Load after update");
@@ -571,7 +571,7 @@ casper.test.begin("unit tests", 33 + gfxTests.length, function(test) {
     .waitForText("DONE");
 
     casper
-    .thenOpen("http://localhost:8000/index.html?downloadJAD=http://localhost:8000/tests/Manifest2.jad&midletClassName=tests.jaddownloader.AMIDlet&logConsole=web,page&args=2.0.0&logLevel=log")
+    .thenOpen("http://localhost:8000/index.html?jad=&downloadJAD=http://localhost:8000/tests/Manifest2.jad&midletClassName=tests.jaddownloader.AMIDlet&logConsole=web,page&args=2.0.0&logLevel=log")
     .withFrame(0, function() {
         casper.waitForText("DONE", function() {
             test.assertTextExists("SUCCESS 3/3", "test JAD downloader - Download with absolute URL");


### PR DESCRIPTION
This fixes #1666, which is a regression from #1578.  Now that runtests.js sets config.jad, config.jad and config.downloadJAD are both defined during the JAD downloader tests, so main.js loads and processes both of them.

Those loads are both asynchronous, and they race each other, so the failure happens when config.jad is processed second, and its data overwrites the data processed from config.downloadJAD.

This changeset does two things to address the issue:

1. Only ever loads one of the two files, preferring config.jad, which should cause these tests to fail consistently rather than intermittently.
2. Unsets config.jad for the JAD Downloader tests, so the tests pass instead of failing.

Along the way, I noticed that *JARStore.installJAR* doesn't set JARStore's *jar* private variable, which means *JARStore.getJAD* will return an undefined value during an install run.  Currently, we never call it during an install run, but it still seems like a footgun, so I fixed that too and made main.js call *JARStore.getJAD* during an install run to ensure it works (and works the same as it does during a non-install run).
