### PR TITLE
Allocate collectable thread objects and enable collection of thread stacks

### DIFF
--- a/int.ts
+++ b/int.ts
@@ -190,7 +190,7 @@ module J2ME {
       var fp = this.fp;
       var sp = this.sp;
       var pc = this.pc;
-      while (this.fp > this.thread.tp) {
+      while (this.fp > (this.thread.tp >> 2)) {
         writer.writeLn((this.methodInfo ? this.methodInfo.implKey : "null") + ", FP: " + this.fp + ", SP: " + this.sp + ", PC: " + this.pc);
         this.set(this.thread, i32[this.fp + FrameLayout.CallerFPOffset],
                  this.fp + this.parameterOffset,
@@ -283,14 +283,14 @@ module J2ME {
     view: FrameView;
 
     constructor(ctx: Context) {
-      this.tp = ASM._gcMallocUncollectable(1024 * 256) >> 2;
-      this.bp = this.tp;
+      this.tp = ASM._gcMallocUncollectable(1024 * 256);
+      this.bp = this.tp >> 2;
       this.fp = this.bp;
       this.sp = this.fp;
       this.pc = -1;
       this.view = new FrameView();
       this.ctx = ctx;
-      release || threadWriter && threadWriter.writeLn("creatingThread: tp: " + toHEX(this.tp << 2) + " " + toHEX(i32.byteLength));
+      release || threadWriter && threadWriter.writeLn("creatingThread: tp: " + toHEX(this.tp) + " " + toHEX(i32.byteLength));
     }
 
     set(fp: number, sp: number, pc: number) {

--- a/int.ts
+++ b/int.ts
@@ -283,7 +283,7 @@ module J2ME {
     view: FrameView;
 
     constructor(ctx: Context) {
-      this.tp = ASM._gcMallocUncollectable(1024 * 256);
+      this.tp = ASM._gcMalloc(1024 * 256);
       this.bp = this.tp >> 2;
       this.fp = this.bp;
       this.sp = this.fp;

--- a/native.js
+++ b/native.js
@@ -654,7 +654,7 @@ Native["com/sun/cldc/isolate/Isolate.registerNewIsolate.()V"] = function(addr) {
 };
 
 Native["com/sun/cldc/isolate/Isolate.getStatus.()I"] = function(addr) {
-    var runtime = Runtime.isolateMap[addr];
+    var runtime = NativeMap.get(addr);
     return runtime ? runtime.status : J2ME.RuntimeStatus.New;
 };
 
@@ -664,7 +664,7 @@ Native["com/sun/cldc/isolate/Isolate.nativeStart.()V"] = function(addr) {
 };
 
 Native["com/sun/cldc/isolate/Isolate.waitStatus.(I)V"] = function(addr, status) {
-    var runtime = Runtime.isolateMap[addr];
+    var runtime = NativeMap.get(addr);
     asyncImpl("V", new Promise(function(resolve, reject) {
         if (runtime.status >= status) {
             resolve();

--- a/vm/context.ts
+++ b/vm/context.ts
@@ -416,7 +416,10 @@ module J2ME {
         methodTimelines.push(this.methodTimeline);
       }
 
-      this.threadData = new Int32Array(ASM.buffer, ASM._gcMallocUncollectable(4), 1);
+      setUncollectable(this.nativeThread.tp);
+      this.threadData = new Int32Array(ASM.buffer, ASM._gcMallocUncollectable(8), 2);
+      this.threadData[1] = this.nativeThread.tp;
+      unsetUncollectable(this.nativeThread.tp);
     }
 
     public set threadAddress(addr: number) {

--- a/vm/context.ts
+++ b/vm/context.ts
@@ -354,7 +354,7 @@ module J2ME {
       // so we cache it here.
       runtime.isolateId = isolate._id;
 
-      Runtime.isolateMap[isolate._address] = runtime;
+      NativeMap.set(isolate._address, runtime);
 
       var sys = CLASSES.getClass("org/mozilla/internal/Sys");
 

--- a/vm/native/native.cpp
+++ b/vm/native/native.cpp
@@ -56,7 +56,9 @@ extern "C" {
 
   uintptr_t gcMallocUncollectable(int32_t size) {
     uintptr_t p = (uintptr_t)GC_MALLOC_UNCOLLECTABLE(size);
+    GC_disable();
     GC_REGISTER_FINALIZER((void*)p, finalizer, NULL, (GC_finalization_proc*)0, (void**)0);
+    GC_enable();
     return p;
   }
 
@@ -66,13 +68,17 @@ extern "C" {
 
   uintptr_t gcMalloc(int32_t size) {
     uintptr_t p = (uintptr_t)GC_MALLOC(size);
+    GC_disable();
     GC_REGISTER_FINALIZER((void*)p, finalizer, NULL, (GC_finalization_proc*)0, (void**)0);
+    GC_enable();
     return p;
   }
 
   uintptr_t gcMallocAtomic(int32_t size) {
     uintptr_t p = (uintptr_t)GC_MALLOC_ATOMIC(size);
+    GC_disable();
     GC_REGISTER_FINALIZER((void*)p, finalizer, NULL, (GC_finalization_proc*)0, (void**)0);
+    GC_enable();
     return p;
   }
 

--- a/vm/runtime.ts
+++ b/vm/runtime.ts
@@ -425,8 +425,6 @@ module J2ME {
   export class RuntimeTemplate {
     static all = new Set();
 
-    static isolateMap = Object.create(null);
-
     jvm: JVM;
     status: RuntimeStatus;
     waiting: any [];

--- a/vm/runtime.ts
+++ b/vm/runtime.ts
@@ -1850,14 +1850,6 @@ module J2ME {
     return new klass();
   }
 
-  export function allocUncollectableObject(klass: Klass): number {
-    // This could be implemented via a call to newObject, at the cost
-    // of creating a temporary object: return newObject(klass)._address;
-    var address = ASM._gcMallocUncollectable(Constants.OBJ_HDR_SIZE + klass.classInfo.sizeOfFields);
-    i32[address >> 2] = klass.id | 0;
-    return address;
-  }
-
   export function allocObject(klass: Klass): number {
     // This could be implemented via a call to newObject, at the cost
     // of creating a temporary object: return newObject(klass)._address;


### PR DESCRIPTION
This also contains code to support collecting thread stacks, but it isn't enabled yet because there's still one bug left to fix.

Depends on #1739 and #1741.