### PR TITLE
Remove build-src/ directoy when building

### DIFF
--- a/java/Makefile
+++ b/java/Makefile
@@ -26,6 +26,7 @@ classes.jar: $(SRCS) $(JPP_DESTS) $(EXTRA)
 	$(foreach dir,$(SRC_DIRS),cp -a $(dir)/. build-src/;)
 	find ./build-src -name *.java > build-srcs.txt
 	javac -cp build-src -g:none -source 1.3 -target 1.3 -bootclasspath "" -extdirs "" -d ./build @build-srcs.txt > /dev/null
+	rm -rf build-src
 	# TODO: Re-enable Soot optimizations once tests with baseline JIT enabled
 	#       for all methods pass.
 	#java -jar ../build_tools/soot-trunk.jar -j2me -process-dir build -no-output-source-file-attribute -no-output-inner-classes-attribute -force-overwrite -include-all 2>&1 > /dev/null


### PR DESCRIPTION
In the default GNOME file manager (Nautilus), search results are organized in a list which contains the name of the file, its parent directory and some other info.
There isn't a column for the entire path (there was in a previous version), so searching for a Java file in our repo is annoying for me (because I always find multiple files and I don't know which one I should open).
Since build-src/ is a temporary directory and isn't actually needed, I'd like to remove it when the build is finished.