### PR TITLE
Support multiple weak references to the same object

### DIFF
--- a/nat.ts
+++ b/nat.ts
@@ -162,6 +162,8 @@ module J2ME {
 
         while (refs[i] != addr && i++ < refs.length);
 
+        release || assert(i < refs.length, "found WeakReference object in the weakReferences map");
+
         refs.splice(i, 1);
 
         if (refs.length === 0) {

--- a/tests/java/lang/ref/TestWeakReference.java
+++ b/tests/java/lang/ref/TestWeakReference.java
@@ -4,7 +4,7 @@ import gnu.testlet.Testlet;
 import gnu.testlet.TestHarness;
 
 public class TestWeakReference implements Testlet {
-  public int getExpectedPass() { return 8; }
+  public int getExpectedPass() { return 11; }
   public int getExpectedFail() { return 0; }
   public int getExpectedKnownFail() { return 0; }
 

--- a/tests/java/lang/ref/TestWeakReference.java
+++ b/tests/java/lang/ref/TestWeakReference.java
@@ -10,13 +10,19 @@ public class TestWeakReference implements Testlet {
 
   int objAddr;
   WeakReference gcWeakRef;
+  WeakReference gcWeakRef2;
 
   class SetWeakRefThread extends Thread {
     public void run() {
       Object obj = new Object();
       gcWeakRef = new WeakReference(obj);
+      gcWeakRef2 = new WeakReference(obj);
     }
   }
+
+  native void setNative(Object object);
+  native boolean checkNative(Object object);
+  native void simulateFinalizer(Object object);
 
   public void test(TestHarness th) {
     Object obj = new Object();
@@ -31,6 +37,7 @@ public class TestWeakReference implements Testlet {
     th.check(weakRef.get() == null, "clearing a cleared WeakReference works");
     th.check(weakRef2.get(), obj, "second weakly held referent is object");
 
+
     SetWeakRefThread thread = new SetWeakRefThread();
     thread.start();
     try {
@@ -40,10 +47,27 @@ public class TestWeakReference implements Testlet {
     }
 
     th.check(gcWeakRef.get() != null, "weakly held referent isn't null");
+    th.check(gcWeakRef2.get() != null, "second weakly held referent isn't null");
     Runtime.getRuntime().gc();
     Runtime.getRuntime().gc();
     th.check(gcWeakRef.get() == null, "GC cleared weakly held referent is null");
+    th.check(gcWeakRef2.get() == null, "second GC cleared weakly held referent is null");
     gcWeakRef.clear();
-    th.check(weakRef.get() == null, "clearing a WeakReference cleared by the GC works");
+    th.check(gcWeakRef.get() == null, "clearing a WeakReference cleared by the GC works");
+
+
+    WeakReference clearWeakRef = new WeakReference(obj);
+    clearWeakRef.clear();
+
+    // Simulate the situation where a native is attached to an object allocated
+    // at the same address as a WeakReference object. In theory this could happen
+    // after a WeakReference object is garbage collected.
+    setNative(clearWeakRef);
+
+    simulateFinalizer(obj);
+
+    // Check that the native object is still in the NativeMap. If we don't clear
+    // the WeakReference correctly, this could fail.
+    th.check(checkNative(clearWeakRef), "native object still exists");
   }
 }

--- a/tests/native.js
+++ b/tests/native.js
@@ -287,3 +287,15 @@ Native["tests/midlets/ContentHandlerMIDlet.shouldStop.()Z"] = function(addr) {
 
   return 0;
 };
+
+Native["java/lang/ref/TestWeakReference.setNative.(Ljava/lang/Object;)V"] = function(addr, objAddr) {
+  NativeMap.set(objAddr, { prop: "ciao", });
+};
+
+Native["java/lang/ref/TestWeakReference.checkNative.(Ljava/lang/Object;)Z"] = function(addr, objAddr) {
+  return (NativeMap.has(objAddr) && NativeMap.get(objAddr).prop === "ciao") ? 1 : 0
+};
+
+Native["java/lang/ref/TestWeakReference.simulateFinalizer.(Ljava/lang/Object;)V"] = function(addr, objAddr) {
+  J2ME.onFinalize(objAddr);
+};

--- a/vm/runtime.ts
+++ b/vm/runtime.ts
@@ -1199,15 +1199,17 @@ module J2ME {
     return address;
   }
 
-  export var weakReferences = new Map<number,number>();
+  export var weakReferences = new Map<number,number[]>();
 
   export function onFinalize(addr: number): void {
     NativeMap.delete(addr);
 
-    var weakReferenceAddr = weakReferences.get(addr);
-    if (weakReferenceAddr) {
+    var weakReferenceAddresses = weakReferences.get(addr);
+    if (weakReferenceAddresses) {
+      for (var i = 0; i < weakReferenceAddresses.length; i++) {
+        NativeMap.delete(weakReferenceAddresses[i]);
+      }
       weakReferences.delete(addr);
-      NativeMap.delete(weakReferenceAddr);
     }
   }
 
@@ -1347,6 +1349,7 @@ module J2ME {
     i32[(uncollectableAddress >> 2) + uncollectableNumber] = 0;
     uncollectableNumber--;
   }
+
   export function newArray(elementClassInfo: ClassInfo, size: number): number {
     release || assert(elementClassInfo instanceof ClassInfo);
     if (size < 0) {


### PR DESCRIPTION
This fixes a bug with WhatsApp.
An "easy" way to reproduce it is to open the "Verify your phone number" screen and then open/close the country list several times.