### PR TITLE
Fix TestRuntime

### DIFF
--- a/tests/org/mozilla/gc/TestRuntime.java
+++ b/tests/org/mozilla/gc/TestRuntime.java
@@ -31,7 +31,7 @@ public class TestRuntime implements Testlet {
         th.check(totalMemory > freeMemory, "Total memory is strictly greater than free memory");
         th.check(freeMemory > 0, "Free memory is strictly greater than 0");
 
-        long[] array = new long[1048576];
+        long[] array = new long[1024];
 
         System.out.println("freeMemory2: " + Runtime.getRuntime().freeMemory());
 

--- a/tests/org/mozilla/gc/TestRuntime.java
+++ b/tests/org/mozilla/gc/TestRuntime.java
@@ -8,10 +8,20 @@ public class TestRuntime implements Testlet {
     public int getExpectedFail() { return 0; }
     public int getExpectedKnownFail() { return 0; }
 
+    void collectAll() {
+        long freeMemory;
+        long endFreeMemory;
+        do {
+            freeMemory = Runtime.getRuntime().freeMemory();
+            Runtime.getRuntime().gc();
+            endFreeMemory = Runtime.getRuntime().freeMemory();
+        } while (endFreeMemory > freeMemory);
+    }
+
     public void test(TestHarness th) {
         System.out.println("freeMemory0: " + Runtime.getRuntime().freeMemory());
 
-        Runtime.getRuntime().gc();
+        collectAll();
 
         long totalMemory = Runtime.getRuntime().totalMemory();
         long freeMemory = Runtime.getRuntime().freeMemory();
@@ -32,7 +42,7 @@ public class TestRuntime implements Testlet {
 
         array = null;
 
-        Runtime.getRuntime().gc();
+        collectAll();
 
         System.out.println("freeMemory3: " + Runtime.getRuntime().freeMemory());
 


### PR DESCRIPTION
I think the problem was that we currently don't set pointers to object interiors as invalid.
Indeed, I was able to reproduce the bug on my machine if I set the size of the array to 10485760, but the bug wasn't reproducible if I merged https://github.com/mozilla/pluotsorbet/pull/1622 into my branch.

I've modified the test to make it reliable also for small allocations (so that https://github.com/mozilla/pluotsorbet/pull/1622 isn't required to make this test reliable) by forcing collections until every dead object is freed before running the test.