### PR TITLE
update license text for files from Jikes RVM

### DIFF
--- a/tests/gnu/testlet/vm/TestArithmetic.java
+++ b/tests/gnu/testlet/vm/TestArithmetic.java
@@ -9,6 +9,9 @@
  *
  *  See the COPYRIGHT.txt file distributed with this work for information
  *  regarding copyright ownership.
+ *
+ *  Alternatively, this file is licensed to You under the MIT License:
+ *      http://opensource.org/licenses/MIT .
  */
 package gnu.testlet.vm;
 

--- a/tests/test/org/jikesrvm/basic/bugs/R1644449.java
+++ b/tests/test/org/jikesrvm/basic/bugs/R1644449.java
@@ -9,6 +9,9 @@
  *
  *  See the COPYRIGHT.txt file distributed with this work for information
  *  regarding copyright ownership.
+ *
+ *  Alternatively, this file is licensed to You under the MIT License:
+ *      http://opensource.org/licenses/MIT .
  */
 package test.org.jikesrvm.basic.bugs;
 

--- a/tests/test/org/jikesrvm/basic/bugs/R1644460.java
+++ b/tests/test/org/jikesrvm/basic/bugs/R1644460.java
@@ -9,6 +9,9 @@
  *
  *  See the COPYRIGHT.txt file distributed with this work for information
  *  regarding copyright ownership.
+ *
+ *  Alternatively, this file is licensed to You under the MIT License:
+ *      http://opensource.org/licenses/MIT .
  */
 package test.org.jikesrvm.basic.bugs;
 

--- a/tests/test/org/jikesrvm/basic/bugs/R1644460_B.java
+++ b/tests/test/org/jikesrvm/basic/bugs/R1644460_B.java
@@ -9,6 +9,9 @@
  *
  *  See the COPYRIGHT.txt file distributed with this work for information
  *  regarding copyright ownership.
+ *
+ *  Alternatively, this file is licensed to You under the MIT License:
+ *      http://opensource.org/licenses/MIT .
  */
 package test.org.jikesrvm.basic.bugs;
 

--- a/tests/test/org/jikesrvm/basic/bugs/R1657236.java
+++ b/tests/test/org/jikesrvm/basic/bugs/R1657236.java
@@ -9,6 +9,9 @@
  *
  *  See the COPYRIGHT.txt file distributed with this work for information
  *  regarding copyright ownership.
+ *
+ *  Alternatively, this file is licensed to You under the MIT License:
+ *      http://opensource.org/licenses/MIT .
  */
 package test.org.jikesrvm.basic.bugs;
 

--- a/tests/test/org/jikesrvm/basic/core/bytecode/TestArrayAccess.java
+++ b/tests/test/org/jikesrvm/basic/core/bytecode/TestArrayAccess.java
@@ -9,6 +9,9 @@
  *
  *  See the COPYRIGHT.txt file distributed with this work for information
  *  regarding copyright ownership.
+ *
+ *  Alternatively, this file is licensed to You under the MIT License:
+ *      http://opensource.org/licenses/MIT .
  */
 package test.org.jikesrvm.basic.core.bytecode;
 

--- a/tests/test/org/jikesrvm/basic/core/bytecode/TestCompare.java
+++ b/tests/test/org/jikesrvm/basic/core/bytecode/TestCompare.java
@@ -9,6 +9,9 @@
  *
  *  See the COPYRIGHT.txt file distributed with this work for information
  *  regarding copyright ownership.
+ *
+ *  Alternatively, this file is licensed to You under the MIT License:
+ *      http://opensource.org/licenses/MIT .
  */
 package test.org.jikesrvm.basic.core.bytecode;
 

--- a/tests/test/org/jikesrvm/basic/core/bytecode/TestConstants.java
+++ b/tests/test/org/jikesrvm/basic/core/bytecode/TestConstants.java
@@ -9,6 +9,9 @@
  *
  *  See the COPYRIGHT.txt file distributed with this work for information
  *  regarding copyright ownership.
+ *
+ *  Alternatively, this file is licensed to You under the MIT License:
+ *      http://opensource.org/licenses/MIT .
  */
 package test.org.jikesrvm.basic.core.bytecode;
 

--- a/tests/test/org/jikesrvm/basic/core/bytecode/TestFieldAccess.java
+++ b/tests/test/org/jikesrvm/basic/core/bytecode/TestFieldAccess.java
@@ -9,6 +9,9 @@
  *
  *  See the COPYRIGHT.txt file distributed with this work for information
  *  regarding copyright ownership.
+ *
+ *  Alternatively, this file is licensed to You under the MIT License:
+ *      http://opensource.org/licenses/MIT .
  */
 package test.org.jikesrvm.basic.core.bytecode;
 

--- a/tests/test/org/jikesrvm/basic/core/bytecode/TestFinally.java
+++ b/tests/test/org/jikesrvm/basic/core/bytecode/TestFinally.java
@@ -9,6 +9,9 @@
  *
  *  See the COPYRIGHT.txt file distributed with this work for information
  *  regarding copyright ownership.
+ *
+ *  Alternatively, this file is licensed to You under the MIT License:
+ *      http://opensource.org/licenses/MIT .
  */
 package test.org.jikesrvm.basic.core.bytecode;
 

--- a/tests/test/org/jikesrvm/basic/core/bytecode/TestFloatingRem.java
+++ b/tests/test/org/jikesrvm/basic/core/bytecode/TestFloatingRem.java
@@ -9,6 +9,9 @@
  *
  *  See the COPYRIGHT.txt file distributed with this work for information
  *  regarding copyright ownership.
+ *
+ *  Alternatively, this file is licensed to You under the MIT License:
+ *      http://opensource.org/licenses/MIT .
  */
 package test.org.jikesrvm.basic.core.bytecode;
 

--- a/tests/test/org/jikesrvm/basic/core/bytecode/TestInstanceOf.java
+++ b/tests/test/org/jikesrvm/basic/core/bytecode/TestInstanceOf.java
@@ -9,6 +9,9 @@
  *
  *  See the COPYRIGHT.txt file distributed with this work for information
  *  regarding copyright ownership.
+ *
+ *  Alternatively, this file is licensed to You under the MIT License:
+ *      http://opensource.org/licenses/MIT .
  */
 package test.org.jikesrvm.basic.core.bytecode;
 

--- a/tests/test/org/jikesrvm/basic/core/bytecode/TestInvoke.java
+++ b/tests/test/org/jikesrvm/basic/core/bytecode/TestInvoke.java
@@ -9,6 +9,9 @@
  *
  *  See the COPYRIGHT.txt file distributed with this work for information
  *  regarding copyright ownership.
+ *
+ *  Alternatively, this file is licensed to You under the MIT License:
+ *      http://opensource.org/licenses/MIT .
  */
 package test.org.jikesrvm.basic.core.bytecode;
 

--- a/tests/test/org/jikesrvm/basic/core/bytecode/TestResolveOnCheckcast.java
+++ b/tests/test/org/jikesrvm/basic/core/bytecode/TestResolveOnCheckcast.java
@@ -9,6 +9,9 @@
  *
  *  See the COPYRIGHT.txt file distributed with this work for information
  *  regarding copyright ownership.
+ *
+ *  Alternatively, this file is licensed to You under the MIT License:
+ *      http://opensource.org/licenses/MIT .
  */
 package test.org.jikesrvm.basic.core.bytecode;
 

--- a/tests/test/org/jikesrvm/basic/core/bytecode/TestResolveOnInstanceof.java
+++ b/tests/test/org/jikesrvm/basic/core/bytecode/TestResolveOnInstanceof.java
@@ -9,6 +9,9 @@
  *
  *  See the COPYRIGHT.txt file distributed with this work for information
  *  regarding copyright ownership.
+ *
+ *  Alternatively, this file is licensed to You under the MIT License:
+ *      http://opensource.org/licenses/MIT .
  */
 package test.org.jikesrvm.basic.core.bytecode;
 

--- a/tests/test/org/jikesrvm/basic/core/bytecode/TestResolveOnInvokeInterface.java
+++ b/tests/test/org/jikesrvm/basic/core/bytecode/TestResolveOnInvokeInterface.java
@@ -9,6 +9,9 @@
  *
  *  See the COPYRIGHT.txt file distributed with this work for information
  *  regarding copyright ownership.
+ *
+ *  Alternatively, this file is licensed to You under the MIT License:
+ *      http://opensource.org/licenses/MIT .
  */
 package test.org.jikesrvm.basic.core.bytecode;
 

--- a/tests/test/org/jikesrvm/basic/core/bytecode/TestReturn.java
+++ b/tests/test/org/jikesrvm/basic/core/bytecode/TestReturn.java
@@ -9,6 +9,9 @@
  *
  *  See the COPYRIGHT.txt file distributed with this work for information
  *  regarding copyright ownership.
+ *
+ *  Alternatively, this file is licensed to You under the MIT License:
+ *      http://opensource.org/licenses/MIT .
  */
 package test.org.jikesrvm.basic.core.bytecode;
 

--- a/tests/test/org/jikesrvm/basic/core/bytecode/TestSwitch.java
+++ b/tests/test/org/jikesrvm/basic/core/bytecode/TestSwitch.java
@@ -9,6 +9,9 @@
  *
  *  See the COPYRIGHT.txt file distributed with this work for information
  *  regarding copyright ownership.
+ *
+ *  Alternatively, this file is licensed to You under the MIT License:
+ *      http://opensource.org/licenses/MIT .
  */
 package test.org.jikesrvm.basic.core.bytecode;
 

--- a/tests/test/org/jikesrvm/basic/core/bytecode/TestThrownException.java
+++ b/tests/test/org/jikesrvm/basic/core/bytecode/TestThrownException.java
@@ -9,6 +9,9 @@
  *
  *  See the COPYRIGHT.txt file distributed with this work for information
  *  regarding copyright ownership.
+ *
+ *  Alternatively, this file is licensed to You under the MIT License:
+ *      http://opensource.org/licenses/MIT .
  */
 package test.org.jikesrvm.basic.core.bytecode;
 

--- a/tests/test/org/jikesrvm/basic/core/classloading/TestClassLoading.java
+++ b/tests/test/org/jikesrvm/basic/core/classloading/TestClassLoading.java
@@ -9,6 +9,9 @@
  *
  *  See the COPYRIGHT.txt file distributed with this work for information
  *  regarding copyright ownership.
+ *
+ *  Alternatively, this file is licensed to You under the MIT License:
+ *      http://opensource.org/licenses/MIT .
  */
 package test.org.jikesrvm.basic.core.classloading;
 

--- a/tests/test/org/jikesrvm/basic/core/classloading/TestUTF8.java
+++ b/tests/test/org/jikesrvm/basic/core/classloading/TestUTF8.java
@@ -9,6 +9,9 @@
  *
  *  See the COPYRIGHT.txt file distributed with this work for information
  *  regarding copyright ownership.
+ *
+ *  Alternatively, this file is licensed to You under the MIT License:
+ *      http://opensource.org/licenses/MIT .
  */
 package test.org.jikesrvm.basic.core.classloading;
 

--- a/tests/test/org/jikesrvm/basic/java/lang/TestMath.java
+++ b/tests/test/org/jikesrvm/basic/java/lang/TestMath.java
@@ -9,6 +9,9 @@
  *
  *  See the COPYRIGHT.txt file distributed with this work for information
  *  regarding copyright ownership.
+ *
+ *  Alternatively, this file is licensed to You under the MIT License:
+ *      http://opensource.org/licenses/MIT .
  */
 package test.org.jikesrvm.basic.java.lang;
 


### PR DESCRIPTION
This updates the license text for files from the Jikes RVM, to which an MIT license was added recently to accommodate our use in this project: http://hg.code.sourceforge.net/p/jikesrvm/code/rev/ddd749963080.