### PR TITLE
Fix race conditions in TestLocalMsgProtocol.

### DIFF
--- a/tests/org/mozilla/io/TestLocalMsgProtocol.java
+++ b/tests/org/mozilla/io/TestLocalMsgProtocol.java
@@ -307,11 +307,15 @@ public class TestLocalMsgProtocol implements Testlet {
             // Test three scenarios that might exhibit race conditions.
 
             // Scenario 1
+            // 1) Server creates a localmsg server
+            // 2) Server calls acceptAndOpen
+            // 3) Client opens a localmsg server
             Thread serverCreateThread = new ThreadServerCreate();
             serverCreateThread.start();
             serverCreateThread.join();
             Thread serverAcceptAndOpenThread = new ThreadServerAcceptAndOpen();
             serverAcceptAndOpenThread.start();
+            Thread.sleep(1000);
             Thread clientThread = new ThreadClientCreate();
             clientThread.start();
             serverAcceptAndOpenThread.join();
@@ -322,9 +326,13 @@ public class TestLocalMsgProtocol implements Testlet {
             serverNum++;
 
             // Scenario 2
+            // 1) Server creates a localmsg server
+            // 2) Client opens a localmsg server
+            // 3) Server calls acceptAndOpen
             serverCreateThread.start();
             serverCreateThread.join();
             clientThread.start();
+            Thread.sleep(1000);
             serverAcceptAndOpenThread.start();
             serverAcceptAndOpenThread.join();
             clientThread.join();
@@ -334,7 +342,11 @@ public class TestLocalMsgProtocol implements Testlet {
             serverNum++;
 
             // Scenario 3
+            // 1) Client opens a localmsg server
+            // 2) Server creates a localmsg server
+            // 3) Server calls acceptAndOpen
             clientThread.start();
+            Thread.sleep(1000);
             serverCreateThread.start();
             serverCreateThread.join();
             serverAcceptAndOpenThread.start();


### PR DESCRIPTION
TestLocalMsgProtocol has some logic that looks like this:

    synchronized (someLockObject) {
        someFlag = true;
        someLockObject.notifyAll();
    }

    someBlockingFunctionThatMakesFlagActuallyTrue();

That's clearly a race condition, as the condition flag is set before the
condition is actually true. If we're relying on timing here, we're
giving ourselves a false sense of security.

Additionally, TestLocalMsgProtocol uses wait-loops to wait for
connections to be opened. However, it also opens those connections on
separate threads, so the wait-loops are unnecessary because we can just
`join` on the thread that creates the connection.

Fixes #1782