### PR TITLE
Reduce Boehm's stack size to 16 kB

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -318,7 +318,7 @@ endif
 bld/native.js: Makefile vm/native/native.cpp vm/native/Boehm.js/.libs/$(BOEHM_LIB)
 	mkdir -p bld
 	rm -f bld/native.js
-	emcc -Ivm/native/Boehm.js/include/ vm/native/Boehm.js/.libs/$(BOEHM_LIB) -Oz -O3 vm/native/native.cpp -o native.raw.js --memory-init-file 0 -s TOTAL_STACK=4*1024*1024 -s TOTAL_MEMORY=$(ASMJS_TOTAL_MEMORY) \
+	emcc -Ivm/native/Boehm.js/include/ vm/native/Boehm.js/.libs/$(BOEHM_LIB) -Oz -O3 vm/native/native.cpp -o native.raw.js --memory-init-file 0 -s TOTAL_STACK=16*1024 -s TOTAL_MEMORY=$(ASMJS_TOTAL_MEMORY) \
 	-s 'EXPORTED_FUNCTIONS=["_main", "_lAdd", "_lNeg", "_lSub", "_lShl", "_lShr", "_lUshr", "_lMul", "_lDiv", "_lRem", "_lCmp", "_gcMallocUncollectable", "_gcFree", "_gcMalloc", "_gcMallocAtomic", "_gcRegisterDisappearingLink", "_gcUnregisterDisappearingLink", "_registerFinalizer", "_forceCollection", "_getUsedHeapSize"]' \
 	-s 'DEFAULT_LIBRARY_FUNCS_TO_INCLUDE=["memcpy", "memset", "malloc", "free", "puts"]' \
 	-s NO_EXIT_RUNTIME=1 -s NO_BROWSER=1 -s NO_FILESYSTEM=1


### PR DESCRIPTION
We're currently using 4 MB, but tests and WhatsApp are running fine with 16 kB (the stack-related assertions added by Emscripten by compiling with *-s ASSERTIONS=2* aren't failing).