### PR TITLE
Reduce Java threads' stack size to 4 kB

### DIFF
--- a/int.ts
+++ b/int.ts
@@ -283,7 +283,7 @@ module J2ME {
     view: FrameView;
 
     constructor(ctx: Context) {
-      this.tp = ASM._gcMalloc(1024 * 256);
+      this.tp = ASM._gcMalloc(4 * 1024);
       this.bp = this.tp >> 2;
       this.fp = this.bp;
       this.sp = this.fp;


### PR DESCRIPTION
This is the default stack size for phoneME Java threads.
phoneME employs a mechanism to grow the stack size when needed (up to 128 kB).

Looks like WhatsApp and tests are running fine with 4 kB.

While running WhatsApp, I've logged the number of threads active on the contact list screen. There are 18 threads in the first isolate and 11 in the second isolate.
Their stacks are occupying *7,25 MB* before this patch, *0,113... MB* after.

I've run the following operations in the JS console (WhatsApp, startup to the contact list, open a conversation, return to the contact list), they confirm the memory savings.
Before:
```
ASM._getUsedHeapSize()
13238272
ASM._forceCollection()

ASM._getUsedHeapSize()
9281536
```

After:
```
ASM._getUsedHeapSize()
1785856
ASM._forceCollection()

ASM._getUsedHeapSize()
1536000
```