### PR TITLE
Optimize System::arraycopy

### DIFF
--- a/bench/ArrayCopyBench.java
+++ b/bench/ArrayCopyBench.java
@@ -1,0 +1,71 @@
+package benchmark;
+
+import com.sun.cldchi.jvm.JVM;
+
+public class ArrayCopyBench {
+    int sizes[] = {
+      2,
+      4,
+      8,
+      16,
+      32,
+      64,
+      128,
+      256,
+      512,
+      1024,
+      2048,
+      4096
+    };
+
+    void runBenchmark() {
+      long start, time;
+
+      // Primitive array
+      for (int i = 0; i < sizes.length; i++) {
+          int size = sizes[i];
+
+          char[] srcArray = new char[size];
+          char[] dstArray = new char[size];
+          start = JVM.monotonicTimeMillis();
+          for (int k = 0; k < 20000; k++) {
+            System.arraycopy(srcArray, 0, dstArray, 0, size);
+          }
+          time = JVM.monotonicTimeMillis() - start;
+          System.out.println("ArrayCopyBench-char-" + size + ": " + time);
+      }
+
+      // Object array
+      for (int i = 0; i < sizes.length; i++) {
+          int size = sizes[i];
+
+          Object[] srcArray = new Object[size];
+          Object[] dstArray = new Object[size];
+          start = JVM.monotonicTimeMillis();
+          for (int k = 0; k < 20000; k++) {
+            System.arraycopy(srcArray, 0, dstArray, 0, size);
+          }
+          time = JVM.monotonicTimeMillis() - start;
+          System.out.println("ArrayCopyBench-Object-" + size + ": " + time);
+      }
+
+      // Object array with casting
+      for (int i = 0; i < sizes.length; i++) {
+          int size = sizes[i];
+
+          Object[] srcArray = new Object[size];
+          String[] dstArray = new String[size];
+          start = JVM.monotonicTimeMillis();
+          for (int k = 0; k < 20000; k++) {
+            System.arraycopy(srcArray, 0, dstArray, 0, size);
+          }
+          time = JVM.monotonicTimeMillis() - start;
+          System.out.println("ArrayCopyBench-Object_with_casting-" + size + ": " + time);
+      }
+    }
+
+    public static void main(String args[]) {
+      ArrayCopyBench bench = new ArrayCopyBench();
+      bench.runBenchmark();
+    }
+}

--- a/native.js.in
+++ b/native.js.in
@@ -21,18 +21,22 @@ function(addr, srcAddr, srcOffset, dstAddr, dstOffset, length) {
         throw $.newNullPointerException("Cannot copy to/from a null array.");
     }
 
-    var src = getHandle(srcAddr);
-    var dst = getHandle(dstAddr);
-
-    var srcClassInfo = src.classInfo;
-    var dstClassInfo = dst.classInfo;
+    var srcClassInfo = J2ME.getClassInfo(srcAddr);
+    var dstClassInfo = J2ME.getClassInfo(dstAddr);
 
     if (!(srcClassInfo instanceof J2ME.ArrayClassInfo) || !(dstClassInfo instanceof J2ME.ArrayClassInfo)) {
         throw $.newArrayStoreException("Can only copy to/from array types.");
     }
-    if (srcOffset < 0 || (srcOffset+length) > src.length || dstOffset < 0 || (dstOffset+length) > dst.length || length < 0) {
+
+    var srcLength = i32[srcAddr + J2ME.Constants.ARRAY_LENGTH_OFFSET >> 2];
+    var dstLength = i32[dstAddr + J2ME.Constants.ARRAY_LENGTH_OFFSET >> 2];
+
+    if (srcOffset < 0 || (srcOffset+length) > srcLength ||
+        dstOffset < 0 || (dstOffset+length) > dstLength ||
+        length < 0) {
         throw $.newArrayIndexOutOfBoundsException("Invalid index.");
     }
+
     var srcIsPrimitive = srcClassInfo instanceof J2ME.PrimitiveArrayClassInfo;
     var dstIsPrimitive = dstClassInfo instanceof J2ME.PrimitiveArrayClassInfo;
     if ((srcIsPrimitive && dstIsPrimitive && srcClassInfo !== dstClassInfo) ||
@@ -42,36 +46,72 @@ function(addr, srcAddr, srcOffset, dstAddr, dstOffset, length) {
     }
 
     if (!dstIsPrimitive) {
+        var src = (srcAddr + J2ME.Constants.ARRAY_HDR_SIZE >> 2) + srcOffset;
+        var dst = (dstAddr + J2ME.Constants.ARRAY_HDR_SIZE >> 2) + dstOffset;
+
         if (srcClassInfo !== dstClassInfo && !J2ME.isAssignableTo(srcClassInfo.elementClass, dstClassInfo.elementClass)) {
             var copy = function(to, from) {
-                var addr = src[from];
-                var obj = getHandle(addr);
-                if (obj && !J2ME.isAssignableTo(obj.classInfo, dstClassInfo.elementClass)) {
-                    throw $.newArrayStoreException("Incompatible component types.");
+                var addr = i32[from];
+                if (addr !== J2ME.Constants.NULL) {
+                    var objClassInfo = J2ME.getClassInfo(addr);
+                    if (!J2ME.isAssignableTo(objClassInfo, dstClassInfo.elementClass)) {
+                        throw $.newArrayStoreException("Incompatible component types.");
+                    }
                 }
-                dst[to] = addr;
+                i32[to] = addr;
             };
-            if (dst !== src || dstOffset < srcOffset) {
-                for (var n = 0; n < length; ++n)
-                    copy(dstOffset++, srcOffset++);
+            if (dstAddr !== srcAddr || dstOffset < srcOffset) {
+                for (var n = 0; n < length; ++n) {
+                    copy(dst++, src++);
+                }
             } else {
-                dstOffset += length;
-                srcOffset += length;
-                for (var n = 0; n < length; ++n)
-                    copy(--dstOffset, --srcOffset);
+                dst += length;
+                src += length;
+                for (var n = 0; n < length; ++n) {
+                    copy(--dst, --src);
+                }
             }
-            return;
+        } else {
+            if (srcAddr !== dstAddr || dstOffset < srcOffset) {
+                for (var n = 0; n < length; ++n) {
+                    i32[dst++] = i32[src++];
+                }
+            } else {
+                dst += length;
+                src += length;
+                for (var n = 0; n < length; ++n) {
+                    i32[--dst] = src[--src];
+                }
+            }
         }
+
+        return;
     }
 
-    if (srcAddr !== dstAddr || dstOffset < srcOffset) {
-        for (var n = 0; n < length; ++n)
-            dst[dstOffset++] = src[srcOffset++];
-    } else {
-        dstOffset += length;
-        srcOffset += length;
-        for (var n = 0; n < length; ++n)
-            dst[--dstOffset] = src[--srcOffset];
+    switch (srcClassInfo.bytesPerElement) {
+        case 1:
+            var src = (srcAddr + J2ME.Constants.ARRAY_HDR_SIZE) + srcOffset;
+            var dst = (dstAddr + J2ME.Constants.ARRAY_HDR_SIZE) + dstOffset;
+            i8.set(i8.subarray(src, src + length), dst);
+            break;
+
+        case 2:
+            var src = (srcAddr + J2ME.Constants.ARRAY_HDR_SIZE >> 1) + srcOffset;
+            var dst = (dstAddr + J2ME.Constants.ARRAY_HDR_SIZE >> 1) + dstOffset;
+            i16.set(i16.subarray(src, src + length), dst);
+            break;
+
+        case 4:
+            var src = (srcAddr + J2ME.Constants.ARRAY_HDR_SIZE >> 2) + srcOffset;
+            var dst = (dstAddr + J2ME.Constants.ARRAY_HDR_SIZE >> 2) + dstOffset;
+            i32.set(i32.subarray(src, src + length), dst);
+            break;
+
+        case 8:
+            var src = (srcAddr + J2ME.Constants.ARRAY_HDR_SIZE >> 3) + srcOffset;
+            var dst = (dstAddr + J2ME.Constants.ARRAY_HDR_SIZE >> 3) + dstOffset;
+            f64.set(f64.subarray(src, src + length), dst);
+            break;
     }
 };
 

--- a/tests/gnu/testlet/java/lang/System/arraycopy.java
+++ b/tests/gnu/testlet/java/lang/System/arraycopy.java
@@ -26,23 +26,99 @@ import gnu.testlet.TestHarness;
 
 public class arraycopy implements Testlet
 {
-  public int getExpectedPass() { return 30; }
+  public int getExpectedPass() { return 62; }
   public int getExpectedFail() { return 0; }
   public int getExpectedKnownFail() { return 0; }
-  public void fill (int[] a)
-  {
-    for (int i = 0; i < a.length; ++i)
-      a[i] = i;
+
+  public void fill(int[] a) {
+      for (int i = 0; i < a.length; ++i) {
+          a[i] = i;
+      }
   }
 
-  public void check (TestHarness harness, int[] expect, int[] result)
-    {
+  public void fill(byte[] a) {
+      for (int i = 0; i < a.length; ++i) {
+          a[i] = (byte)i;
+      }
+  }
+
+  public void fill(char[] a) {
+      for (int i = 0; i < a.length; ++i) {
+          a[i] = (char)i;
+      }
+  }
+
+  public void fill(long[] a) {
+      for (int i = 0; i < a.length; ++i) {
+          a[i] = i;
+      }
+  }
+
+  public void fill(double[] a) {
+      for (int i = 0; i < a.length; ++i) {
+          a[i] = i;
+      }
+  }
+
+  public void check (TestHarness harness, int[] expect, int[] result) {
       boolean ok = expect.length == result.length;
-      for (int i = 0; ok && i < expect.length; ++i)
-	if (expect[i] != result[i])
-	  ok = false;
-      harness.check (ok);
-    }
+
+      for (int i = 0; ok && i < expect.length; ++i) {
+          if (expect[i] != result[i]) {
+	            ok = false;
+          }
+
+          harness.check (ok);
+      }
+  }
+
+  public void check (TestHarness harness, byte[] expect, byte[] result) {
+      boolean ok = expect.length == result.length;
+
+      for (int i = 0; ok && i < expect.length; ++i) {
+          if (expect[i] != result[i]) {
+              ok = false;
+          }
+
+          harness.check (ok);
+      }
+  }
+
+  public void check (TestHarness harness, char[] expect, char[] result) {
+      boolean ok = expect.length == result.length;
+
+      for (int i = 0; ok && i < expect.length; ++i) {
+          if (expect[i] != result[i]) {
+              ok = false;
+          }
+
+          harness.check (ok);
+      }
+  }
+
+  public void check (TestHarness harness, long[] expect, long[] result) {
+      boolean ok = expect.length == result.length;
+
+      for (int i = 0; ok && i < expect.length; ++i) {
+          if (expect[i] != result[i]) {
+              ok = false;
+          }
+
+          harness.check (ok);
+      }
+  }
+
+  public void check (TestHarness harness, double[] expect, double[] result) {
+      boolean ok = expect.length == result.length;
+
+      for (int i = 0; ok && i < expect.length; ++i) {
+          if (expect[i] != result[i]) {
+              ok = false;
+          }
+
+          harness.check (ok);
+      }
+  }
 
   public Object copy (Object from, int a, Object to, int b, int c)
     {
@@ -87,6 +163,38 @@ public class arraycopy implements Testlet
       harness.check (copy (x, 0, y, x.length - 1, 1), null);
       int[] two = { 1, 2, 3, 4, 0 };
       check (harness, y, two);
+
+      harness.checkPoint("Copying byte array");
+      byte[] xBytes = new byte[5];
+      byte[] yBytes = new byte[5];
+      fill(xBytes);
+      harness.check(copy(xBytes, 0, yBytes, 0, xBytes.length), null);
+      byte[] oneBytes = { 0, 1, 2, 3, 4 };
+      check(harness, yBytes, oneBytes);
+
+      harness.checkPoint("Copying char array");
+      char[] xChars = new char[5];
+      char[] yChars = new char[5];
+      fill(xChars);
+      harness.check(copy(xChars, 0, yChars, 0, xChars.length), null);
+      char[] oneChars = { 0, 1, 2, 3, 4 };
+      check(harness, yChars, oneChars);
+
+      harness.checkPoint("Copying long array");
+      long[] xLongs = new long[5];
+      long[] yLongs = new long[5];
+      fill(xLongs);
+      harness.check(copy(xLongs, 0, yLongs, 0, xLongs.length), null);
+      long[] oneLongs = { 0, 1, 2, 3, 4 };
+      check(harness, yLongs, oneLongs);
+
+      harness.checkPoint("Copying double array");
+      double[] xDoubles = new double[5];
+      double[] yDoubles = new double[5];
+      fill(xDoubles);
+      harness.check(copy(xDoubles, 0, yDoubles, 0, xDoubles.length), null);
+      double[] oneDoubles = { 0, 1, 2, 3, 4 };
+      check(harness, yDoubles, oneDoubles);
 
       harness.checkPoint("Incompatible arrays");
 


### PR DESCRIPTION
The attached benchmark is almost 2x faster with these changes (I've tested it in the JS shell with RELEASE=0, because RELEASE=1 is broken in the shell).