### PR TITLE
update to newer version of Closure Compiler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -294,11 +294,10 @@ bld/jsc.js: jsc.ts bld/j2me-jsc.js
 	tsc --sourcemap --target ES5 jsc.ts --out bld/jsc.js
 
 # Some scripts use ES6 features, so we have to specify ES6 as the in-language
-# (and ES5 as the out-language, since Closure doesn't recognize ES6 as a valid
-# out-language) in order for Closure to compile them, even though for now
-# we're optimizing "WHITESPACE_ONLY".
+# in order for Closure to compile them, even though for now we're optimizing
+# "WHITESPACE_ONLY".
 bld/main-all.js: $(MAIN_JS_SRCS) build_tools/closure.jar .checksum
-	java -jar build_tools/closure.jar $(CLOSURE_FLAGS) --warning_level $(CLOSURE_WARNING_LEVEL) --language_in ES6 --language_out ES5 --create_source_map bld/main-all.js.map --source_map_location_mapping "|../" -O WHITESPACE_ONLY $(MAIN_JS_SRCS) > bld/main-all.js
+	java -jar build_tools/closure.jar $(CLOSURE_FLAGS) --warning_level $(CLOSURE_WARNING_LEVEL) --language_in ES6 --create_source_map bld/main-all.js.map --source_map_location_mapping "|../" -O WHITESPACE_ONLY $(MAIN_JS_SRCS) > bld/main-all.js
 	echo '//# sourceMappingURL=main-all.js.map' >> bld/main-all.js
 
 j2me: bld/j2me.js bld/jsc.js

--- a/Makefile
+++ b/Makefile
@@ -194,7 +194,7 @@ SOOT_VERSION=25Mar2015
 OLD_SOOT_VERSION := $(shell [ -f build_tools/.soot_version ] && cat build_tools/.soot_version)
 $(shell [ "$(SOOT_VERSION)" != "$(OLD_SOOT_VERSION)" ] && echo $(SOOT_VERSION) > build_tools/.soot_version)
 
-CLOSURE_COMPILER_VERSION=j2me.js-v20150428
+CLOSURE_COMPILER_VERSION=pluotsorbet-v20150814
 OLD_CLOSURE_COMPILER_VERSION := $(shell [ -f build_tools/.closure_compiler_version ] && cat build_tools/.closure_compiler_version)
 $(shell [ "$(CLOSURE_COMPILER_VERSION)" != "$(OLD_CLOSURE_COMPILER_VERSION)" ] && echo $(CLOSURE_COMPILER_VERSION) > build_tools/.closure_compiler_version)
 


### PR DESCRIPTION
@marco-c This branch updates to the newer version of the Closure Compiler in https://github.com/mykmelez/closure-compiler/tree/pluotsorbet-v20150814 (based on https://github.com/mbebenita/closure-compiler/tree/master). It throws these errors on the basic unit tests:
> ReferenceError: $jscomp is not defined main-all.js:12122:10
> ReferenceError: $jscomp is not defined main-all.js:4392:14
