### PR TITLE
specify custom XULRunner with XULRUNNER make argument

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -231,8 +231,18 @@ ifneq (,$(findstring CYGWIN,$(UNAME_S)))
 	BOOTCLASSPATH_SEPARATOR=;
 endif
 
+# The path to the XULRunner executable that is actually used by the test runner.
+# Set this on the command line to run tests against a different version
+# of XULRunner than the default (which is specified by XULRUNNER_PATH),
+# so you can test changes for compatibility with older and newer versions
+# of Gecko than the default.  For example:
+#
+#   make test XULRUNNER=/Applications/Firefox28.app/Contents/MacOS/firefox
+#
+XULRUNNER ?= build_tools/$(XULRUNNER_PATH)
+
 test: all build_tools/slimerjs-$(SLIMERJS_VERSION) build_tools/$(XULRUNNER_PATH)
-	SLIMERJSLAUNCHER=build_tools/$(XULRUNNER_PATH) tests/runtests.py
+	SLIMERJSLAUNCHER=$(XULRUNNER) tests/runtests.py
 
 build_tools/slimerjs-$(SLIMERJS_VERSION): build_tools/.slimerjs_version
 	rm -rf build_tools/slimerjs*


### PR DESCRIPTION
This enables you to test against custom XULRunner installations with a Make argument:

> make test XULRUNNER=/Applications/Firefox28.app/Contents/MacOS/firefox

Unfortunately, I don't have much luck testing against other versions, at least not when using a Firefox installation as XULRunner. Various test suites (including the basic unit tests) stall and time out on older versions of Firefox, even though they run fine (and faster than the test timeout) in the browser itself, including on Firefox 25, Firefox 28, and Firefox 31 (the last of which should be equivalent to XULRunner 31, the default for our tests).

Meanwhile, newer versions of Firefox don't run tests at all, they simply exit immediately. On Firefox 40, that could be https://github.com/laurentj/slimerjs/pull/380, but I see it on 37.0.2 too:

> 08-14 14:40 > make test XULRUNNER=/Applications/Firefox37.0.2.app/Contents/MacOS/firefox
> python tools/preprocess-1.1.0/lib/preprocess.py -s -D RELEASE=false -D PROFILE=0 -D PROFILE_FORMAT=PLAIN -D BENCHMARK=false -D CONSOLE=true -D JSR_256=1 -D JSR_179=1 -D CONTENT_HANDLER_FILTER='["image/*", "video/*", "audio/*"]' -D CONFIG=config/runtests.js -D NAME="PluotSorbet" -D MIDLET_NAME="midlet" -D DESCRIPTION="a J2ME-compatible virtual machine written in JavaScript" -D ORIGIN=app://pluotsorbet.mozilla.org -D VERSION=1439588461  -o config/build.js config/build.js.in
> make -C java
> make[1]: `classes.jar' is up to date.
> make -C tools/jasmin-2.4
> make[1]: Nothing to be done for `all'.
> make -C tests
> make[1]: Circular MIDletTestlets.java <- MIDletTestlets.java dependency dropped.
> make[1]: Circular Testlets.java <- MIDletTestlets.java dependency dropped.
> make[1]: Circular Testlets.java <- Testlets.java dependency dropped.
> make[1]: Nothing to be done for `all'.
> SLIMERJSLAUNCHER=/Applications/Firefox37.0.2.app/Contents/MacOS/firefox tests/runtests.py
> pre-main prep time: 0 ms
> Loaded java/classes.jar in 0.52 ms.
> The end
> Time: 28.0129 ms

I'm not sure what's up with that.
