### PR TITLE
Set GC_INITIAL_HEAP_SIZE for WA and reduce ASMJS_TOTAL_MEMORY

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,10 @@ export CONFIG
 ASMJS_TOTAL_MEMORY ?= 16*1024*1024
 export ASMJS_TOTAL_MEMORY
 
+# Initial size of the GC heap
+GC_INITIAL_HEAP_SIZE ?= 0
+export GC_INITIAL_HEAP_SIZE
+
 # Whether or not to package test files like tests.jar and support scripts.
 # Set this to 1 if running tests on a device or building an app for a midlet
 # in the tests/ subdirectory, like Asteroids.
@@ -315,7 +319,7 @@ endif
 bld/native.js: Makefile vm/native/native.cpp vm/native/Boehm.js/.libs/$(BOEHM_LIB) jit/relooper/Relooper.cpp jit/relooper/Relooper.h
 	mkdir -p bld
 	rm -f bld/native.js
-	emcc -DNDEBUG -Ivm/native/Boehm.js/include/ vm/native/Boehm.js/.libs/$(BOEHM_LIB) -Oz -O3 vm/native/native.cpp jit/relooper/Relooper.cpp -o native.raw.js --memory-init-file 0 -s TOTAL_STACK=16*1024 -s TOTAL_MEMORY=$(ASMJS_TOTAL_MEMORY) \
+	emcc -DNDEBUG -Ivm/native/Boehm.js/include/ vm/native/Boehm.js/.libs/$(BOEHM_LIB) -Oz -O3 vm/native/native.cpp jit/relooper/Relooper.cpp -o native.raw.js --memory-init-file 0 -s TOTAL_STACK=16*1024 -s TOTAL_MEMORY=$(ASMJS_TOTAL_MEMORY) -DGC_INITIAL_HEAP_SIZE=$(GC_INITIAL_HEAP_SIZE) \
 	-s 'EXPORTED_FUNCTIONS=["_main", "_lAdd", "_lNeg", "_lSub", "_lShl", "_lShr", "_lUshr", "_lMul", "_lDiv", "_lRem", "_lCmp", "_gcMallocUncollectable", "_gcFree", "_gcMalloc", "_gcMallocAtomic", "_gcRegisterDisappearingLink", "_gcUnregisterDisappearingLink", "_registerFinalizer", "_forceCollection", "_getUsedHeapSize", "_rl_set_output_buffer","_rl_make_output_buffer","_rl_new_block","_rl_set_block_code","_rl_delete_block","_rl_block_add_branch_to","_rl_new_relooper","_rl_delete_relooper","_rl_relooper_add_block","_rl_relooper_calculate","_rl_relooper_render", "_rl_set_asm_js_mode"]' \
 	-s 'DEFAULT_LIBRARY_FUNCS_TO_INCLUDE=["memcpy", "memset", "malloc", "free", "puts"]' \
 	-s NO_EXIT_RUNTIME=1 -s NO_BROWSER=1 -s NO_FILESYSTEM=1 --post-js jit/relooper/glue.js

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ CONFIG ?= config/runtests.js
 export CONFIG
 
 # Amount of memory for Emscripten-compiled code.
-ASMJS_TOTAL_MEMORY ?= 128*1024*1024
+ASMJS_TOTAL_MEMORY ?= 16*1024*1024
 export ASMJS_TOTAL_MEMORY
 
 # Whether or not to package test files like tests.jar and support scripts.

--- a/Makefile
+++ b/Makefile
@@ -329,7 +329,9 @@ endif
 bld/native.js: Makefile vm/native/native.cpp vm/native/Boehm.js/.libs/$(BOEHM_LIB) jit/relooper/Relooper.cpp jit/relooper/Relooper.h
 	mkdir -p bld
 	rm -f bld/native.js
-	emcc -DNDEBUG -Ivm/native/Boehm.js/include/ vm/native/Boehm.js/.libs/$(BOEHM_LIB) -Oz -O3 vm/native/native.cpp jit/relooper/Relooper.cpp -o native.raw.js --memory-init-file 0 -s TOTAL_STACK=16*1024 -s TOTAL_MEMORY=$(ASMJS_TOTAL_MEMORY) -DGC_INITIAL_HEAP_SIZE=$(GC_INITIAL_HEAP_SIZE) \
+	emcc -DNDEBUG -Ivm/native/Boehm.js/include/ vm/native/Boehm.js/.libs/$(BOEHM_LIB) -Oz -O3 \
+	vm/native/native.cpp jit/relooper/Relooper.cpp -o native.raw.js --memory-init-file 0 \
+	-s TOTAL_STACK=16*1024 -s TOTAL_MEMORY=$(ASMJS_TOTAL_MEMORY) -DGC_INITIAL_HEAP_SIZE=$(GC_INITIAL_HEAP_SIZE) \
 	-s 'EXPORTED_FUNCTIONS=["_main", "_lAdd", "_lNeg", "_lSub", "_lShl", "_lShr", "_lUshr", "_lMul", "_lDiv", "_lRem", "_lCmp", "_gcMallocUncollectable", "_gcFree", "_gcMalloc", "_gcMallocAtomic", "_gcRegisterDisappearingLink", "_gcUnregisterDisappearingLink", "_registerFinalizer", "_forceCollection", "_getUsedHeapSize", "_rl_set_output_buffer","_rl_make_output_buffer","_rl_new_block","_rl_set_block_code","_rl_delete_block","_rl_block_add_branch_to","_rl_new_relooper","_rl_delete_relooper","_rl_relooper_add_block","_rl_relooper_calculate","_rl_relooper_render", "_rl_set_asm_js_mode"]' \
 	-s 'DEFAULT_LIBRARY_FUNCS_TO_INCLUDE=["memcpy", "memset", "malloc", "free", "puts"]' \
 	-s NO_EXIT_RUNTIME=1 -s NO_BROWSER=1 -s NO_FILESYSTEM=1 --post-js jit/relooper/glue.js

--- a/runwhatsapppreview.mk
+++ b/runwhatsapppreview.mk
@@ -18,5 +18,6 @@ ICON_128 = img/runwhatsapppreview-icon-128.png
 ICON_512 = img/runwhatsapppreview-icon-512.png
 
 ASMJS_TOTAL_MEMORY = 4*1024*1024
+GC_INITIAL_HEAP_SIZE = 2285568
 
 include Makefile

--- a/runwhatsapppreview.mk
+++ b/runwhatsapppreview.mk
@@ -17,4 +17,6 @@ ORIGIN = app://runwhatsapppreview.mozilla.org
 ICON_128 = img/runwhatsapppreview-icon-128.png
 ICON_512 = img/runwhatsapppreview-icon-512.png
 
+ASMJS_TOTAL_MEMORY = 4*1024*1024
+
 include Makefile

--- a/vm/native/native.cpp
+++ b/vm/native/native.cpp
@@ -1,7 +1,6 @@
 //#define GC_DEBUG
 //#define GC_MAXIMUM_HEAP_SIZE (128 * 1024 * 1024)
 #define GC_IGNORE_WARN
-#define GC_INITIAL_HEAP_SIZE 2285568
 
 #include "gc.h"
 #include <stdio.h>

--- a/vm/native/native.cpp
+++ b/vm/native/native.cpp
@@ -1,6 +1,7 @@
 //#define GC_DEBUG
 //#define GC_MAXIMUM_HEAP_SIZE (128 * 1024 * 1024)
 #define GC_IGNORE_WARN
+#define GC_INITIAL_HEAP_SIZE 2285568
 
 #include "gc.h"
 #include <stdio.h>


### PR DESCRIPTION
This should improve startup time.

In my testing for WA, the heap size right after startup is 2285568 bytes (often it is 1658880 bytes, but I wouldn't expect the difference to matter much). It never grows to more than 3 MB, so I've set ASMJS_TOTAL_MEMORY to 4 MB for WA (the error that occurs when the memory isn't enough is pretty clear, so we can increase it easily if needed).