### PR TITLE
make downloadJAD take precedence to jad

### DIFF
--- a/main.js
+++ b/main.js
@@ -103,9 +103,7 @@ function performDownload(url, callback) {
   });
 }
 
-if (config.jad) {
-  loadingMIDletPromises.push(load(config.jad, "text").then(processJAD));
-} else if (config.downloadJAD) {
+if (config.downloadJAD) {
   loadingMIDletPromises.push(new Promise(function(resolve, reject) {
     JARStore.loadJAR("midlet.jar").then(function(loaded) {
       if (loaded) {
@@ -129,6 +127,8 @@ if (config.jad) {
       });
     });
   }));
+} else if (config.jad) {
+  loadingMIDletPromises.push(load(config.jad, "text").then(processJAD));
 }
 
 if (config.jad || config.downloadJAD) {

--- a/tests/automation.js
+++ b/tests/automation.js
@@ -560,7 +560,7 @@ casper.test.begin("unit tests", 39 + gfxTests.length, function(test) {
     });
 
     casper
-    .thenOpen("http://localhost:8000/index.html?jad=&downloadJAD=http://localhost:8000/tests/Manifest1.jad&midletClassName=tests.jaddownloader.AMIDlet&logConsole=web,page&args=1.0.0&logLevel=log")
+    .thenOpen("http://localhost:8000/index.html?downloadJAD=http://localhost:8000/tests/Manifest1.jad&midletClassName=tests.jaddownloader.AMIDlet&logConsole=web,page&args=1.0.0&logLevel=log")
     .withFrame(0, function() {
         casper.waitForText("DONE", function() {
             test.assertTextExists("SUCCESS 3/3", "test JAD downloader - Download");
@@ -570,7 +570,7 @@ casper.test.begin("unit tests", 39 + gfxTests.length, function(test) {
 
     // Run the test a second time to ensure loading the JAR stored in the JARStore works correctly.
     casper
-    .thenOpen("http://localhost:8000/index.html?jad=&downloadJAD=http://localhost:8000/tests/Manifest1.jad&midletClassName=tests.jaddownloader.AMIDlet&logConsole=web,page&args=1.0.0&logLevel=log")
+    .thenOpen("http://localhost:8000/index.html?downloadJAD=http://localhost:8000/tests/Manifest1.jad&midletClassName=tests.jaddownloader.AMIDlet&logConsole=web,page&args=1.0.0&logLevel=log")
     .withFrame(0, function() {
         casper.waitForText("DONE", function() {
             test.assertTextExists("SUCCESS 3/3", "test JAD downloader - Load");
@@ -581,7 +581,7 @@ casper.test.begin("unit tests", 39 + gfxTests.length, function(test) {
 
     // Run the test that updates the MIDlet
     casper
-    .thenOpen("http://localhost:8000/index.html?jad=&downloadJAD=http://localhost:8000/tests/Manifest1.jad&midletClassName=tests.jaddownloader.AMIDletUpdater&logConsole=web,page&logLevel=log")
+    .thenOpen("http://localhost:8000/index.html?downloadJAD=http://localhost:8000/tests/Manifest1.jad&midletClassName=tests.jaddownloader.AMIDletUpdater&logConsole=web,page&logLevel=log")
     .withFrame(0, function() {
         var alertText = null;
         casper.on('remote.alert', function onAlert(message) {
@@ -599,7 +599,7 @@ casper.test.begin("unit tests", 39 + gfxTests.length, function(test) {
 
     // Verify that the update has been applied
     casper
-    .thenOpen("http://localhost:8000/index.html?jad=&downloadJAD=http://localhost:8000/tests/Manifest1.jad&midletClassName=tests.jaddownloader.AMIDlet&logConsole=web,page&args=3.0.0&logLevel=log")
+    .thenOpen("http://localhost:8000/index.html?downloadJAD=http://localhost:8000/tests/Manifest1.jad&midletClassName=tests.jaddownloader.AMIDlet&logConsole=web,page&args=3.0.0&logLevel=log")
     .withFrame(0, function() {
         casper.waitForText("DONE", function() {
             test.assertTextExists("SUCCESS 3/3", "test JAD downloader - Load after update");
@@ -613,7 +613,7 @@ casper.test.begin("unit tests", 39 + gfxTests.length, function(test) {
     .waitForText("DONE");
 
     casper
-    .thenOpen("http://localhost:8000/index.html?jad=&downloadJAD=http://localhost:8000/tests/Manifest2.jad&midletClassName=tests.jaddownloader.AMIDlet&logConsole=web,page&args=2.0.0&logLevel=log")
+    .thenOpen("http://localhost:8000/index.html?downloadJAD=http://localhost:8000/tests/Manifest2.jad&midletClassName=tests.jaddownloader.AMIDlet&logConsole=web,page&args=2.0.0&logLevel=log")
     .withFrame(0, function() {
         casper.waitForText("DONE", function() {
             test.assertTextExists("SUCCESS 3/3", "test JAD downloader - Download with absolute URL");


### PR DESCRIPTION
Since #1737, if you specify both *jad* and *downloadJAD*, *jad* takes precedence. But *jad* is set to tests/runtests.jad by default (in config/runtests.js, which is the default value of *CONFIG* in Makefile). So if you |make| and then specify *downloadJAD* in a URL parameter, it'll be ignored, which is why @brendandahl and I have been having trouble loading midlets via URLs like http://localhost:8000/index.html?downloadJAD=….

This change makes *downloadJAD* take precedence over *jad*, so URLs like that work as before. The automation.js changes simply undo a workaround for the problem when loading test URLs that relied on downloadJAD (which I completely forgot about, otherwise the problem would have been more obvious).
