### PR TITLE
reenable compiled method cache

### DIFF
--- a/int.ts
+++ b/int.ts
@@ -142,18 +142,12 @@ module J2ME {
   }
 
   export const enum FrameLayout {
-    /**
-     * Stored in the lower 28 bits.
-     */
-    CalleeMethodInfoOffset      = 4,
-    /**
-     * Stored in the upper 4 bits.
-     */
-    FrameTypeOffset             = 2,
-    CallerFPOffset              = 1,
-    CallerRAOffset              = 0,
-    MonitorOffset               = 3,
-    CallerSaveSize              = 5
+    CallerRAOffset         = 0,
+    CallerFPOffset         = 1,
+    FrameTypeOffset        = 2,
+    MonitorOffset          = 3,
+    CalleeMethodInfoOffset = 4,
+    CallerSaveSize         = 5
   }
 
   export class FrameView {

--- a/int.ts
+++ b/int.ts
@@ -117,28 +117,28 @@ module J2ME {
     /**
      * Normal interpreter frame.
      */
-    Interpreter = 0x00000000,
+    Interpreter = 0x0,
 
     /**
      * Marks the beginning of a sequence of interpreter frames. If we see this
      * frame when returning we need to exit the interpreter loop.
      */
-    ExitInterpreter = 0x10000000,
+    ExitInterpreter = 0x1,
 
     /**
      * Native frames are pending and need to be pushed on the stack.
      */
-    PushPendingFrames = 0x20000000,
+    PushPendingFrames = 0x2,
 
     /**
      * Marks the beginning of frames that were not invoked by the previous frame.
      */
-    Interrupt = 0x30000000,
+    Interrupt = 0x3,
 
     /**
      * Marks the beginning of native/compiled code called from the interpreter.
      */
-    Native = 0x40000000
+    Native = 0x4
   }
 
   export const enum FrameLayout {

--- a/vm/parser.ts
+++ b/vm/parser.ts
@@ -822,8 +822,6 @@ module J2ME {
   }
 
   export class MethodInfo extends ByteStream {
-    private static nextId: number = 1;
-
     public classInfo: ClassInfo;
     public accessFlags: ACCESS_FLAGS;
 
@@ -862,14 +860,20 @@ module J2ME {
 
     constructor(classInfo: ClassInfo, offset: number, index: number) {
       super(classInfo.buffer, offset);
-      this.id = MethodInfo.nextId++;
-      methodIdToMethodInfoMap[this.id] = this;
       this.index = index;
       this.accessFlags = this.u2(0);
       this.classInfo = classInfo;
       var cp = this.classInfo.constantPool;
       this.utf8Name = cp.resolveUtf8(this.u2(2));
       this.utf8Signature = cp.resolveUtf8(this.u2(4));
+
+      var utf8ImplKey = new Uint8Array(classInfo.utf8Name.length + this.utf8Name.length + this.utf8Signature.length);
+      utf8ImplKey.set(classInfo.utf8Name);
+      utf8ImplKey.set(this.utf8Name, classInfo.utf8Name.length);
+      utf8ImplKey.set(this.utf8Signature, classInfo.utf8Name.length + this.utf8Name.length);
+      this.id = hashBytesTo32BitsMurmur(utf8ImplKey, 0, utf8ImplKey.length) >> 0;
+      methodIdToMethodInfoMap[this.id] = this;
+
       this.vTableIndex = -1;
 
       this.state = MethodState.Cold;
@@ -1041,14 +1045,6 @@ module J2ME {
   }
 
   export class ClassInfo extends ByteStream {
-    /**
-     * We use this ID to map Java objects to their ClassInfo objects,
-     * storing the ID for the Class in the first four bytes
-     * of the memory allocated for the Java object in the ASM heap.
-     *
-     */
-    private static nextId: number = 1;
-
     constantPool: ConstantPool = null;
 
     utf8Name: Uint8Array = null;
@@ -1095,8 +1091,6 @@ module J2ME {
 
     constructor(buffer: Uint8Array) {
       super(buffer, 0);
-      this.id = ClassInfo.nextId++;
-      release || assert(phase === ExecutionPhase.Compiler || this.id <= Constants.MAX_CLASS_ID, "Maximum class id was exceeded, " + this.id);
       if (!buffer) {
         sealObjects && Object.seal(this);
         return;
@@ -1109,6 +1103,7 @@ module J2ME {
       s.seek(this.constantPool.offset);
       this.accessFlags = s.readU2();
       this.utf8Name = this.constantPool.resolveUtf8ClassName(s.readU2());
+      this.id = hashBytesTo32BitsMurmur(this.utf8Name, 0, this.utf8Name.length) >> 0;
       this.utf8SuperName = this.constantPool.resolveUtf8ClassName(s.readU2());
       this.vTable = [];
       this.fTable = []
@@ -1601,6 +1596,7 @@ module J2ME {
     constructor(utf8Name, mangledName) {
       super(null);
       this.utf8Name = utf8Name;
+      this.id = hashBytesTo32BitsMurmur(this.utf8Name, 0, this.utf8Name.length) >> 0;
       this.mangledName = mangledName;
       this.complete();
     }
@@ -1635,6 +1631,7 @@ module J2ME {
       } else {
         this.utf8Name = strcat4Single(UTF8Chars.OpenBracket, UTF8Chars.L, elementClass.utf8Name, UTF8Chars.Semicolon);
       }
+      this.id = hashBytesTo32BitsMurmur(this.utf8Name, 0, this.utf8Name.length) >> 0;
       this.mangledName = mangleClassName(this.utf8Name);
       this.complete();
     }
@@ -1645,6 +1642,7 @@ module J2ME {
     constructor(elementClass: ClassInfo, mangledName: string, bytesPerElement: number) {
       super(elementClass);
       this.utf8Name = strcatSingle(UTF8Chars.OpenBracket, elementClass.utf8Name);
+      this.id = hashBytesTo32BitsMurmur(this.utf8Name, 0, this.utf8Name.length) >> 0;
       this.mangledName = mangledName;
       this.bytesPerElement = bytesPerElement;
       this.complete();

--- a/vm/runtime.ts
+++ b/vm/runtime.ts
@@ -12,8 +12,20 @@ interface Math {
 }
 
 interface CompiledMethodCache {
-  get(key: string): { key: string; source: string; referencedClasses: string[]; };
-  put(obj: { key: string; source: string; referencedClasses: string[]; }): Promise<any>;
+  get(key: string): {
+    key: string;
+    args: string[];
+    body: string;
+    referencedClasses: string[];
+    onStackReplacementEntryPoints: any;
+  };
+  put(obj: {
+    key: string;
+    args: string[];
+    body: string;
+    referencedClasses: string[];
+    onStackReplacementEntryPoints: any;
+  }): Promise<any>;
 }
 
 interface AOTMetaData {
@@ -63,7 +75,7 @@ module J2ME {
   /**
    * Turns on caching of JIT-compiled methods.
    */
-  export var enableCompiledMethodCache = false && typeof CompiledMethodCache !== "undefined";
+  export var enableCompiledMethodCache = true && typeof CompiledMethodCache !== "undefined";
 
   /**
    * Traces method execution.
@@ -359,13 +371,13 @@ module J2ME {
     status: RuntimeStatus;
     waiting: any [];
     threadCount: number;
-    initialized: Int8Array;
-    staticObjectAddresses: Int32Array;
-    classObjectAddresses: Int32Array;
+    initialized: Map<number, boolean>;
+    staticObjectAddresses: Map<number, number>;
+    classObjectAddresses: Map<number, number>;
 
-    I: Int8Array; // Compiler alias for initialized
-    SA: Int32Array; // Compiler alias for staticObjectAddresses
-    CO: Int32Array; // Compiler alias for classObjectAddresses
+    I: Map<number, boolean>; // Compiler alias for initialized
+    SA: Map<number, number>; // Compiler alias for staticObjectAddresses
+    CO: Map<number, number>; // Compiler alias for classObjectAddresses
 
     ctx: Context;
     allCtxs: Set<Context>;
@@ -385,9 +397,9 @@ module J2ME {
       this.status = RuntimeStatus.New;
       this.waiting = [];
       this.threadCount = 0;
-      this.I = this.initialized = new Int8Array(Constants.MAX_CLASS_ID);
-      this.SA = this.staticObjectAddresses = new Int32Array(Constants.INITIAL_MAX_CLASS_ID);
-      this.CO = this.classObjectAddresses = new Int32Array(Constants.INITIAL_MAX_CLASS_ID);
+      this.I = this.initialized = Object.create(null);
+      this.SA = this.staticObjectAddresses = Object.create(null);
+      this.CO = this.classObjectAddresses = Object.create(null);
       this.ctx = null;
       this.allCtxs = new Set();
       this._runtimeId = RuntimeTemplate._nextRuntimeId ++;
@@ -418,7 +430,7 @@ module J2ME {
      * different threads that need trigger the Class.initialize() code so they block.
      */
     setClassInitialized(classId: number) {
-      this.initialized[classId] = 1;
+      this.initialized[classId] = true;
     }
 
     getClassObjectAddress(classInfo: ClassInfo): number {
@@ -427,9 +439,6 @@ module J2ME {
         var addr = allocUncollectableObject(CLASSES.java_lang_Class);
         var handle = <java.lang.Class>getHandle(addr);
         handle.vmClass = id;
-        // Ensure that maps are large enough.
-        this.SA = this.staticObjectAddresses = ArrayUtilities.ensureInt32ArrayLength(this.staticObjectAddresses, id + 1);
-        this.CO = this.classObjectAddresses = ArrayUtilities.ensureInt32ArrayLength(this.classObjectAddresses, id + 1);
         this.classObjectAddresses[id] = addr;
         this.staticObjectAddresses[id] = gcMallocUncollectable(J2ME.Constants.OBJ_HDR_SIZE + classInfo.sizeOfStaticFields);
         linkWriter && linkWriter.writeLn("Initializing Class Object For: " + classInfo.getClassNameSlow());
@@ -670,10 +679,7 @@ module J2ME {
     ARRAY_HDR_SIZE = 8,
 
     ARRAY_LENGTH_OFFSET = 4,
-    NULL = 0,
-
-    MAX_CLASS_ID = 4096,
-    INITIAL_MAX_CLASS_ID = 512
+    NULL = 0
   }
 
   export class Runtime extends RuntimeTemplate {
@@ -741,7 +747,7 @@ module J2ME {
   /**
    * Maps classIds to vTables containing JS functions.
    */
-  export var classIdToLinkedVTableMap = ArrayUtilities.makeDenseArray(Constants.MAX_CLASS_ID + 1, null);
+  export var classIdToLinkedVTableMap: Map<number, Function[]> = Object.create(null);
 
   export function getClassInfo(addr: number) {
     release || assert(addr !== Constants.NULL, "addr !== Constants.NULL");
@@ -1125,14 +1131,23 @@ module J2ME {
       return;
     }
 
-    //if (enableCompiledMethodCache) {
-    //  var cachedMethod;
-    //  if (cachedMethod = CompiledMethodCache.get(methodInfo.implKey)) {
-    //    cachedMethodCount ++;
-    //    jitWriter && jitWriter.writeLn("Getting " + methodInfo.implKey + " from compiled method cache");
-    //    return linkMethodSource(methodInfo, cachedMethod.source, cachedMethod.referencedClasses, cachedMethod.onStackReplacementEntryPoints);
-    //  }
-    //}
+    if (enableCompiledMethodCache) {
+      var cachedMethod;
+      if (cachedMethod = CompiledMethodCache.get(methodInfo.implKey)) {
+        cachedMethodCount ++;
+        jitWriter && jitWriter.writeLn("Retrieved " + methodInfo.implKey + " from compiled method cache");
+        linkMethodSource(methodInfo, cachedMethod.args, cachedMethod.body, cachedMethod.onStackReplacementEntryPoints);
+
+        // Ensure referenced classes are loaded.
+        // We only need to do this for cached methods, since referenced classes
+        // get loaded automatically during JIT compilation.
+        for (var i = 0; i < cachedMethod.referencedClasses.length; i++) {
+          CLASSES.getClass(cachedMethod.referencedClasses[i]);
+        }
+
+        return;
+      }
+    }
 
     var mangledClassAndMethodName = methodInfo.mangledClassAndMethodName;
 
@@ -1154,17 +1169,18 @@ module J2ME {
     codeWriter && codeWriter.writeLn("// Method: " + methodInfo.implKey);
     codeWriter && codeWriter.writeLn("// Arguments: " + compiledMethod.args.join(", "));
     codeWriter && codeWriter.writeLns(compiledMethod.body);
-    var referencedClasses = compiledMethod.referencedClasses.map(function(v) { return v.getClassNameSlow() });
 
-    //if (enableCompiledMethodCache) {
-    //  CompiledMethodCache.put({
-    //    key: methodInfo.implKey,
-    //    source: source,
-    //    referencedClasses: referencedClasses,
-    //    onStackReplacementEntryPoints: compiledMethod.onStackReplacementEntryPoints
-    //  });
-    //}
-    linkMethodSource(methodInfo, compiledMethod.args, compiledMethod.body, referencedClasses, compiledMethod.onStackReplacementEntryPoints);
+    if (enableCompiledMethodCache) {
+      CompiledMethodCache.put({
+        key: methodInfo.implKey,
+        args: compiledMethod.args,
+        body: compiledMethod.body,
+        referencedClasses: compiledMethod.referencedClasses.map(function(v) { return v.getClassNameSlow() }),
+        onStackReplacementEntryPoints: compiledMethod.onStackReplacementEntryPoints
+      });
+    }
+
+    linkMethodSource(methodInfo, compiledMethod.args, compiledMethod.body, compiledMethod.onStackReplacementEntryPoints);
     var methodJITTime = (performance.now() - s);
     totalJITTime += methodJITTime;
     if (jitWriter) {
@@ -1199,7 +1215,7 @@ module J2ME {
   /**
    * Links up compiled method at runtime.
    */
-  export function linkMethodSource(methodInfo: MethodInfo, args: string[], body: string, referencedClasses: string[], onStackReplacementEntryPoints: any) {
+  export function linkMethodSource(methodInfo: MethodInfo, args: string[], body: string, onStackReplacementEntryPoints: any) {
     jitWriter && jitWriter.writeLn("Link method: " + methodInfo.implKey);
 
     enterTimeline("Eval Compiled Code");


### PR DESCRIPTION
This branch reenables the compiled method cache, using hashes for ClassInfo and MethodInfo IDs to maintain their stability across runs. The cache reduces startup time significantly relative to compilation without caching:

|         Test         | Baseline Mean |     Mean    |     +/-     |     %    |     P    |      Min     |      Max      | 
|:---------------------|--------------:|------------:|------------:|---------:|---------:|-------------:|--------------:|
| startupTime          |       1,265ms |       976ms |      -289ms |   -22.86 |   BETTER |        964ms |       1,008ms | 
| vmStartupTime        |         212ms |       206ms |        -6ms |    -3.02 |     SAME |        186ms |         243ms | 
| bgStartupTime        |          52ms |        43ms |        -9ms |   -17.10 |   BETTER |         41ms |          44ms | 
| fgStartupTime        |         848ms |       612ms |      -236ms |   -27.81 |   BETTER |        591ms |         666ms | 
| fgRefreshStartupTime |         153ms |       115ms |       -38ms |   -24.93 |   BETTER |         88ms |         121ms | 
| fgRestartTime        |           n/a |       NaNms |         n/a |      n/a |      n/a |   Infinityms |   -Infinityms | 
| *totalSize*          |    *61,654kb* |  *59,026kb* |  *-2,628kb* |  *-4.26* | *BETTER* |   *57,800kb* |    *59,859kb* | 
| *domSize*            |       *169kb* |     *169kb* |       *0kb* |   *0.00* |   *SAME* |      *168kb* |       *169kb* | 
| *styleSize*          |       *397kb* |     *396kb* |       *0kb* |  *-0.08* |   *SAME* |      *395kb* |       *398kb* | 
| *jsObjectsSize*      |    *51,445kb* |  *51,387kb* |     *-58kb* |  *-0.11* | *BETTER* |   *51,368kb* |    *51,391kb* | 
| *jsStringsSize*      |       *541kb* |     *499kb* |     *-42kb* |  *-7.75* | *BETTER* |      *497kb* |       *501kb* | 
| *jsOtherSize*        |     *8,866kb* |   *6,338kb* |  *-2,528kb* | *-28.51* | *BETTER* |    *5,115kb* |     *7,166kb* | 
| *otherSize*          |       *237kb* |     *236kb* |       *0kb* |  *-0.20* |   *SAME* |      *224kb* |       *239kb* | 
| *USS*                |         *n/a* |     *NaNkb* |       *n/a* |    *n/a* |    *n/a* | *Infinitykb* | *-Infinitykb* | 
| *peakRSS*            |   *509,009kb* | *458,217kb* | *-50,792kb* |  *-9.98* | *BETTER* |  *453,832kb* |   *458,748kb* | 

In fact startup time on this branch with compilation enabled is now better than startup time on master:


|         Test         | Baseline Mean |     Mean    |     +/-     |     %    |     P    |      Min     |      Max      | 
|:---------------------|--------------:|------------:|------------:|---------:|---------:|-------------:|--------------:|
| startupTime          |         998ms |       975ms |       -22ms |    -2.25 |   BETTER |        965ms |         992ms | 
| vmStartupTime        |         210ms |       204ms |        -6ms |    -2.77 |     SAME |        187ms |         223ms | 
| bgStartupTime        |          48ms |        43ms |        -5ms |   -10.56 |   BETTER |         41ms |          45ms | 
| fgStartupTime        |         649ms |       613ms |       -35ms |    -5.43 |   BETTER |        590ms |         660ms | 
| fgRefreshStartupTime |          92ms |       115ms |        24ms |    25.78 |    WORSE |         86ms |         121ms | 
| fgRestartTime        |           n/a |       NaNms |         n/a |      n/a |      n/a |   Infinityms |   -Infinityms | 
| *totalSize*          |    *29,523kb* |  *59,028kb* |  *29,505kb* |  *99.94* |  *WORSE* |   *57,790kb* |    *59,882kb* | 
| *domSize*            |       *165kb* |     *169kb* |       *3kb* |   *1.90* |  *WORSE* |      *168kb* |       *169kb* | 
| *styleSize*          |       *394kb* |     *396kb* |       *2kb* |   *0.54* |  *WORSE* |      *396kb* |       *399kb* | 
| *jsObjectsSize*      |    *19,757kb* |  *51,387kb* |  *31,631kb* | *160.10* |  *WORSE* |   *51,368kb* |    *51,395kb* | 
| *jsStringsSize*      |       *654kb* |     *500kb* |    *-155kb* | *-23.66* | *BETTER* |      *497kb* |       *501kb* | 
| *jsOtherSize*        |     *8,325kb* |   *6,339kb* |  *-1,986kb* | *-23.85* | *BETTER* |    *5,118kb* |     *7,196kb* | 
| *otherSize*          |       *228kb* |     *237kb* |       *9kb* |   *3.94* |  *WORSE* |      *232kb* |       *239kb* | 
| *USS*                |         *n/a* |     *NaNkb* |       *n/a* |    *n/a* |    *n/a* | *Infinitykb* | *-Infinitykb* | 
| *peakRSS*            |   *366,208kb* | *499,795kb* | *133,587kb* |  *36.48* |  *WORSE* |  *496,976kb* |   *499,952kb* | 
