### PR TITLE
enable compiler on intex branch

### DIFF
--- a/tests/automation.js
+++ b/tests/automation.js
@@ -180,7 +180,7 @@ function syncFS() {
     });
 }
 
-casper.test.begin("unit tests", 37 + gfxTests.length, function(test) {
+casper.test.begin("unit tests", 39 + gfxTests.length, function(test) {
     casper.start("data:text/plain,start");
 
     casper.page.onLongRunningScript = function(message) {

--- a/tests/automation.js
+++ b/tests/automation.js
@@ -226,17 +226,15 @@ casper.test.begin("unit tests", 37 + gfxTests.length, function(test) {
     .thenOpen("http://localhost:8000/index.html?logConsole=web,page&logLevel=log")
     .withFrame(0, basicUnitTests);
 
-    // TODO: Re-enable rerunning tests once we re-enable the JIT.
-
     // Run the same unit tests again to test the compiled method cache.
-    /*casper
+    casper
     .thenOpen("http://localhost:8000/index.html?logConsole=web,page&logLevel=log")
     .withFrame(0, basicUnitTests);
 
     // Run the same unit tests again with baseline JIT enabled for all methods.
     casper
     .thenOpen("http://localhost:8000/index.html?logConsole=web,page&logLevel=log&forceRuntimeCompilation=1")
-    .withFrame(0, basicUnitTests);*/
+    .withFrame(0, basicUnitTests);
 
     casper
     .thenOpen("http://localhost:8000/index.html?main=tests/isolate/TestIsolate&logLevel=info&logConsole=web,page,raw")

--- a/tests/com/sun/midp/crypto/TestBouncyCastleSHA256.java
+++ b/tests/com/sun/midp/crypto/TestBouncyCastleSHA256.java
@@ -5,7 +5,7 @@ import gnu.testlet.TestHarness;
 import gnu.testlet.Testlet;
 
 public class TestBouncyCastleSHA256 implements Testlet {
-    public int getExpectedPass() { return 6; }
+    public int getExpectedPass() { return 7; }
     public int getExpectedFail() { return 0; }
     public int getExpectedKnownFail() { return 0; }
 
@@ -40,12 +40,10 @@ public class TestBouncyCastleSHA256 implements Testlet {
             th.check(Util.hexEncode(retValue).toLowerCase(), digests[i]);
         }
 
-        /* TODO: Re-enable when compilation is enabled.
-
         for (int i = 0; i < 1000000; i++) {
             md.update((byte)'a');
         }
         md.doFinal(retValue, 0);
-        th.check(Util.hexEncode(retValue).toLowerCase(), MILLION_A_DIGEST);*/
+        th.check(Util.hexEncode(retValue).toLowerCase(), MILLION_A_DIGEST);
     }
 }

--- a/tests/com/sun/midp/crypto/TestClasspathSHA256.java
+++ b/tests/com/sun/midp/crypto/TestClasspathSHA256.java
@@ -5,7 +5,7 @@ import gnu.testlet.TestHarness;
 import gnu.testlet.Testlet;
 
 public class TestClasspathSHA256 implements Testlet {
-    public int getExpectedPass() { return 6; }
+    public int getExpectedPass() { return 7; }
     public int getExpectedFail() { return 0; }
     public int getExpectedKnownFail() { return 0; }
 
@@ -38,11 +38,9 @@ public class TestClasspathSHA256 implements Testlet {
             th.check(Util.hexEncode(md.digest()).toLowerCase(), digests[i]);
         }
 
-        /* TODO: Re-enable when compilation is enabled.
-
         for (int i = 0; i < 1000000; i++) {
             md.update((byte)'a');
         }
-        th.check(Util.hexEncode(md.digest()).toLowerCase(), MILLION_A_DIGEST);*/
+        th.check(Util.hexEncode(md.digest()).toLowerCase(), MILLION_A_DIGEST);
     }
 }

--- a/vm/runtime.ts
+++ b/vm/runtime.ts
@@ -671,7 +671,8 @@ module J2ME {
     // that the midlet OOMed once less than ~3MB of memory was available, presumably
     // because compiled codeis allocating more than that before unwinding.  It would be
     // useful to have more insight into which code allocates memory, and in what chunks,
-    // but this value seems to work ok in the meantime.
+    // so we can set this to the maximum amount of memory needed by compiled code.
+    // But this value seems to work ok in the meantime.
     FREE_MEMORY_TARGET = 4 * 1024 * 1024, // 4MiB
 
     // The size in bytes of the header in the memory allocated to the object.

--- a/vm/runtime.ts
+++ b/vm/runtime.ts
@@ -666,9 +666,12 @@ module J2ME {
     TWO_PWR_32_DBL = 4294967296,
     TWO_PWR_63_DBL = 9223372036854776000,
 
-    // The target amount of free memory(in bytes) before garbage collection is forced on unwind.
-    // Note: This number was chosen somewhat randomly to allow some space for allocation
-    // during forceCollection, though it has not been verified it needs any space.
+    // The target amount of free memory (in bytes) before garbage collection is forced on unwind.
+    // Note: This number was chosen through ad-hoc testing of a midlet, which showed
+    // that the midlet OOMed once less than ~3MB of memory was available, presumably
+    // because compiled codeis allocating more than that before unwinding.  It would be
+    // useful to have more insight into which code allocates memory, and in what chunks,
+    // but this value seems to work ok in the meantime.
     FREE_MEMORY_TARGET = 4 * 1024 * 1024, // 4MiB
 
     // The size in bytes of the header in the memory allocated to the object.

--- a/vm/runtime.ts
+++ b/vm/runtime.ts
@@ -669,7 +669,7 @@ module J2ME {
     // The target amount of free memory(in bytes) before garbage collection is forced on unwind.
     // Note: This number was chosen somewhat randomly to allow some space for allocation
     // during forceCollection, though it has not been verified it needs any space.
-    FREE_MEMORY_TARGET = 4086,
+    FREE_MEMORY_TARGET = 4 * 1024 * 1024, // 4MiB
 
     // The size in bytes of the header in the memory allocated to the object.
     OBJ_HDR_SIZE = 8,

--- a/vm/runtime.ts
+++ b/vm/runtime.ts
@@ -65,7 +65,7 @@ module J2ME {
   /**
    * Turns on just-in-time compilation of methods.
    */
-  export var enableRuntimeCompilation = false;
+  export var enableRuntimeCompilation = true;
 
   /**
    * Turns on onStackReplacement


### PR DESCRIPTION
With #1828, the compiler should be ready to enable on the intex branch. This branch does so.

It also increases *FREE_MEMORY_TARGET* to 4MiB as I noticed that WhatsApp was OOMing when it was set to 2MiB or less. We could use more insight into which code is allocating memory, and in what chunks. But this works for now.
