### PR TITLE
Relocatable JIT Code

### DIFF
--- a/bench/All.java
+++ b/bench/All.java
@@ -1,6 +1,5 @@
 package benchmark;
 import com.sun.cldchi.jvm.JVM;
-import com.sun.cldchi.jvm.JVM;
 
 class All {
     public static void summary(String message) {

--- a/bench/All.java
+++ b/bench/All.java
@@ -1,93 +1,100 @@
 package benchmark;
 import com.sun.cldchi.jvm.JVM;
+import com.sun.cldchi.jvm.JVM;
 
 class All {
+    public static void summary(String message) {
+        System.out.println(message);
+        Thread.yield();
+    }
     public static void main(String[] args) {
 
+        long bigBang = JVM.monotonicTimeMillis();
         long start = JVM.monotonicTimeMillis();
 
         com.sun.midp.crypto.ARC4_Bench.main(args);
-        System.out.println(">> com.sun.midp.crypto.ARC4_Bench: " + (JVM.monotonicTimeMillis() - start)); start = JVM.monotonicTimeMillis();
+        summary(">> com.sun.midp.crypto.ARC4_Bench: " + (JVM.monotonicTimeMillis() - start)); start = JVM.monotonicTimeMillis();
 
         com.sun.midp.crypto.Cipher_Bench.main(args);
-        System.out.println(">> com.sun.midp.crypto.Cipher_Bench: " + (JVM.monotonicTimeMillis() - start)); start = JVM.monotonicTimeMillis();
+        summary(">> com.sun.midp.crypto.Cipher_Bench: " + (JVM.monotonicTimeMillis() - start)); start = JVM.monotonicTimeMillis();
 
         Arithmetic.main(args);
-        System.out.println(">> Arithmetic: " + (JVM.monotonicTimeMillis() - start)); start = JVM.monotonicTimeMillis();
+        summary(">> Arithmetic: " + (JVM.monotonicTimeMillis() - start)); start = JVM.monotonicTimeMillis();
 
         Compiler.main(args);
-        System.out.println(">> Compiler: " + (JVM.monotonicTimeMillis() - start)); start = JVM.monotonicTimeMillis();
+        summary(">> Compiler: " + (JVM.monotonicTimeMillis() - start)); start = JVM.monotonicTimeMillis();
 
         BouncyCastleSHA256.main(args);
-        System.out.println(">> BouncyCastleSHA256: " + (JVM.monotonicTimeMillis() - start)); start = JVM.monotonicTimeMillis();
+        summary(">> BouncyCastleSHA256: " + (JVM.monotonicTimeMillis() - start)); start = JVM.monotonicTimeMillis();
 
         BubbleSort.main(args);
-        System.out.println(">> BubbleSort: " + (JVM.monotonicTimeMillis() - start)); start = JVM.monotonicTimeMillis();
+        summary(">> BubbleSort: " + (JVM.monotonicTimeMillis() - start)); start = JVM.monotonicTimeMillis();
 
         // ByteArrayInputOutputStreamBench.main(args); // Memory problem, too slow.
         // CallNativeBench.main(args);
         ClassLoading.main(args);
-        System.out.println(">> ClassLoading: " + (JVM.monotonicTimeMillis() - start)); start = JVM.monotonicTimeMillis();
+        summary(">> ClassLoading: " + (JVM.monotonicTimeMillis() - start)); start = JVM.monotonicTimeMillis();
 
         DataInputOutputStreamBench.main(args);
-        System.out.println(">> DataInputOutputStreamBench: " + (JVM.monotonicTimeMillis() - start)); start = JVM.monotonicTimeMillis();
+        summary(">> DataInputOutputStreamBench: " + (JVM.monotonicTimeMillis() - start)); start = JVM.monotonicTimeMillis();
 
         // DataInputOutputStreamFileBench.main(args);
         DefaultCaseConverterBench.main(args);
-        System.out.println(">> DefaultCaseConverterBench: " + (JVM.monotonicTimeMillis() - start)); start = JVM.monotonicTimeMillis();
+        summary(">> DefaultCaseConverterBench: " + (JVM.monotonicTimeMillis() - start)); start = JVM.monotonicTimeMillis();
 
         Fields.main(args);
-        System.out.println(">> Fields: " + (JVM.monotonicTimeMillis() - start)); start = JVM.monotonicTimeMillis();
+        summary(">> Fields: " + (JVM.monotonicTimeMillis() - start)); start = JVM.monotonicTimeMillis();
 
         // FileConnectionBench.main(args);
         FileStressBench.main(args);
-        System.out.println(">> FileStressBench: " + (JVM.monotonicTimeMillis() - start)); start = JVM.monotonicTimeMillis();
+        summary(">> FileStressBench: " + (JVM.monotonicTimeMillis() - start)); start = JVM.monotonicTimeMillis();
 
         GestureInteractiveZoneBench.main(args);
-        System.out.println(">> GestureInteractiveZoneBench: " + (JVM.monotonicTimeMillis() - start)); start = JVM.monotonicTimeMillis();
+        summary(">> GestureInteractiveZoneBench: " + (JVM.monotonicTimeMillis() - start)); start = JVM.monotonicTimeMillis();
 
         // ImageProcessingBench.main(args);
         Invoke.main(args);
-        System.out.println(">> Invoke: " + (JVM.monotonicTimeMillis() - start)); start = JVM.monotonicTimeMillis();
+        summary(">> Invoke: " + (JVM.monotonicTimeMillis() - start)); start = JVM.monotonicTimeMillis();
 
         InvokeInterface.main(args);
-        System.out.println(">> InvokeInterface: " + (JVM.monotonicTimeMillis() - start)); start = JVM.monotonicTimeMillis();
+        summary(">> InvokeInterface: " + (JVM.monotonicTimeMillis() - start)); start = JVM.monotonicTimeMillis();
 
         InvokeStatic.main(args);
-        System.out.println(">> InvokeStatic: " + (JVM.monotonicTimeMillis() - start)); start = JVM.monotonicTimeMillis();
+        summary(">> InvokeStatic: " + (JVM.monotonicTimeMillis() - start)); start = JVM.monotonicTimeMillis();
 
         InvokeVirtual.main(args);
-        System.out.println(">> InvokeVirtual: " + (JVM.monotonicTimeMillis() - start)); start = JVM.monotonicTimeMillis();
+        summary(">> InvokeVirtual: " + (JVM.monotonicTimeMillis() - start)); start = JVM.monotonicTimeMillis();
 
         // JITBenchmark.main(args);
         // JZlibBench.main(args); Memory
         MathBench.main(args);
-        System.out.println(">> MathBench: " + (JVM.monotonicTimeMillis() - start)); start = JVM.monotonicTimeMillis();
+        summary(">> MathBench: " + (JVM.monotonicTimeMillis() - start)); start = JVM.monotonicTimeMillis();
 
         // Regex.main(args); Memory
         com.sun.cldc.io.ResourceInputStreamBench.main(args);
-        System.out.println(">> com.sun.cldc.io.ResourceInputStreamBench: " + (JVM.monotonicTimeMillis() - start)); start = JVM.monotonicTimeMillis();
+        summary(">> com.sun.cldc.io.ResourceInputStreamBench: " + (JVM.monotonicTimeMillis() - start)); start = JVM.monotonicTimeMillis();
 
         com.sun.midp.crypto.SHA1_Bench.main(args);
-        System.out.println(">> com.sun.midp.crypto.SHA1_Bench: " + (JVM.monotonicTimeMillis() - start)); start = JVM.monotonicTimeMillis();
+        summary(">> com.sun.midp.crypto.SHA1_Bench: " + (JVM.monotonicTimeMillis() - start)); start = JVM.monotonicTimeMillis();
 
         Sha256Bench.main(args);
-        System.out.println(">> Sha256Bench: " + (JVM.monotonicTimeMillis() - start)); start = JVM.monotonicTimeMillis();
+        summary(">> Sha256Bench: " + (JVM.monotonicTimeMillis() - start)); start = JVM.monotonicTimeMillis();
 
         // SocketBench.main(args);
         // SocketStressBench.main(args);
         // SSLSocketBench.main(args);
         DoubleBench.main(args);
-        System.out.println(">> DoubleBench: " + (JVM.monotonicTimeMillis() - start)); start = JVM.monotonicTimeMillis();
+        summary(">> DoubleBench: " + (JVM.monotonicTimeMillis() - start)); start = JVM.monotonicTimeMillis();
 
         // SystemOutBench.main(args);
         // TestFileSystemPerf.main(args);
         Time.main(args);
-        System.out.println(">> Time: " + (JVM.monotonicTimeMillis() - start)); start = JVM.monotonicTimeMillis();
+        summary(">> Time: " + (JVM.monotonicTimeMillis() - start)); start = JVM.monotonicTimeMillis();
 
         // UTF8Bench.main(args); // Bug
         YieldBench.main(args);
-        System.out.println(">> YieldBench: " + (JVM.monotonicTimeMillis() - start)); start = JVM.monotonicTimeMillis();
+        summary(">> YieldBench: " + (JVM.monotonicTimeMillis() - start)); start = JVM.monotonicTimeMillis();
 
+        summary("== All ==: " + (JVM.monotonicTimeMillis() - bigBang));
     }
 }

--- a/int.ts
+++ b/int.ts
@@ -176,7 +176,7 @@ module J2ME {
         assert(fp < (thread.tp + Constants.MAX_STACK_SIZE >> 2), "Frame pointer is not greater than the stack size.");
         var callee = methodIdToMethodInfoMap[i32[this.fp + FrameLayout.CalleeMethodInfoOffset] & FrameLayout.CalleeMethodInfoMask];
         assert(
-          callee === undefined ||
+          !callee ||
           callee instanceof MethodInfo,
           "Callee @" + ((this.fp + FrameLayout.CalleeMethodInfoOffset) & FrameLayout.CalleeMethodInfoMask) + " is not a MethodInfo, " + toName(callee)
         );
@@ -404,7 +404,7 @@ module J2ME {
       if (frameType === FrameType.Native) {
         this.nativeFrameCount--;
       }
-      return this.popFrame(undefined, frameType);
+      return this.popFrame(null, frameType);
     }
 
     popFrame(methodInfo: MethodInfo, frameType: FrameType = FrameType.Interpreter): MethodInfo {
@@ -651,12 +651,13 @@ module J2ME {
 
   export function prepareInterpretedMethod(methodInfo: MethodInfo): Function {
     var method = function fastInterpreterFrameAdapter() {
+      runtimeCounter && runtimeCounter.count("fastInterpreterFrameAdapter");
       var calleeStats = methodInfo.stats;
       calleeStats.interpreterCallCount++;
       if (config.forceRuntimeCompilation ||
           calleeStats.interpreterCallCount + calleeStats.backwardsBranchCount > ConfigThresholds.InvokeThreshold) {
         compileAndLinkMethod(methodInfo);
-        if(methodInfo.state === MethodState.Compiled) {
+        if (methodInfo.state === MethodState.Compiled) {
           return methodInfo.fn.apply(null, arguments);
         }
       }
@@ -2028,7 +2029,7 @@ module J2ME {
             release || assert(fp >= (thread.tp >> 2), "Valid frame pointer after return.");
             mi = methodIdToMethodInfoMap[i32[fp + FrameLayout.CalleeMethodInfoOffset] & FrameLayout.CalleeMethodInfoMask];
             type = i32[fp + FrameLayout.FrameTypeOffset] & FrameLayout.FrameTypeMask;
-            release || assert(type === FrameType.Interpreter && mi !== undefined || type !== FrameType.Interpreter && mi === undefined, "Is valid frame type and method info after return.");
+            release || assert(type === FrameType.Interpreter && mi || type !== FrameType.Interpreter && !mi, "Is valid frame type and method info after return.");
             var interrupt = false;
             while (type !== FrameType.Interpreter) {
               if (type === FrameType.ExitInterpreter) {

--- a/int.ts
+++ b/int.ts
@@ -99,9 +99,7 @@ module J2ME {
    *             +--------------------------------+
    *             | Caller FP                      |
    *             +--------------------------------+
-   *             | Frame Type                     |
-   *             +--------------------------------+
-   *             | Callee Method Info ID          |
+   *             | Callee Method Info | Marker    |
    *             +--------------------------------+
    *             | Monitor                        |
    *             +--------------------------------+
@@ -145,15 +143,17 @@ module J2ME {
     /**
      * Stored in the lower 28 bits.
      */
-    CalleeMethodInfoOffset      = 4,
+    CalleeMethodInfoOffset      = 2,
+    CalleeMethodInfoMask        = 0x0FFFFFFF,
     /**
      * Stored in the upper 4 bits.
      */
     FrameTypeOffset             = 2,
+    FrameTypeMask               = 0xF0000000,
     CallerFPOffset              = 1,
     CallerRAOffset              = 0,
     MonitorOffset               = 3,
-    CallerSaveSize              = 5
+    CallerSaveSize              = 4
   }
 
   export class FrameView {
@@ -174,11 +174,11 @@ module J2ME {
       if (!release) {
         assert(fp >= (thread.tp >> 2), "Frame pointer is not less than than the top of the stack.");
         assert(fp < (thread.tp + Constants.MAX_STACK_SIZE >> 2), "Frame pointer is not greater than the stack size.");
-        var callee = methodIdToMethodInfoMap[i32[this.fp + FrameLayout.CalleeMethodInfoOffset]];
+        var callee = methodIdToMethodInfoMap[i32[this.fp + FrameLayout.CalleeMethodInfoOffset] & FrameLayout.CalleeMethodInfoMask];
         assert(
           callee === undefined ||
           callee instanceof MethodInfo,
-          "Callee @" + ((this.fp + FrameLayout.CalleeMethodInfoOffset)) + " is not a MethodInfo, " + toName(callee)
+          "Callee @" + ((this.fp + FrameLayout.CalleeMethodInfoOffset) & FrameLayout.CalleeMethodInfoMask) + " is not a MethodInfo, " + toName(callee)
         );
       }
     }
@@ -203,15 +203,15 @@ module J2ME {
     }
 
     get methodInfo(): MethodInfo {
-      return methodIdToMethodInfoMap[i32[this.fp + FrameLayout.CalleeMethodInfoOffset]];
+      return methodIdToMethodInfoMap[i32[this.fp + FrameLayout.CalleeMethodInfoOffset] & FrameLayout.CalleeMethodInfoMask];
     }
 
     get type(): FrameType {
-      return i32[this.fp + FrameLayout.FrameTypeOffset];
+      return i32[this.fp + FrameLayout.FrameTypeOffset] & FrameLayout.FrameTypeMask;
     }
 
     set methodInfo(methodInfo: MethodInfo) {
-      i32[this.fp + FrameLayout.CalleeMethodInfoOffset] = methodInfo.id;
+      i32[this.fp + FrameLayout.CalleeMethodInfoOffset] = (i32[this.fp + FrameLayout.FrameTypeOffset] & FrameLayout.FrameTypeMask) | methodInfo.id;
     }
 
     get parameterOffset() {
@@ -266,7 +266,7 @@ module J2ME {
       if (this.methodInfo) {
         op = this.methodInfo.codeAttribute.code[this.pc];
       }
-      var type  = i32[this.fp + FrameLayout.FrameTypeOffset];
+      var type  = i32[this.fp + FrameLayout.FrameTypeOffset] & FrameLayout.FrameTypeMask;
       writer.writeLn("Frame: " + FrameType[type] + " " + (this.methodInfo ? this.methodInfo.implKey : "null") + ", FP: " + this.fp + "(" + (this.fp - (this.thread.tp >> 2)) + "), SP: " + this.sp + ", PC: " + this.pc + (op >= 0 ? ", OP: " + Bytecodes[op] : ""));
       if (details) {
         for (var i = Math.max(0, this.fp + this.parameterOffset); i < this.sp; i++) {
@@ -394,8 +394,7 @@ module J2ME {
       release || assert(fp < (this.tp + Constants.MAX_STACK_SIZE >> 2), "Frame pointer is not greater than the stack size.");
       i32[this.fp + FrameLayout.CallerRAOffset] = this.pc;    // Caller RA
       i32[this.fp + FrameLayout.CallerFPOffset] = fp;         // Caller FP
-      i32[this.fp + FrameLayout.FrameTypeOffset] = frameType; // Frame Type
-      i32[this.fp + FrameLayout.CalleeMethodInfoOffset] = (methodInfo === null ? Constants.NULL : methodInfo.id); // Callee
+      i32[this.fp + FrameLayout.CalleeMethodInfoOffset] = frameType | (methodInfo === null ? Constants.NULL : methodInfo.id); // Callee
       i32[this.fp + FrameLayout.MonitorOffset] = monitorAddr; // Monitor
       this.sp = this.fp + FrameLayout.CallerSaveSize + sp;
       this.pc = pc;
@@ -409,15 +408,15 @@ module J2ME {
     }
 
     popFrame(methodInfo: MethodInfo, frameType: FrameType = FrameType.Interpreter): MethodInfo {
-      var mi = methodIdToMethodInfoMap[i32[this.fp + FrameLayout.CalleeMethodInfoOffset]];
-      var type = i32[this.fp + FrameLayout.FrameTypeOffset];
+      var mi = methodIdToMethodInfoMap[i32[this.fp + FrameLayout.CalleeMethodInfoOffset] & FrameLayout.CalleeMethodInfoMask];
+      var type = i32[this.fp + FrameLayout.FrameTypeOffset] & FrameLayout.FrameTypeMask;
       release || assert(mi === methodInfo && type === frameType, "mi === methodInfo && type === frameType");
       this.pc = i32[this.fp + FrameLayout.CallerRAOffset];
       var maxLocals = mi ? mi.codeAttribute.max_locals : 0;
       this.sp = this.fp - maxLocals;
       this.fp = i32[this.fp + FrameLayout.CallerFPOffset];
       release || assert(this.fp >= (this.tp >> 2), "Valid frame pointer after pop.");
-      return methodIdToMethodInfoMap[i32[this.fp + FrameLayout.CalleeMethodInfoOffset]];
+      return methodIdToMethodInfoMap[i32[this.fp + FrameLayout.CalleeMethodInfoOffset] & FrameLayout.CalleeMethodInfoMask];
     }
 
     run() {
@@ -430,10 +429,10 @@ module J2ME {
       var pc = -1;
       var classInfo;
       while (true) {
-        var frameType = i32[this.fp + FrameLayout.FrameTypeOffset];
+        var frameType = i32[this.fp + FrameLayout.FrameTypeOffset] & FrameLayout.FrameTypeMask;
         switch (frameType) {
           case FrameType.Interpreter:
-            var mi = methodIdToMethodInfoMap[i32[this.fp + FrameLayout.CalleeMethodInfoOffset]];
+            var mi = methodIdToMethodInfoMap[i32[this.fp + FrameLayout.CalleeMethodInfoOffset] & FrameLayout.CalleeMethodInfoMask];
             release || traceWriter && traceWriter.writeLn("Looking for handler in: " + mi.implKey);
             for (var i = 0; i < mi.exception_table_length; i++) {
               var exceptionEntryView = mi.getExceptionEntryViewByIndex(i);
@@ -560,7 +559,7 @@ module J2ME {
           }
           ASM._gcFree(pendingNativeFrameAddress);
         }
-        var frameType = i32[this.fp + FrameLayout.FrameTypeOffset];
+        var frameType = i32[this.fp + FrameLayout.FrameTypeOffset] & FrameLayout.FrameTypeMask;
 
         if (frameType === FrameType.PushPendingFrames) {
           continue;
@@ -1537,7 +1536,7 @@ module J2ME {
                 // Just because we've jumped backwards doesn't mean we are at a loop header but it does mean that we are
                 // at the beginning of a basic block. This is a really cheap test and a convenient place to perform an
                 // on stack replacement.
-                var previousFrameType = i32[i32[fp + FrameLayout.CallerFPOffset] + FrameLayout.FrameTypeOffset];
+                var previousFrameType = i32[i32[fp + FrameLayout.CallerFPOffset] + FrameLayout.FrameTypeOffset] & FrameLayout.FrameTypeMask;
 
                 if ((previousFrameType === FrameType.Interpreter || previousFrameType === FrameType.ExitInterpreter) && mi.onStackReplacementEntryPoints.indexOf(opPC + jumpOffset) > -1) {
                   traceWriter && traceWriter.writeLn("OSR: " + mi.implKey);
@@ -1599,8 +1598,8 @@ module J2ME {
                     }
                   }
 
-                  mi = methodIdToMethodInfoMap[i32[fp + FrameLayout.CalleeMethodInfoOffset]];
-                  type = i32[fp + FrameLayout.FrameTypeOffset];
+                  mi = methodIdToMethodInfoMap[i32[fp + FrameLayout.CalleeMethodInfoOffset] & FrameLayout.CalleeMethodInfoMask];
+                  type = i32[fp + FrameLayout.FrameTypeOffset] & FrameLayout.FrameTypeMask;
 
                   maxLocals = mi.codeAttribute.max_locals;
                   lp = fp - maxLocals | 0;
@@ -2027,8 +2026,8 @@ module J2ME {
             sp = fp - maxLocals | 0;
             fp = i32[fp + FrameLayout.CallerFPOffset];
             release || assert(fp >= (thread.tp >> 2), "Valid frame pointer after return.");
-            mi = methodIdToMethodInfoMap[i32[fp + FrameLayout.CalleeMethodInfoOffset]];
-            type = i32[fp + FrameLayout.FrameTypeOffset];
+            mi = methodIdToMethodInfoMap[i32[fp + FrameLayout.CalleeMethodInfoOffset] & FrameLayout.CalleeMethodInfoMask];
+            type = i32[fp + FrameLayout.FrameTypeOffset] & FrameLayout.FrameTypeMask;
             release || assert(type === FrameType.Interpreter && mi !== undefined || type !== FrameType.Interpreter && mi === undefined, "Is valid frame type and method info after return.");
             var interrupt = false;
             while (type !== FrameType.Interpreter) {
@@ -2052,8 +2051,8 @@ module J2ME {
                 fp = thread.fp | 0;
                 sp = thread.sp | 0;
                 opPC = pc = thread.pc;
-                type = i32[fp + FrameLayout.FrameTypeOffset];
-                mi = methodIdToMethodInfoMap[i32[fp + FrameLayout.CalleeMethodInfoOffset]];
+                type = i32[fp + FrameLayout.FrameTypeOffset] & FrameLayout.FrameTypeMask;
+                mi = methodIdToMethodInfoMap[i32[fp + FrameLayout.CalleeMethodInfoOffset] & FrameLayout.CalleeMethodInfoMask];
                 continue;
               } else if (type === FrameType.Interrupt) {
                 thread.set(fp, sp, opPC);
@@ -2061,8 +2060,8 @@ module J2ME {
                 fp = thread.fp | 0;
                 sp = thread.sp | 0;
                 opPC = pc = thread.pc;
-                type = i32[fp + FrameLayout.FrameTypeOffset];
-                mi = methodIdToMethodInfoMap[i32[fp + FrameLayout.CalleeMethodInfoOffset]];
+                type = i32[fp + FrameLayout.FrameTypeOffset] & FrameLayout.FrameTypeMask;
+                mi = methodIdToMethodInfoMap[i32[fp + FrameLayout.CalleeMethodInfoOffset] & FrameLayout.CalleeMethodInfoMask];
                 interrupt = true;
                 continue;
               } else {
@@ -2277,8 +2276,7 @@ module J2ME {
             // Caller saved values.
             i32[fp + FrameLayout.CallerRAOffset] = opPC;
             i32[fp + FrameLayout.CallerFPOffset] = callerFPOffset;
-            i32[fp + FrameLayout.FrameTypeOffset] = FrameType.Interpreter;
-            i32[fp + FrameLayout.CalleeMethodInfoOffset] = mi.id;
+            i32[fp + FrameLayout.CalleeMethodInfoOffset] = FrameType.Interpreter | mi.id;
             i32[fp + FrameLayout.MonitorOffset] = Constants.NULL; // Monitor
 
             // Reset PC.

--- a/int.ts
+++ b/int.ts
@@ -142,12 +142,18 @@ module J2ME {
   }
 
   export const enum FrameLayout {
-    CallerRAOffset         = 0,
-    CallerFPOffset         = 1,
-    FrameTypeOffset        = 2,
-    MonitorOffset          = 3,
-    CalleeMethodInfoOffset = 4,
-    CallerSaveSize         = 5
+    /**
+     * Stored in the lower 28 bits.
+     */
+    CalleeMethodInfoOffset      = 4,
+    /**
+     * Stored in the upper 4 bits.
+     */
+    FrameTypeOffset             = 2,
+    CallerFPOffset              = 1,
+    CallerRAOffset              = 0,
+    MonitorOffset               = 3,
+    CallerSaveSize              = 5
   }
 
   export class FrameView {

--- a/int.ts
+++ b/int.ts
@@ -117,28 +117,28 @@ module J2ME {
     /**
      * Normal interpreter frame.
      */
-    Interpreter = 0x0,
+    Interpreter = 0x00000000,
 
     /**
      * Marks the beginning of a sequence of interpreter frames. If we see this
      * frame when returning we need to exit the interpreter loop.
      */
-    ExitInterpreter = 0x1,
+    ExitInterpreter = 0x10000000,
 
     /**
      * Native frames are pending and need to be pushed on the stack.
      */
-    PushPendingFrames = 0x2,
+    PushPendingFrames = 0x20000000,
 
     /**
      * Marks the beginning of frames that were not invoked by the previous frame.
      */
-    Interrupt = 0x3,
+    Interrupt = 0x30000000,
 
     /**
      * Marks the beginning of native/compiled code called from the interpreter.
      */
-    Native = 0x4
+    Native = 0x40000000
   }
 
   export const enum FrameLayout {

--- a/jit/baseline.ts
+++ b/jit/baseline.ts
@@ -614,7 +614,7 @@ module J2ME {
     classInfoSymbol(classInfo: ClassInfo): string {
       var id = this.referencedClasses.indexOf(classInfo);
       assert(id >= 0, "Class info not found in the referencedClasses list.");
-      return "@@" + id;
+      return classInfoSymbolPrefix + id;
     }
 
     classInfoObject(classInfo: ClassInfo): string {
@@ -630,7 +630,7 @@ module J2ME {
     methodInfoSymbol(methodInfo: MethodInfo): string {
       var id = this.referencedClasses.indexOf(methodInfo.classInfo);
       assert(id >= 0, "Class info not found in the referencedClasses list.");
-      return "@!" + id + ":" + methodInfo.index;
+      return methodInfoSymbolPrefix + id + "_" + methodInfo.index;
     }
 
     lookupField(cpi: number, opcode: Bytecodes, isStatic: boolean): FieldInfo {

--- a/jit/baseline.ts
+++ b/jit/baseline.ts
@@ -229,10 +229,6 @@ module J2ME {
     return String(v);
   }
 
-  function classConstant(classInfo: ClassInfo): string {
-    return "CI[" + classInfo.id + "]";
-  }
-
   function throwCompilerError(message: string) {
     throw new Error(message);
   }
@@ -278,7 +274,7 @@ module J2ME {
       this.pc = 0;
       this.sp = 0;
       this.parameters = [];
-      this.referencedClasses = [];
+      this.referencedClasses = [this.methodInfo.classInfo];
       this.initializedClasses = null;
       this.hasHandlers = methodInfo.exception_table_length > 0;
       this.hasMonitorEnter = false;
@@ -346,15 +342,6 @@ module J2ME {
         }
         this.setBlockStackHeight(successors[i].startBci, sp);
       }
-    }
-
-    // Cache classes known to be initialized as locals.
-    localClassConstant(classInfo: ClassInfo): string {
-      if (classInfo !== this.methodInfo.classInfo) {
-        return classConstant(classInfo);
-      }
-      this.needsVariable("k0", classConstant(classInfo));
-      return "k0";
     }
 
     emitBody() {
@@ -440,7 +427,7 @@ module J2ME {
         if (classInfo.isInterface) {
           check = "IOI";
         }
-        check += "(" + this.peek(Kind.Reference) + "," + classInfo.id + ")";
+        check += "(" + this.peek(Kind.Reference) + "," + this.classInfoSymbol(classInfo) + ")";
         check = "&&" + check;
       }
       this.bodyEmitter.writeLn("if(pc>=" + handler.start_pc + "&&pc<" + handler.end_pc + check + "){pc=" + this.getBlockIndex(handler.handler_pc) + ";continue;}");
@@ -624,10 +611,26 @@ module J2ME {
       return classInfo;
     }
 
+    classInfoSymbol(classInfo: ClassInfo): string {
+      var id = this.referencedClasses.indexOf(classInfo);
+      assert(id >= 0, "Class info not found in the referencedClasses list.");
+      return "@@" + id;
+    }
+
+    classInfoObject(classInfo: ClassInfo): string {
+      return "CI[" + this.classInfoSymbol(classInfo) + "]";
+    }
+
     lookupMethod(cpi: number, opcode: Bytecodes, isStatic: boolean): MethodInfo {
       var methodInfo = this.methodInfo.classInfo.constantPool.resolveMethod(cpi, isStatic);
       ArrayUtilities.pushUnique(this.referencedClasses, methodInfo.classInfo);
       return methodInfo;
+    }
+
+    methodInfoSymbol(methodInfo: MethodInfo): string {
+      var id = this.referencedClasses.indexOf(methodInfo.classInfo);
+      assert(id >= 0, "Class info not found in the referencedClasses list.");
+      return "@!" + id + ":" + methodInfo.index;
     }
 
     lookupField(cpi: number, opcode: Bytecodes, isStatic: boolean): FieldInfo {
@@ -848,12 +851,12 @@ module J2ME {
 
     runtimeClass(classInfo: ClassInfo) {
       this.needsVariable("sa", "$.SA");
-      return "sa[" + classInfo.id + "]";
+      return "sa[" + this.classInfoSymbol(classInfo) + "]";
     }
 
     runtimeClassObject(classInfo: ClassInfo) {
       this.needsVariable("co", "$.CO");
-      return "co[" + classInfo.id + "]";
+      return "co[" + this.classInfoSymbol(classInfo) + "]";
     }
 
     emitClassInitializationCheck(classInfo: ClassInfo) {
@@ -871,7 +874,7 @@ module J2ME {
         } else {
           (emitDebugInfoComments || baselineCounter) && (message = "ClassInitializationCheck: " + classInfo.getClassNameSlow());
           this.needsVariable("ci", "$.I");
-          this.blockEmitter.writeLn("ci[" + classInfo.id + "] || CIC(" + classConstant(classInfo) + ");");
+          this.blockEmitter.writeLn("ci[" + this.classInfoSymbol(classInfo) + "] || CIC(" + this.classInfoObject(classInfo) + ");");
           if (canStaticInitializerYield(classInfo)) {
             this.emitUnwind(this.blockEmitter, String(this.pc));
           } else {
@@ -903,14 +906,14 @@ module J2ME {
       }
 
       var call;
-      var classConstant = this.localClassConstant(methodInfo.classInfo);
+      var classInfoObject = this.classInfoObject(methodInfo.classInfo);
       var methodId = null;
       if (opcode !== Bytecodes.INVOKESTATIC) {
         var object = this.pop(Kind.Reference);
         this.emitNullPointerCheck(object);
         args.unshift(object);
         if (opcode === Bytecodes.INVOKESPECIAL) {
-          methodId = methodInfo.id;
+          methodId = this.methodInfoSymbol(methodInfo);
           call = "(LM[" + methodId + "]||" + "GLM(" + methodId + "))(" + args.join(",") + ")";
         } else if (opcode === Bytecodes.INVOKEVIRTUAL) {
           var classId = "i32[(" + object + "|0)>>2]";
@@ -928,7 +931,7 @@ module J2ME {
         }
       } else {
         args.unshift(String(Constants.NULL));
-        methodId = methodInfo.id;
+        methodId = this.methodInfoSymbol(methodInfo);
         call = "(LM[" + methodId + "]||" + "GLM(" + methodId + "))(" + args.join(",") + ")";
       }
 
@@ -1086,7 +1089,7 @@ module J2ME {
           this.emitPushLongBits(l, h);
           return;
         case TAGS.CONSTANT_String:
-          this.emitPush(Kind.Reference, this.localClassConstant(this.methodInfo.classInfo) + ".constantPool.resolve(" + index + ", " + TAGS.CONSTANT_String + ")");
+          this.emitPush(Kind.Reference, this.classInfoObject(this.methodInfo.classInfo) + ".constantPool.resolve(" + index + ", " + TAGS.CONSTANT_String + ")");
           return;
         default:
           throw "Not done for: " + TAGS[tag];
@@ -1102,7 +1105,7 @@ module J2ME {
     emitNewInstance(cpi: number) {
       var classInfo = this.lookupClass(cpi);
       this.emitClassInitializationCheck(classInfo);
-      this.emitPush(Kind.Reference, "AO(" + this.localClassConstant(classInfo) + ")");
+      this.emitPush(Kind.Reference, "AO(" + this.classInfoObject(classInfo) + ")");
     }
 
     emitNewTypeArray(typeCode: number) {
@@ -1123,9 +1126,9 @@ module J2ME {
       if (classInfo.isInterface) {
         call = "CCI";
       }
-      call = call + "(" + object + "," + classInfo.id + ")"
+      call = call + "(" + object + "," + this.classInfoSymbol(classInfo) + ")"
       if (inlineRuntimeCalls) {
-        this.blockEmitter.writeLn("(!" + object + ")||i32[" + object + "+" + Constants.OBJ_CLASS_ID_OFFSET + ">>2]===" + classInfo.id + "||" + call + ";");
+        this.blockEmitter.writeLn("(!" + object + ")||i32[" + object + "+" + Constants.OBJ_CLASS_ID_OFFSET + ">>2]===" + this.classInfoSymbol(classInfo) + "||" + call + ";");
       } else {
         this.blockEmitter.writeLn(call + ";");
       }
@@ -1138,9 +1141,9 @@ module J2ME {
       if (classInfo.isInterface) {
         call = "IOI";
       }
-      call = call + "(" + object + "," + classInfo.id + ")|0";
+      call = call + "(" + object + "," + this.classInfoSymbol(classInfo) + ")|0";
       if (inlineRuntimeCalls) {
-        call = "((" + object + "&&i32[" + object + "+" + Constants.OBJ_CLASS_ID_OFFSET + ">>2]=== " + classInfo.id + ")||" + call + ")|0";
+        call = "((" + object + "&&i32[" + object + "+" + Constants.OBJ_CLASS_ID_OFFSET + ">>2]=== " + this.classInfoSymbol(classInfo) + ")||" + call + ")|0";
       }
       this.emitPush(Kind.Int, call);
     }
@@ -1160,7 +1163,7 @@ module J2ME {
       this.emitClassInitializationCheck(classInfo);
       var length = this.pop(Kind.Int);
       this.emitNegativeArraySizeCheck(length);
-      this.emitPush(Kind.Reference, "NA(" + this.localClassConstant(classInfo) + ", " + length + ")");
+      this.emitPush(Kind.Reference, "NA(" + this.classInfoObject(classInfo) + ", " + length + ")");
     }
 
     emitNewMultiObjectArray(cpi: number, stream: BytecodeStream) {
@@ -1170,7 +1173,7 @@ module J2ME {
       for (var i = numDimensions - 1; i >= 0; i--) {
         dimensions[i] = this.pop(Kind.Int);
       }
-      this.emitPush(Kind.Reference, "NM(" + this.localClassConstant(classInfo) + ",[" + dimensions.join(",") + "])");
+      this.emitPush(Kind.Reference, "NM(" + this.classInfoObject(classInfo) + ",[" + dimensions.join(",") + "])");
     }
 
     private emitUnwind(emitter: Emitter, pc: string, forceInline: boolean = false) {
@@ -1187,7 +1190,7 @@ module J2ME {
 
     private emitBailout(emitter: Emitter, pc: string, sp: string, stackCount: number) {
       var localCount = this.methodInfo.codeAttribute.max_locals;
-      var args = [this.methodInfo.id, pc, this.lockObject];
+      var args = [this.methodInfoSymbol(this.methodInfo), pc, this.lockObject];
       for (var i = 0; i < localCount; i++) {
         args.push(this.getLocalName(i));
       }

--- a/jit/baseline.ts
+++ b/jit/baseline.ts
@@ -914,7 +914,11 @@ module J2ME {
           call = "(LM[" + methodId + "]||" + "GLM(" + methodId + "))(" + args.join(",") + ")";
         } else if (opcode === Bytecodes.INVOKEVIRTUAL) {
           var classId = "i32[(" + object + "|0)>>2]";
-          call = "(VT[" + classId + "][" + methodInfo.vTableIndex + "]||" + "GLVM(" + classId + "," + methodInfo.vTableIndex + "))(" + args.join(",") + ")";
+          if (methodInfo.vTableIndex < (1 << Constants.LOG_MAX_FLAT_VTABLE_SIZE)) {
+            call = "(FT[(" + classId + "<<" + Constants.LOG_MAX_FLAT_VTABLE_SIZE + ")+" + methodInfo.vTableIndex + "]||" + "GLVM(" + classId + "," + methodInfo.vTableIndex + "))(" + args.join(",") + ")";
+          } else {
+            call = "(VT[" + classId + "][" + methodInfo.vTableIndex + "]||" + "GLVM(" + classId + "," + methodInfo.vTableIndex + "))(" + args.join(",") + ")";
+          }
         } else if (opcode === Bytecodes.INVOKEINTERFACE) {
           var objClass = "CI[i32[(" + object + "+" + Constants.OBJ_CLASS_ID_OFFSET + ")>>2]]";
           methodId = objClass + ".iTable['" + methodInfo.mangledName + "'].id";

--- a/jsshell.js
+++ b/jsshell.js
@@ -298,6 +298,9 @@ try {
   var writer = new J2ME.IndentingWriter(false, function (x) {
     print(x);
   });
+  if (J2ME.runtimeCounter) {
+    J2ME.runtimeCounter.traceSorted(writer);
+  }
   if (J2ME.gcCounter) {
     J2ME.gcCounter.traceSorted(writer);
   }

--- a/utilities.ts
+++ b/utilities.ts
@@ -20,10 +20,17 @@ var jsGlobal = (function() { return this || (1, eval)('this'); })();
 var inBrowser = typeof pc2line === "undefined";
 
 
+declare var flagsOf;
 declare var putstr;
 declare var printErr;
 
 declare var dateNow: () => number;
+
+if (!jsGlobal.flagsOf) {
+  jsGlobal.flagsOf = function () {
+    return 0;
+  };
+}
 
 if (!jsGlobal.performance) {
   jsGlobal.performance = {};
@@ -106,6 +113,14 @@ module J2ME {
 
     export function abstractMethod(message: string) {
       Debug.assert(false, "Abstract Method " + message);
+    }
+
+    /**
+     * Ensures that the object is not in dictionary mode. To use this, you'll need a
+     * special build of SpiderMonkey, ask mbx.
+     */
+    export function assertNonDictionaryModeObject(object: Object) {
+      Debug.assert((flagsOf(object) & 1) === 0, "Object is in dictionary mode.");
     }
 
     export function unexpected(message?: any) {

--- a/vm/classRegistry.ts
+++ b/vm/classRegistry.ts
@@ -146,7 +146,6 @@ module J2ME {
       var classInfo = new ClassInfo(bytes);
       leaveTimeline("loadClassBytes");
       loadWriter && loadWriter.writeLn(classInfo.getClassNameSlow() + " -> " + classInfo.superClassName + ";");
-      classIdToClassInfoMap[classInfo.id] = classInfo;
       this.classes[classInfo.getClassNameSlow()] = classInfo;
       return classInfo;
     }
@@ -220,7 +219,6 @@ module J2ME {
         }
         classInfo = new ObjectArrayClassInfo(this.getClass(elementType));
       }
-      classIdToClassInfoMap[classInfo.id] = classInfo;
       return this.classes[typeName] = classInfo;
     }
 

--- a/vm/parser.ts
+++ b/vm/parser.ts
@@ -822,6 +822,8 @@ module J2ME {
   }
 
   export class MethodInfo extends ByteStream {
+    private static nextId: number = 1;
+
     public classInfo: ClassInfo;
     public accessFlags: ACCESS_FLAGS;
 
@@ -860,20 +862,14 @@ module J2ME {
 
     constructor(classInfo: ClassInfo, offset: number, index: number) {
       super(classInfo.buffer, offset);
+      this.id = MethodInfo.nextId++;
+      methodIdToMethodInfoMap[this.id] = this;
       this.index = index;
       this.accessFlags = this.u2(0);
       this.classInfo = classInfo;
       var cp = this.classInfo.constantPool;
       this.utf8Name = cp.resolveUtf8(this.u2(2));
       this.utf8Signature = cp.resolveUtf8(this.u2(4));
-
-      var utf8ImplKey = new Uint8Array(classInfo.utf8Name.length + this.utf8Name.length + this.utf8Signature.length);
-      utf8ImplKey.set(classInfo.utf8Name);
-      utf8ImplKey.set(this.utf8Name, classInfo.utf8Name.length);
-      utf8ImplKey.set(this.utf8Signature, classInfo.utf8Name.length + this.utf8Name.length);
-      this.id = hashBytesTo32BitsMurmur(utf8ImplKey, 0, utf8ImplKey.length) >> 0;
-      methodIdToMethodInfoMap[this.id] = this;
-
       this.vTableIndex = -1;
 
       this.state = MethodState.Cold;
@@ -1045,6 +1041,14 @@ module J2ME {
   }
 
   export class ClassInfo extends ByteStream {
+    /**
+     * We use this ID to map Java objects to their ClassInfo objects,
+     * storing the ID for the Class in the first four bytes
+     * of the memory allocated for the Java object in the ASM heap.
+     *
+     */
+    private static nextId: number = 1;
+
     constantPool: ConstantPool = null;
 
     utf8Name: Uint8Array = null;
@@ -1091,6 +1095,8 @@ module J2ME {
 
     constructor(buffer: Uint8Array) {
       super(buffer, 0);
+      this.id = ClassInfo.nextId++;
+      release || assert(phase === ExecutionPhase.Compiler || this.id <= Constants.MAX_CLASS_ID, "Maximum class id was exceeded, " + this.id);
       if (!buffer) {
         sealObjects && Object.seal(this);
         return;
@@ -1103,7 +1109,6 @@ module J2ME {
       s.seek(this.constantPool.offset);
       this.accessFlags = s.readU2();
       this.utf8Name = this.constantPool.resolveUtf8ClassName(s.readU2());
-      this.id = hashBytesTo32BitsMurmur(this.utf8Name, 0, this.utf8Name.length) >> 0;
       this.utf8SuperName = this.constantPool.resolveUtf8ClassName(s.readU2());
       this.vTable = [];
       this.fTable = []
@@ -1596,7 +1601,6 @@ module J2ME {
     constructor(utf8Name, mangledName) {
       super(null);
       this.utf8Name = utf8Name;
-      this.id = hashBytesTo32BitsMurmur(this.utf8Name, 0, this.utf8Name.length) >> 0;
       this.mangledName = mangledName;
       this.complete();
     }
@@ -1631,7 +1635,6 @@ module J2ME {
       } else {
         this.utf8Name = strcat4Single(UTF8Chars.OpenBracket, UTF8Chars.L, elementClass.utf8Name, UTF8Chars.Semicolon);
       }
-      this.id = hashBytesTo32BitsMurmur(this.utf8Name, 0, this.utf8Name.length) >> 0;
       this.mangledName = mangleClassName(this.utf8Name);
       this.complete();
     }
@@ -1642,7 +1645,6 @@ module J2ME {
     constructor(elementClass: ClassInfo, mangledName: string, bytesPerElement: number) {
       super(elementClass);
       this.utf8Name = strcatSingle(UTF8Chars.OpenBracket, elementClass.utf8Name);
-      this.id = hashBytesTo32BitsMurmur(this.utf8Name, 0, this.utf8Name.length) >> 0;
       this.mangledName = mangledName;
       this.bytesPerElement = bytesPerElement;
       this.complete();

--- a/vm/parser.ts
+++ b/vm/parser.ts
@@ -863,7 +863,7 @@ module J2ME {
     constructor(classInfo: ClassInfo, offset: number, index: number) {
       super(classInfo.buffer, offset);
       this.id = MethodInfo.nextId++;
-      methodIdToMethodInfoMap[this.id] = this;
+      registerMethodId(this.id, this);
       this.index = index;
       this.accessFlags = this.u2(0);
       this.classInfo = classInfo;
@@ -1096,7 +1096,7 @@ module J2ME {
     constructor(buffer: Uint8Array) {
       super(buffer, 0);
       this.id = ClassInfo.nextId++;
-      release || assert(phase === ExecutionPhase.Compiler || this.id <= Constants.MAX_CLASS_ID, "Maximum class id was exceeded, " + this.id);
+      registerClassId(this.id, this);
       if (!buffer) {
         sealObjects && Object.seal(this);
         return;

--- a/vm/runtime.ts
+++ b/vm/runtime.ts
@@ -1279,16 +1279,24 @@ module J2ME {
     linkedMethods[methodInfo.id] = fn;
   }
 
+  // Make sure class and method symbol references can be parsed as identifiers. This allows closure and other tools
+  // to process this code as JS files.
+  export var classInfoSymbolPrefix =  "$C"; // "$C123
+  export var methodInfoSymbolPrefix = "$M"; // "$M123_456
+  var classInfoSymbolPrefixPattern =  /\$C(\d+)/g;
+  var methodInfoSymbolPrefixPattern = /\$M(\d+)_(\d+)/g;
+
   /**
    * Links up compiled method at runtime.
    */
   export function linkMethodSource(methodInfo: MethodInfo, args: string[], body: string, referencedClasses: ClassInfo [], onStackReplacementEntryPoints: any) {
     jitWriter && jitWriter.writeLn("Link method: " + methodInfo.implKey);
     // TODO: Don't use RegExp ever ever.
-    body = body.replace(/@@(\d+)/g, <any>function (match, symbol) {
+    // Patch class and method symbols in relocatable code.
+    body = body.replace(classInfoSymbolPrefixPattern, <any>function (match, symbol) {
       // jitWriter && jitWriter.writeLn("Linking Class Symbol: " + symbol + " to " + referencedClasses[symbol]);
       return referencedClasses[symbol].id;
-    }).replace(/@!(\d+):(\d+)/g, <any>function (match, symbol, index) {
+    }).replace(methodInfoSymbolPrefixPattern, <any>function (match, symbol, index) {
       // jitWriter && jitWriter.writeLn("Linking Method Symbol: " + symbol + ":" + index + " to " + referencedClasses[symbol].getMethodByIndex(index));
       return referencedClasses[symbol].getMethodByIndex(index).id;
     });

--- a/vm/runtime.ts
+++ b/vm/runtime.ts
@@ -1076,9 +1076,12 @@ module J2ME {
   }
 
   export function getLinkedVirtualMethodById(classId: number, vTableIndex: number) {
-    var fn = getLinkedMethod(classIdToClassInfoMap[classId].vTable[vTableIndex]);
-    // Cache linked method in the |linkedVTableMap|.
-    classIdToLinkedVTableMap[classId][vTableIndex] = fn;
+    var methodInfo = classIdToClassInfoMap[classId].vTable[vTableIndex];
+    var fn = getLinkedMethod(methodInfo);
+    // Only cache compiled methods in the |linkedVTableMap|.
+    if (methodInfo.state === MethodState.Compiled) {
+      classIdToLinkedVTableMap[classId][vTableIndex] = fn;
+    }
     return fn;
   }
 

--- a/vm/runtime.ts
+++ b/vm/runtime.ts
@@ -751,6 +751,7 @@ module J2ME {
     while (array.length < length) {
       array.push(null);
     }
+    release || Debug.assertNonDictionaryModeObject(array);
   }
 
   export function registerClassId(classId: number, classInfo: ClassInfo) {
@@ -765,10 +766,6 @@ module J2ME {
     ensureDenseObjectMapLength(linkedMethods, methodId + 1);
     methodIdToMethodInfoMap[methodId] = methodInfo;
   }
-
-  //export var classIdToClassInfoMap = ArrayUtilities.makeDenseArray(Constants.MAX_CLASS_ID + 1, null);
-  //export var methodIdToMethodInfoMap = ArrayUtilities.makeDenseArray(Constants.MAX_METHOD_ID + 1, null);
-  //export var linkedMethods = ArrayUtilities.makeDenseArray(Constants.MAX_METHOD_ID + 1, null);
 
   /**
    * Maps classIds to vTables containing JS functions.
@@ -1080,7 +1077,9 @@ module J2ME {
     var fn = getLinkedMethod(methodInfo);
     // Only cache compiled methods in the |linkedVTableMap|.
     if (methodInfo.state === MethodState.Compiled) {
-      classIdToLinkedVTableMap[classId][vTableIndex] = fn;
+      var vTable = classIdToLinkedVTableMap[classId];
+      release || Debug.assertNonDictionaryModeObject(vTable);
+      vTable[vTableIndex] = fn;
     }
     return fn;
   }

--- a/vm/runtime.ts
+++ b/vm/runtime.ts
@@ -623,11 +623,11 @@ module J2ME {
 
       if (!classInfo.isInterface) {
         // Pre-allocate linkedVTableMap.
-        ensureDenseObjectMapLength(classIdToLinkedVTableMap, classInfo.id + 1);
-        classIdToLinkedVTableMap[classInfo.id] = ArrayUtilities.makeDenseArray(classInfo.vTable.length, null);
+        ensureDenseObjectMapLength(linkedVTableMap, classInfo.id + 1);
+        ensureDenseObjectMapLength(flatLinkedVTableMap, (classInfo.id + 1) << Constants.LOG_MAX_FLAT_VTABLE_SIZE);
+        linkedVTableMap[classInfo.id] = ArrayUtilities.makeDenseArray(classInfo.vTable.length, null);
       }
     }
-
   }
 
   export enum VMState {
@@ -682,7 +682,9 @@ module J2ME {
     INITIAL_MAX_METHOD_ID = 511,
 
     MAX_CLASS_ID = 4095,
-    INITIAL_MAX_CLASS_ID = 511
+    INITIAL_MAX_CLASS_ID = 511,
+
+    LOG_MAX_FLAT_VTABLE_SIZE = 8
   }
 
   export class Runtime extends RuntimeTemplate {
@@ -770,7 +772,16 @@ module J2ME {
   /**
    * Maps classIds to vTables containing JS functions.
    */
-  export var classIdToLinkedVTableMap = [];
+  export var linkedVTableMap = [];
+
+  /**
+   * Flat map of classId and vTableIndex to JS functions. This allows the compiler to
+   * emit a single memory load to lookup a vTable entry 
+   *  flatLinkedVTableMap[classId << LOG_MAX_FLAT_VTABLE_SIZE + vTableIndex]
+   * instead of the slower more general
+   *  linkedVTableMap[classId][vTableIndex]
+   */
+  export var flatLinkedVTableMap = [];
 
   export function getClassInfo(addr: number) {
     release || assert(addr !== Constants.NULL, "addr !== Constants.NULL");
@@ -1075,11 +1086,16 @@ module J2ME {
   export function getLinkedVirtualMethodById(classId: number, vTableIndex: number) {
     var methodInfo = classIdToClassInfoMap[classId].vTable[vTableIndex];
     var fn = getLinkedMethod(methodInfo);
-    // Only cache compiled methods in the |linkedVTableMap|.
+    // Only cache compiled methods in the |linkedVTableMap| and |flatLinkedVTableMap|.
     if (methodInfo.state === MethodState.Compiled) {
-      var vTable = classIdToLinkedVTableMap[classId];
+      var vTable = linkedVTableMap[classId];
       release || Debug.assertNonDictionaryModeObject(vTable);
       vTable[vTableIndex] = fn;
+      // Only cache methods in the |flatLinkedVTableMap| if there is room.
+      if (vTableIndex < (1 << Constants.LOG_MAX_FLAT_VTABLE_SIZE)) {
+        release || Debug.assertNonDictionaryModeObject(flatLinkedVTableMap);
+        flatLinkedVTableMap[(classId << Constants.LOG_MAX_FLAT_VTABLE_SIZE) + vTableIndex] = fn;
+      }
     }
     return fn;
   }
@@ -2068,7 +2084,8 @@ var MI = J2ME.methodIdToMethodInfoMap;
 var LM = J2ME.linkedMethods;
 var GLM = J2ME.getLinkedMethodById;
 var GLVM = J2ME.getLinkedVirtualMethodById;
-var VT = J2ME.classIdToLinkedVTableMap;
+var VT = J2ME.linkedVTableMap;
+var FT = J2ME.flatLinkedVTableMap;
 
 var CIC = J2ME.classInitCheck;
 var GH = J2ME.getHandle;

--- a/vm/runtime.ts
+++ b/vm/runtime.ts
@@ -699,7 +699,7 @@ module J2ME {
     MAX_CLASS_ID = 4095,
     INITIAL_MAX_CLASS_ID = 511,
 
-    LOG_MAX_FLAT_VTABLE_SIZE = 8
+    LOG_MAX_FLAT_VTABLE_SIZE = 6 // 64
   }
 
   export class Runtime extends RuntimeTemplate {


### PR DESCRIPTION
This backs out some of the previous work on code caching, applies some optimizations that I had in my previews patch queue and then re-lands code caching but using relocatable JIT code instead of trying to come up with unique class ids.