### PR TITLE
Make interpreter loop slimmer.

### DIFF
--- a/int.ts
+++ b/int.ts
@@ -1251,6 +1251,10 @@ module J2ME {
             ll = i32[--sp];
             index = i32[--sp];
             address = i32[--sp];
+            if (address === Constants.NULL) {
+              thread.throwException(fp, sp, opPC, ExceptionType.NullPointerException);
+              continue;
+            }
             if ((index >>> 0) >= (i32[address + Constants.ARRAY_LENGTH_OFFSET >> 2] >>> 0)) {
               thread.throwException(fp, sp, opPC, ExceptionType.ArrayIndexOutOfBoundsException, index);
             }
@@ -1261,6 +1265,10 @@ module J2ME {
           case Bytecodes.DALOAD:
             index = i32[--sp];
             address = i32[--sp];
+            if (address === Constants.NULL) {
+              thread.throwException(fp, sp, opPC, ExceptionType.NullPointerException);
+              continue;
+            }
             if ((index >>> 0) >= (i32[address + Constants.ARRAY_LENGTH_OFFSET >> 2] >>> 0)) {
               thread.throwException(fp, sp, opPC, ExceptionType.ArrayIndexOutOfBoundsException, index);
             }

--- a/int.ts
+++ b/int.ts
@@ -1130,50 +1130,33 @@ module J2ME {
             continue;
           case Bytecodes.IALOAD:
           case Bytecodes.FALOAD:
-            index = i32[--sp];
-            arrayAddr = i32[--sp];
-            if ((index >>> 0) >= (i32[arrayAddr + Constants.ARRAY_LENGTH_OFFSET >> 2] >>> 0)) {
-              thread.throwException(fp, sp, opPC, ExceptionType.ArrayIndexOutOfBoundsException, index);
-            }
-            i32[sp++] = i32[(arrayAddr + Constants.ARRAY_HDR_SIZE >> 2) + index];
-            continue;
+          case Bytecodes.AALOAD:
           case Bytecodes.BALOAD:
-            index = i32[--sp];
-            arrayAddr = i32[--sp];
-            if ((index >>> 0) >= (i32[arrayAddr + Constants.ARRAY_LENGTH_OFFSET >> 2] >>> 0)) {
-              thread.throwException(fp, sp, opPC, ExceptionType.ArrayIndexOutOfBoundsException, index);
-            }
-            i32[sp++] = i8[arrayAddr + Constants.ARRAY_HDR_SIZE + index];
-            continue;
           case Bytecodes.CALOAD:
-            index = i32[--sp];
-            arrayAddr = i32[--sp];
-            if ((index >>> 0) >= (i32[arrayAddr + Constants.ARRAY_LENGTH_OFFSET >> 2] >>> 0)) {
-              thread.throwException(fp, sp, opPC, ExceptionType.ArrayIndexOutOfBoundsException, index);
-            }
-            i32[sp++] = u16[(arrayAddr + Constants.ARRAY_HDR_SIZE >> 1) + index];
-            continue;
           case Bytecodes.SALOAD:
             index = i32[--sp];
-            arrayAddr = i32[--sp];
-            if ((index >>> 0) >= (i32[arrayAddr + Constants.ARRAY_LENGTH_OFFSET >> 2] >>> 0)) {
-              thread.throwException(fp, sp, opPC, ExceptionType.ArrayIndexOutOfBoundsException, index);
-            }
-            i32[sp++] = i16[(arrayAddr + Constants.ARRAY_HDR_SIZE >> 1) + index];
-            continue;
-          case Bytecodes.AALOAD:
-            index = i32[--sp];
-            arrayAddr = i32[--sp];
-
-            if (arrayAddr === Constants.NULL) {
+            address = i32[--sp];
+            if (address === Constants.NULL) {
               thread.throwException(fp, sp, opPC, ExceptionType.NullPointerException);
               continue;
             }
-
-            if ((index >>> 0) >= (i32[arrayAddr + Constants.ARRAY_LENGTH_OFFSET >> 2] >>> 0)) {
+            if ((index >>> 0) >= (i32[address + Constants.ARRAY_LENGTH_OFFSET >> 2] >>> 0)) {
               thread.throwException(fp, sp, opPC, ExceptionType.ArrayIndexOutOfBoundsException, index);
             }
-            i32[sp++] = i32[(arrayAddr + Constants.ARRAY_HDR_SIZE >> 2) + index];
+            switch (op) {
+              case Bytecodes.BALOAD:
+                i32[sp++] = i8[address + Constants.ARRAY_HDR_SIZE + index];
+                continue;
+              case Bytecodes.CALOAD:
+                i32[sp++] = u16[(address + Constants.ARRAY_HDR_SIZE >> 1) + index];
+                continue;
+              case Bytecodes.SALOAD:
+                i32[sp++] = i16[(address + Constants.ARRAY_HDR_SIZE >> 1) + index];
+                continue;
+              default:
+                i32[sp++] = i32[(address + Constants.ARRAY_HDR_SIZE >> 2) + index];
+            }
+
             continue;
           case Bytecodes.ISTORE:
           case Bytecodes.FSTORE:
@@ -1232,76 +1215,76 @@ module J2ME {
           case Bytecodes.FASTORE:
             value = i32[--sp];
             index = i32[--sp];
-            arrayAddr = i32[--sp];
-            if ((index >>> 0) >= (i32[arrayAddr + Constants.ARRAY_LENGTH_OFFSET >> 2] >>> 0)) {
+            address = i32[--sp];
+            if ((index >>> 0) >= (i32[address + Constants.ARRAY_LENGTH_OFFSET >> 2] >>> 0)) {
               thread.throwException(fp, sp, opPC, ExceptionType.ArrayIndexOutOfBoundsException, index);
             }
-            i32[(arrayAddr + Constants.ARRAY_HDR_SIZE >> 2) + index] = value;
+            i32[(address + Constants.ARRAY_HDR_SIZE >> 2) + index] = value;
             continue;
           case Bytecodes.BASTORE:
             value = i32[--sp];
             index = i32[--sp];
-            arrayAddr = i32[--sp];
-            if ((index >>> 0) >= (i32[arrayAddr + Constants.ARRAY_LENGTH_OFFSET >> 2] >>> 0)) {
+            address = i32[--sp];
+            if ((index >>> 0) >= (i32[address + Constants.ARRAY_LENGTH_OFFSET >> 2] >>> 0)) {
               thread.throwException(fp, sp, opPC, ExceptionType.ArrayIndexOutOfBoundsException, index);
             }
-            i8[arrayAddr + Constants.ARRAY_HDR_SIZE + index] = value;
+            i8[address + Constants.ARRAY_HDR_SIZE + index] = value;
             continue;
           case Bytecodes.CASTORE:
             value = i32[--sp];
             index = i32[--sp];
-            arrayAddr = i32[--sp];
-            if ((index >>> 0) >= (i32[arrayAddr + Constants.ARRAY_LENGTH_OFFSET >> 2] >>> 0)) {
+            address = i32[--sp];
+            if ((index >>> 0) >= (i32[address + Constants.ARRAY_LENGTH_OFFSET >> 2] >>> 0)) {
               thread.throwException(fp, sp, opPC, ExceptionType.ArrayIndexOutOfBoundsException, index);
             }
-            u16[(arrayAddr + Constants.ARRAY_HDR_SIZE >> 1) + index] = value;
+            u16[(address + Constants.ARRAY_HDR_SIZE >> 1) + index] = value;
             continue;
           case Bytecodes.SASTORE:
             value = i32[--sp];
             index = i32[--sp];
-            arrayAddr = i32[--sp];
-            if ((index >>> 0) >= (i32[arrayAddr + Constants.ARRAY_LENGTH_OFFSET >> 2] >>> 0)) {
+            address = i32[--sp];
+            if ((index >>> 0) >= (i32[address + Constants.ARRAY_LENGTH_OFFSET >> 2] >>> 0)) {
               thread.throwException(fp, sp, opPC, ExceptionType.ArrayIndexOutOfBoundsException, index);
             }
-            i16[(arrayAddr + Constants.ARRAY_HDR_SIZE >> 1) + index] = value;
+            i16[(address + Constants.ARRAY_HDR_SIZE >> 1) + index] = value;
             continue;
           case Bytecodes.LASTORE:
           case Bytecodes.DASTORE:
             lh = i32[--sp];
             ll = i32[--sp];
             index = i32[--sp];
-            arrayAddr = i32[--sp];
-            if ((index >>> 0) >= (i32[arrayAddr + Constants.ARRAY_LENGTH_OFFSET >> 2] >>> 0)) {
+            address = i32[--sp];
+            if ((index >>> 0) >= (i32[address + Constants.ARRAY_LENGTH_OFFSET >> 2] >>> 0)) {
               thread.throwException(fp, sp, opPC, ExceptionType.ArrayIndexOutOfBoundsException, index);
             }
-            i32[(arrayAddr + Constants.ARRAY_HDR_SIZE >> 2) + index * 2    ] = ll;
-            i32[(arrayAddr + Constants.ARRAY_HDR_SIZE >> 2) + index * 2 + 1] = lh;
+            i32[(address + Constants.ARRAY_HDR_SIZE >> 2) + index * 2    ] = ll;
+            i32[(address + Constants.ARRAY_HDR_SIZE >> 2) + index * 2 + 1] = lh;
             continue;
           case Bytecodes.LALOAD:
           case Bytecodes.DALOAD:
             index = i32[--sp];
-            arrayAddr = i32[--sp];
-            if ((index >>> 0) >= (i32[arrayAddr + Constants.ARRAY_LENGTH_OFFSET >> 2] >>> 0)) {
+            address = i32[--sp];
+            if ((index >>> 0) >= (i32[address + Constants.ARRAY_LENGTH_OFFSET >> 2] >>> 0)) {
               thread.throwException(fp, sp, opPC, ExceptionType.ArrayIndexOutOfBoundsException, index);
             }
-            i32[sp++] = i32[(arrayAddr + Constants.ARRAY_HDR_SIZE >> 2) + index * 2    ];
-            i32[sp++] = i32[(arrayAddr + Constants.ARRAY_HDR_SIZE >> 2) + index * 2 + 1];
+            i32[sp++] = i32[(address + Constants.ARRAY_HDR_SIZE >> 2) + index * 2    ];
+            i32[sp++] = i32[(address + Constants.ARRAY_HDR_SIZE >> 2) + index * 2 + 1];
             continue;
           case Bytecodes.AASTORE:
-            address = i32[--sp];
+            value = i32[--sp];
             index = i32[--sp];
-            arrayAddr = i32[--sp];
+            address = i32[--sp];
 
-            if (arrayAddr === Constants.NULL) {
+            if (address === Constants.NULL) {
               thread.throwException(fp, sp, opPC, ExceptionType.NullPointerException);
               continue;
             }
 
-            if ((index >>> 0) >= (i32[arrayAddr + Constants.ARRAY_LENGTH_OFFSET >> 2] >>> 0)) {
+            if ((index >>> 0) >= (i32[address + Constants.ARRAY_LENGTH_OFFSET >> 2] >>> 0)) {
               thread.throwException(fp, sp, opPC, ExceptionType.ArrayIndexOutOfBoundsException, index);
             }
-            checkArrayStore(arrayAddr, address);
-            i32[(arrayAddr + Constants.ARRAY_HDR_SIZE >> 2) + index] = address;
+            checkArrayStore(address, value);
+            i32[(address + Constants.ARRAY_HDR_SIZE >> 2) + index] = value;
             continue;
           case Bytecodes.POP:
             sp = sp - 1 | 0;
@@ -1768,12 +1751,12 @@ module J2ME {
             i32[sp++] = J2ME.newMultiArray(classInfo, lengths.reverse());
             continue;
           case Bytecodes.ARRAYLENGTH:
-            arrayAddr = i32[--sp];
-            if (arrayAddr === Constants.NULL) {
+            address = i32[--sp];
+            if (address === Constants.NULL) {
               thread.throwException(fp, sp, opPC, ExceptionType.NullPointerException);
               continue;
             }
-            i32[sp++] = i32[(arrayAddr + Constants.ARRAY_LENGTH_OFFSET >> 2)];
+            i32[sp++] = i32[(address + Constants.ARRAY_LENGTH_OFFSET >> 2)];
             continue;
           case Bytecodes.GETFIELD:
           case Bytecodes.GETSTATIC:

--- a/int.ts
+++ b/int.ts
@@ -1588,22 +1588,12 @@ module J2ME {
 
                   if (previousFrameType === FrameType.ExitInterpreter) {
                     thread.set(fp, sp, opPC);
-                    switch (kind) {
-                      case Kind.Long:
-                      case Kind.Double:
-                        return returnLong(returnValue, tempReturn0);
-                      case Kind.Int:
-                      case Kind.Byte:
-                      case Kind.Char:
-                      case Kind.Float:
-                      case Kind.Short:
-                      case Kind.Boolean:
-                      case Kind.Reference:
-                        return returnValue;
-                      case Kind.Void:
-                        return;
-                      default:
-                        release || assert(false, "Invalid Kind: " + Kind[kind]);
+                    if (kind === Kind.Void) {
+                      return;
+                    } else if (kind === Kind.Long || kind === Kind.Double) {
+                      return returnLong(returnValue, tempReturn0);
+                    } else {
+                      return returnValue;
                     }
                   }
 
@@ -1618,25 +1608,15 @@ module J2ME {
 
                   pc = opPC + (code[opPC] === Bytecodes.INVOKEINTERFACE ? 5 : 3);
                   // Push return value.
-                  switch (kind) {
-                    case Kind.Long:
-                    case Kind.Double:
-                      i32[sp++] = returnValue;
-                      i32[sp++] = tempReturn0;
-                      continue;
-                    case Kind.Int:
-                    case Kind.Byte:
-                    case Kind.Char:
-                    case Kind.Float:
-                    case Kind.Short:
-                    case Kind.Boolean:
-                    case Kind.Reference:
-                      i32[sp++] = returnValue;
-                      continue;
-                    case Kind.Void:
-                      continue;
-                    default:
-                      release || assert(false, "Invalid Kind: " + Kind[kind]);
+                  if (kind === Kind.Void) {
+                    continue;
+                  } else if (kind === Kind.Long || kind === Kind.Double) {
+                    i32[sp++] = returnValue;
+                    i32[sp++] = tempReturn0;
+                    continue;
+                  } else {
+                    i32[sp++] = returnValue;
+                    continue;
                   }
                 }
               }

--- a/int.ts
+++ b/int.ts
@@ -2056,23 +2056,10 @@ module J2ME {
 
                 for (var i = signatureKinds.length - 1; i > 0; i--) {
                   kind = signatureKinds[i];
-                  switch (kind) {
-                    case Kind.Long:
-                    case Kind.Double:
-                      args.unshift(i32[--sp]); // High Bits
-                      // Fallthrough
-                    case Kind.Int:
-                    case Kind.Byte:
-                    case Kind.Char:
-                    case Kind.Float:
-                    case Kind.Short:
-                    case Kind.Boolean:
-                    case Kind.Reference:
-                      args.unshift(i32[--sp]);
-                      break;
-                    default:
-                      release || assert(false, "Invalid Kind: " + Kind[kind]);
+                  if (kind === Kind.Long || kind === Kind.Double) {
+                    args.unshift(i32[--sp]); // High Bits
                   }
+                  args.unshift(i32[--sp]);
                 }
 
                 if (!isStatic) {
@@ -2100,28 +2087,17 @@ module J2ME {
               kind = signatureKinds[0];
 
               // Push return value.
-              switch (kind) {
-                case Kind.Long:
-                case Kind.Double:
-                  i32[sp++] = returnValue;
-                  i32[sp++] = tempReturn0;
-                  continue;
-                case Kind.Int:
-                case Kind.Byte:
-                case Kind.Char:
-                case Kind.Float:
-                case Kind.Short:
-                case Kind.Boolean:
-                  i32[sp++] = returnValue;
-                  continue;
-                case Kind.Reference:
-                  release || assert(returnValue !== "number", "native return value is a number");
-                  i32[sp++] = returnValue;
-                  continue;
-                case Kind.Void:
-                  continue;
-                default:
-                  release || assert(false, "Invalid Kind: " + Kind[kind]);
+              if (kind === Kind.Void) {
+                continue;
+              } else if (kind === Kind.Long || kind === Kind.Double) {
+                i32[sp++] = returnValue;
+                i32[sp++] = tempReturn0;
+                continue;
+              } else {
+                i32[sp++] = returnValue;
+              }
+              if (release && kind === Kind.Reference) {
+                release || assert(returnValue !== "number", "native return value is a number");
               }
               continue;
             }

--- a/int.ts
+++ b/int.ts
@@ -846,6 +846,38 @@ module J2ME {
     return sp;
   }
 
+  function Bytecode_D2I(sp: number) {
+    aliasedI32[0] = i32[sp - 2];
+    aliasedI32[1] = i32[sp - 1];
+    var a = aliasedF64[0];
+    if (a > Constants.INT_MAX) {
+      i32[sp - 2] = Constants.INT_MAX;
+    } else if (a < Constants.INT_MIN) {
+      i32[sp - 2] = Constants.INT_MIN;
+    } else {
+      i32[sp - 2] = a | 0;
+    }
+    sp--;
+    return sp;
+  }
+
+  function Bytecode_D2L(sp: number) {
+    aliasedI32[0] = i32[sp - 2];
+    aliasedI32[1] = i32[sp - 1];
+    var a = aliasedF64[0];
+    if (a === Number.POSITIVE_INFINITY) {
+      i32[sp - 2] = Constants.LONG_MAX_LOW;
+      i32[sp - 1] = Constants.LONG_MAX_HIGH;
+    } else if (a === Number.NEGATIVE_INFINITY) {
+      i32[sp - 2] = Constants.LONG_MIN_LOW;
+      i32[sp - 1] = Constants.LONG_MIN_HIGH;
+    } else {
+      i32[sp - 2] = returnLongValue(a);
+      i32[sp - 1] = tempReturn0;
+    }
+    return sp;
+  }
+
   /**
    * Main interpreter loop. This method is carefully written to avoid memory allocation and
    * function calls on fast paths. Therefore, everything is inlined, even if it makes the code
@@ -1650,32 +1682,10 @@ module J2ME {
             i32[sp++] = aliasedI32[1];
             continue;
           case Bytecodes.D2I:
-            aliasedI32[0] = i32[sp - 2];
-            aliasedI32[1] = i32[sp - 1];
-            var D2I_fa = aliasedF64[0];
-            if (D2I_fa > Constants.INT_MAX) {
-              i32[sp - 2] = Constants.INT_MAX;
-            } else if (D2I_fa < Constants.INT_MIN) {
-              i32[sp - 2] = Constants.INT_MIN;
-            } else {
-              i32[sp - 2] = D2I_fa | 0;
-            }
-            sp --;
+            sp = Bytecode_D2I(sp);
             continue;
           case Bytecodes.D2L:
-            aliasedI32[0] = i32[sp - 2];
-            aliasedI32[1] = i32[sp - 1];
-            var D2L_fa = aliasedF64[0];
-            if (D2L_fa === Number.POSITIVE_INFINITY) {
-              i32[sp - 2] = Constants.LONG_MAX_LOW;
-              i32[sp - 1] = Constants.LONG_MAX_HIGH;
-            } else if (D2L_fa === Number.NEGATIVE_INFINITY) {
-              i32[sp - 2] = Constants.LONG_MIN_LOW;
-              i32[sp - 1] = Constants.LONG_MIN_HIGH;
-            } else {
-              i32[sp - 2] = returnLongValue(D2L_fa);
-              i32[sp - 1] = tempReturn0;
-            }
+            sp = Bytecode_D2L(sp);
             continue;
           case Bytecodes.D2F:
             aliasedI32[0] = i32[sp - 2];


### PR DESCRIPTION
Should be merged on top of #1836. This PR reduces the size of the interpreter loop by factoring out opcodes that are not very frequent. My hope is that ION compilation time will be reduced, especially since it appears to be happening several times. This PR also makes the interpreter loop more clear to understand.
