### PR TITLE
Re-enable preemption.

### DIFF
--- a/int.ts
+++ b/int.ts
@@ -2255,6 +2255,12 @@ module J2ME {
               continue;
             }
 
+            if (thread.nativeFrameCount === 0 && Scheduler.shouldPreempt()) {
+              thread.set(fp, sp, opPC);
+              $.yield("preempt");
+              return;
+            }
+
             // Call Interpreted Method.
             release || traceWriter && traceWriter.writeLn(">> I " + calleeTargetMethodInfo.implKey);
             mi = calleeTargetMethodInfo;

--- a/jit/baseline.ts
+++ b/jit/baseline.ts
@@ -106,7 +106,7 @@ module J2ME {
   /**
    * Emits preemption checks for methods that already yield.
    */
-  export var emitCheckPreemption = false;
+  export var emitCheckPreemption = true;
 
   export function baselineCompileMethod(methodInfo: MethodInfo, target: CompilationTarget): CompiledMethodInfo {
     var compileExceptions = true;

--- a/jit/baseline.ts
+++ b/jit/baseline.ts
@@ -579,7 +579,7 @@ module J2ME {
       // Insert a preemption check after the OSR code so the pc
       // and state will be stored. We can only do this if the
       // method has the necessary unwinding code.
-      if (canYield(this.methodInfo)) {
+      if (needsOSREntryPoint) {
         this.emitPreemptionCheck(this.bodyEmitter);
       }
 

--- a/scheduler.ts
+++ b/scheduler.ts
@@ -185,7 +185,7 @@ module J2ME {
       var totalElapsed = now - windowStartTime;
       if (totalElapsed > MAX_WINDOW_EXECUTION_TIME) {
         preemptionCount++;
-        threadWriter && threadWriter.writeLn("Execution window timeout: " + totalElapsed.toFixed(2) + " ms, samples: " + PS + ", count: " + preemptionCount);
+        threadWriter && threadWriter.writeLn("Execution window timeout: " + totalElapsed.toFixed(2) + " ms, samples: " + jsGlobal.PS + ", count: " + preemptionCount);
         return true;
       }
 
@@ -204,7 +204,7 @@ module J2ME {
 
       if ($.ctx.virtualRuntime > runningQueue[0].virtualRuntime) {
         preemptionCount++;
-        threadWriter && threadWriter.writeLn("Preemption: " + elapsed.toFixed(2) + " ms, samples: " + PS + ", count: " + preemptionCount);
+        threadWriter && threadWriter.writeLn("Preemption: " + elapsed.toFixed(2) + " ms, samples: " + jsGlobal.PS + ", count: " + preemptionCount);
         return true;
       }
 

--- a/vm/runtime.ts
+++ b/vm/runtime.ts
@@ -2174,7 +2174,7 @@ var TS = J2ME.throwNegativeArraySizeException;
 var TN = J2ME.throwNullPointerException;
 
 var PE = J2ME.preempt;
-var PS = 0; // Preemption samples.
+jsGlobal.PS = 0; // Preemption samples.
 
 var fadd = J2ME.fadd;
 var fsub = J2ME.fsub;


### PR DESCRIPTION
Helps with slower devices and UI responsiveness.  As before it seems to hurt startup perf on desktop:

| Test | Baseline Mean | Mean | +/- | % | P | Min | Max |
| :-- | --: | --: | --: | --: | --: | --: | --: |
| startupTime | 1,185ms | 1,292ms | 107ms | 9.06 | WORSE | 1,280ms | 1,307ms |
| vmStartupTime | 225ms | 235ms | 9ms | 4.16 | WORSE | 231ms | 237ms |
| bgStartupTime | 52ms | 49ms | -2ms | -4.69 | SAME | 48ms | 50ms |
| fgStartupTime | 754ms | 809ms | 55ms | 7.35 | WORSE | 802ms | 819ms |
| fgRefreshStartupTime | 154ms | 199ms | 45ms | 29.23 | WORSE | 194ms | 203ms |
| fgRestartTime | n/a | NaNms | n/a | n/a | n/a | Infinityms | -Infinityms |
| _totalSize_ | _31,656kb_ | _32,219kb_ | _563kb_ | _1.78_ | _SAME_ | _30,923kb_ | _33,084kb_ |
| _domSize_ | _131kb_ | _131kb_ | _0kb_ | _0.01_ | _SAME_ | _131kb_ | _131kb_ |
| _styleSize_ | _392kb_ | _437kb_ | _44kb_ | _11.33_ | _WORSE_ | _431kb_ | _445kb_ |
| _jsObjectsSize_ | _24,161kb_ | _24,595kb_ | _434kb_ | _1.79_ | _WORSE_ | _24,561kb_ | _24,604kb_ |
| _jsStringsSize_ | _490kb_ | _490kb_ | _0kb_ | _0.04_ | _SAME_ | _490kb_ | _490kb_ |
| _jsOtherSize_ | _6,288kb_ | _6,352kb_ | _64kb_ | _1.01_ | _SAME_ | _5,066kb_ | _7,212kb_ |
| _otherSize_ | _193kb_ | _214kb_ | _21kb_ | _10.84_ | _WORSE_ | _203kb_ | _223kb_ |
| _USS_ | _n/a_ | _NaNkb_ | _n/a_ | _n/a_ | _n/a_ | _Infinitykb_ | _-Infinitykb_ |
| _peakRSS_ | _629,876kb_ | _1,598,196kb_ | _968,320kb_ | _153.73_ | _SAME_ | _1,598,196kb_ | _1,598,196kb_ |
