### PR TITLE
Add option to disable null checks in the compiler.

### DIFF
--- a/jsshell.js
+++ b/jsshell.js
@@ -107,6 +107,11 @@ var options = {
     short: "cas",
     value: true,
     type: "boolean"
+  },
+  "emitCheckNull": {
+    short: "cn",
+    value: true,
+    type: "boolean"
   }
 };
 
@@ -279,6 +284,7 @@ try {
   J2ME.enableOnStackReplacement = options.enableOnStackReplacement.value;
   J2ME.emitCheckArrayBounds = options.emitCheckArrayBounds.value;
   J2ME.emitCheckArrayStore = options.emitCheckArrayStore.value;
+  J2ME.emitCheckNull = options.emitCheckNull.value;
 
   start = dateNow();
   var runtime = jvm.startIsolate0(files[0], config.args);


### PR DESCRIPTION
This makes a huge difference on some micro-benchmarks. We should investigate why. I suspect that it has to do with some optimizations being prevented by calls to `TN()`.

BubbleSort with 1000 iterations goes from 2969ms to 705ms. HotSpot is about 300ms. 
