### PR TITLE
Use throw instead function calls for exceptions.

### DIFF
--- a/jit/baseline.ts
+++ b/jit/baseline.ts
@@ -960,7 +960,7 @@ module J2ME {
       if (this.isPrivileged) {
         return;
       }
-      this.blockEmitter.writeLn(length + "<0&&TS();");
+      this.blockEmitter.writeLn("if(" + length + "<0)throw " + ExceptionType.NegativeArraySizeException + ";");
     }
 
     emitBoundsCheck(array: string, index: string) {
@@ -968,7 +968,7 @@ module J2ME {
         return;
       }
       if (inlineRuntimeCalls) {
-        this.blockEmitter.writeLn("if((" + index + ">>>0)>=(i32[" + array + "+" + Constants.ARRAY_LENGTH_OFFSET + ">>2]>>>0))TI(" + index + ");");
+        this.blockEmitter.writeLn("if((" + index + ">>>0)>=(i32[" + array + "+" + Constants.ARRAY_LENGTH_OFFSET + ">>2]>>>0))throw " + ExceptionType.ArrayIndexOutOfBoundsException + ";");
       } else {
         this.blockEmitter.writeLn("CAB(" + array + "," + index + ");");
       }
@@ -1149,7 +1149,7 @@ module J2ME {
     }
 
     emitNullPointerCheck(address) {
-      this.blockEmitter.writeLn("!" + address + "&&TN();");
+      this.blockEmitter.writeLn("if(!" + address + ")throw " + ExceptionType.NullPointerException + ";");
     }
 
     emitArrayLength() {
@@ -1288,9 +1288,9 @@ module J2ME {
         return;
       }
       if (kind === Kind.Int) {
-        this.blockEmitter.writeLn("!" + l + "&&TA();");
+        this.blockEmitter.writeLn("if(!" + l + ")throw " + ExceptionType.ArithmeticException + ";");
       } else if (kind === Kind.Long) {
-        this.blockEmitter.writeLn("!" + l + "&&!" + h + "&&TA();");
+        this.blockEmitter.writeLn("if(!" + l + "&&!" + h + ")throw " + ExceptionType.ArithmeticException + ";");
       } else {
         Debug.unexpected(getKindName(kind));
       }

--- a/vm/runtime.ts
+++ b/vm/runtime.ts
@@ -1698,6 +1698,16 @@ module J2ME {
   }
 
   export function translateException(e) {
+    switch (e) {
+      case ExceptionType.NullPointerException:
+        return $.newNullPointerException();
+      case ExceptionType.ArrayIndexOutOfBoundsException:
+        return $.newArrayIndexOutOfBoundsException();
+      case ExceptionType.ArithmeticException:
+        return $.newArithmeticException();
+      case ExceptionType.NegativeArraySizeException:
+        return $.newNegativeArraySizeException();
+    }
     if (e.name === "TypeError") {
       // JavaScript's TypeError is analogous to a NullPointerException.
       return $.newNullPointerException(e.message);
@@ -2171,10 +2181,6 @@ var ME = J2ME.monitorEnter;
 var MX = J2ME.monitorExit;
 
 var TE = J2ME.translateException;
-var TI = J2ME.throwArrayIndexOutOfBoundsException;
-var TA = J2ME.throwArithmeticException;
-var TS = J2ME.throwNegativeArraySizeException;
-var TN = J2ME.throwNullPointerException;
 
 var PE = J2ME.preempt;
 var PS = 0; // Preemption samples.


### PR DESCRIPTION
Mbx and I found this when running the bubble sort benchmark. Seems to do nothing for startup time, but does improve benchmarks from 8600ms to 7900ms on my machine. Also improves bubble sort bench quite a bit if more rounds are run.
