### PR TITLE
ensure /tcktestdir created for FileConnection tests

### DIFF
--- a/libs/fs-init.js
+++ b/libs/fs-init.js
@@ -25,7 +25,7 @@ var initialFiles = [
 var initFS = new Promise(function(resolve, reject) {
   fs.init(resolve);
 }).then(function() {
-  if (typeof config !== "undefined" && config.midletClassName == "RunTestsMIDlet") {
+  if (typeof config !== "undefined" && config.main === "com.ibm.tck.client.TestRunner") {
     initialDirs.push("/tcktestdir");
   }
 

--- a/libs/fs.js
+++ b/libs/fs.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var DEBUG_FS = true;
+var DEBUG_FS = false;
 
 var fs = (function() {
   var reportRequestError = function(type, request) {

--- a/libs/fs.js
+++ b/libs/fs.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var DEBUG_FS = false;
+var DEBUG_FS = true;
 
 var fs = (function() {
   var reportRequestError = function(type, request) {

--- a/main.js
+++ b/main.js
@@ -34,9 +34,8 @@ var getMobileInfo = new Promise(function(resolve, reject) {
   });
 });
 
-var loadingMIDletPromises = [initFS, getMobileInfo];
-
-var loadingPromises = [];
+var loadingMIDletPromises = [getMobileInfo];
+var loadingPromises = [initFS];
 
 loadingPromises.push(load("java/classes.jar", "arraybuffer").then(function(data) {
   JARStore.addBuiltIn("java/classes.jar", data);

--- a/tests/fs/automation.js
+++ b/tests/fs/automation.js
@@ -103,6 +103,10 @@ casper.test.begin("fs tests", 7, function(test) {
         test.assertTextExists("DONE: 137 pass, 0 fail", "run fs.js unit tests");
     });
 
+    casper
+    .thenOpen("http://localhost:8000/tests/fs/delete-fs.html")
+    .waitForText("DONE");
+
     // Run the FileConnection TCK unit tests.
     casper
     .thenOpen("http://localhost:8000/index.html?main=com.ibm.tck.client.TestRunner&args=-noserver&jars=tests/tests.jar&logConsole=web,page&logLevel=log")


### PR DESCRIPTION
I think the TCK FileConnection tests fail sometimes because there's a race between two fs.init promise handlers: first, in fs-init.js, which mkdirs /tcktestdir after fs.init; and second, in fstests.js, which calls fs.clear after fs.init.

When fstests.js clears the database before fs-init.js creates /tcktestdir, then that directory exists, and the FileConnection tests pass.  But when fstests.js clears the database *after* fs-init.js creates /tcktestdir, then that directory gets deleted after being created, so it doesn't exist when the FileConnection tests are run, and they fail.

This branch explicitly creates /tcktestdir if we're running the FileConnection tests.  It also explicitly deletes the database before running those tests, so it should lead to more consistent success (or failure!) of that test suite.
