### PR TITLE
remove obsolete methodInfo property

### DIFF
--- a/int.ts
+++ b/int.ts
@@ -708,7 +708,6 @@ module J2ME {
       // release || traceWriter && traceWriter.writeLn("<< I");
       return v;
     };
-    (<any>method).methodInfo = methodInfo;
     return method;
   }
 


### PR DESCRIPTION
I don't think this is being used anymore, and tests pass without it, but requesting a pull so someone else can confirm. @brendandahl or @mbebenita?
